### PR TITLE
fix: recover stale SSH control sockets without leaking processes

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -2,7 +2,9 @@
 // forward) over one ControlMaster per host. Pane streams deliberately use
 // their own direct connections instead (see pane.rs).
 
-use std::path::PathBuf;
+use std::fs;
+use std::os::unix::fs::FileTypeExt;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
@@ -58,6 +60,31 @@ async fn ssh(args: &[String], timeout_ms: u64) -> SshOutput {
     }
 }
 
+fn remove_stale_control_socket(path: &Path) -> Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(err(format!(
+                "cannot inspect ssh control socket {}: {e}",
+                path.display()
+            )))
+        }
+    };
+    if !metadata.file_type().is_socket() {
+        return Err(err(format!(
+            "refusing to replace ssh control path {} because it is not a socket",
+            path.display()
+        )));
+    }
+    fs::remove_file(path).map_err(|e| {
+        err(format!(
+            "cannot remove stale ssh control socket {}: {e}",
+            path.display()
+        ))
+    })
+}
+
 pub struct RemoteHost {
     pub cfg: HostConfig,
     ctl_path: PathBuf,
@@ -91,8 +118,15 @@ impl RemoteHost {
             return Ok(());
         }
         self.forwarded = false;
-        let mut start: Vec<String> =
-            vec!["-M".into(), "-S".into(), self.ctl_path.display().to_string()];
+        // OpenSSH falls back to a standalone connection when ControlPath exists
+        // but no master is listening. With -f -N that silently leaks one process
+        // per retry, while every later -O command keeps targeting the dead socket.
+        remove_stale_control_socket(&self.ctl_path)?;
+        let mut start: Vec<String> = vec![
+            "-M".into(),
+            "-S".into(),
+            self.ctl_path.display().to_string(),
+        ];
         start.extend(SSH_COMMON_OPTS.iter().map(|s| s.to_string()));
         start.extend([
             "-o".into(),
@@ -107,6 +141,14 @@ impl RemoteHost {
                 "ssh master to {} failed: {}",
                 self.cfg.target,
                 nonempty(&res.err, res.code)
+            )));
+        }
+        let verified = ssh(&check, 15000).await;
+        if verified.code != 0 {
+            return Err(err(format!(
+                "ssh master to {} did not create a usable control socket: {}",
+                self.cfg.target,
+                nonempty(&verified.err, verified.code)
             )));
         }
         Ok(())
@@ -242,6 +284,40 @@ fn version_supported(version: &str) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_path(name: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "herdr-mirror-{name}-{}-{nonce}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn removes_stale_control_socket() {
+        let path = test_path("stale-control");
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+        drop(listener);
+
+        remove_stale_control_socket(&path).unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn refuses_to_replace_non_socket_control_path() {
+        let path = test_path("non-socket-control");
+        fs::write(&path, "do not delete").unwrap();
+
+        let error = remove_stale_control_socket(&path).unwrap_err().to_string();
+
+        assert!(error.contains("is not a socket"));
+        assert_eq!(fs::read_to_string(&path).unwrap(), "do not delete");
+        fs::remove_file(path).unwrap();
+    }
 
     #[test]
     fn version_gate() {


### PR DESCRIPTION
## Summary

- remove a stale SSH ControlMaster socket after `ssh -O check` confirms it is unusable
- refuse to replace a ControlPath that is not a Unix socket
- verify the newly started master before using it for remote commands or socket forwarding
- add regression coverage for stale-socket removal and non-socket preservation

## Root cause

When a dead ControlMaster left its socket behind, `ensure_master` detected the failed `-O check` but launched `ssh -M -f -N` against the same path. OpenSSH warned that the ControlSocket already existed, disabled multiplexing, and left a standalone detached SSH process running. The later `-O forward` still targeted the dead socket and failed, so every reconnect retry leaked another process.

I observed this in a live installation after the remote Herdr server became available: the daemon remained at zero mirrors, logged repeated `Control socket ... Connection refused` failures, and accumulated 3,599 detached SSH transports tied to the stale ControlPath.

## Verification

- `cargo test remote::tests -- --nocapture` — 3 passed
- `cargo test --all-targets` — 37 passed
- `cargo clippy --all-targets` — passed with the repository's existing dead-code warnings
- `cargo build --release` — passed
- `git diff --check` — passed

## Notes

This prevents new leaks and restores automatic recovery. It deliberately does not attempt to discover or kill standalone SSH processes leaked by older versions, because doing that safely requires external process ownership information that the current daemon does not retain.
