### PR TITLE
fix: render double-width (CJK/Hangul) characters without column drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "unicode-width",
 ]
 
 [[package]]
@@ -268,6 +269,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1"
 toml = { version = "0.8", features = ["preserve_order"] }
 base64 = "0.22"
 libc = "0.2"
+unicode-width = "0.2"
 
 [profile.release]
 lto = true

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -7,6 +7,12 @@
 
 use std::fmt::Write as _;
 use std::rc::Rc;
+use unicode_width::UnicodeWidthChar;
+
+/// Terminal display width of a char (CJK/Hangul are 2 columns).
+fn cw(ch: char) -> usize {
+    UnicodeWidthChar::width(ch).unwrap_or(1).max(1)
+}
 
 #[derive(Clone, PartialEq)]
 pub struct Cell {
@@ -84,11 +90,17 @@ impl Grid {
             }
             let ch = chars[i];
             if ch >= ' ' || ch == '\t' {
+                let ch = if ch == '\t' { ' ' } else { ch };
+                let w = cw(ch);
                 if row < self.height && col < self.width {
-                    let ch = if ch == '\t' { ' ' } else { ch };
                     self.rows[row][col] = Some(Cell { sgr: sgr.clone(), ch });
+                    // wide char spans two columns: clear any stale cell in the
+                    // spacer slot so delta frames cannot leave mixed glyphs
+                    if w == 2 && col + 1 < self.width {
+                        self.rows[row][col + 1] = None;
+                    }
                 }
-                col += 1;
+                col += w;
             }
             i += 1;
         }
@@ -196,14 +208,27 @@ impl Renderer {
             let cells = grid.rows.get(r + offset_r).unwrap_or(&empty);
             let mut line = String::new();
             let mut prev_sgr: Option<&str> = None;
-            for c in 0..out_cols.min(grid.width) {
+            let limit = out_cols.min(grid.width);
+            let mut c = 0usize;
+            while c < limit {
                 let cell = cells.get(c).and_then(|c| c.as_ref());
                 let sgr = cell.map(|c| &*c.sgr).unwrap_or("\x1b[0m");
                 if prev_sgr != Some(sgr) {
                     line.push_str(if sgr.is_empty() { "\x1b[0m" } else { sgr });
                     prev_sgr = Some(sgr);
                 }
-                line.push(cell.map(|c| c.ch).unwrap_or(' '));
+                let ch = cell.map(|c| c.ch).unwrap_or(' ');
+                let w = cw(ch);
+                // a wide char that would straddle the right edge is blanked
+                if w == 2 && c + 1 >= limit {
+                    line.push(' ');
+                    c += 1;
+                    continue;
+                }
+                line.push(ch);
+                // wide char occupies two columns: skip its spacer cell so the
+                // painted columns stay aligned with the grid (Hangul/CJK fix)
+                c += w;
             }
             let is_status_row = r == out_rows - 1 && !self.status_text.is_empty();
             let painted = if is_status_row {
@@ -270,6 +295,30 @@ mod tests {
         // delta frame erases the bottom content with spaces
         g.apply("\x1b[7;1H      ");
         assert_eq!(g.content_bottom, 0);
+    }
+
+    #[test]
+    fn wide_chars_do_not_drift() {
+        let mut g = Grid::new();
+        g.resize(10, 1);
+        // the server skips the spacer cell after a wide char with a CUP jump
+        g.apply("\x1b[1;1H한\x1b[1;3H글\x1b[1;5H!");
+        assert_eq!((g.cursor_row, g.cursor_col), (0, 5));
+        let mut r = Renderer::new();
+        let out = r.paint(&g, 10, 1);
+        // without width handling this painted "한 글 !" and drifted right
+        assert!(out.contains("한글!"), "got: {out:?}");
+    }
+
+    #[test]
+    fn wide_char_overwrites_stale_spacer() {
+        let mut g = Grid::new();
+        g.resize(10, 1);
+        g.apply("\x1b[1;1Hab"); // narrow content first
+        g.apply("\x1b[1;1H한"); // delta frame paints a wide char over it
+        let mut r = Renderer::new();
+        let out = r.paint(&g, 10, 1);
+        assert!(!out.contains('b'), "stale spacer cell survived: {out:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Mirrored panes render CJK/Hangul text corrupted. Korean text that displays
correctly when attaching to the remote herdr directly (`ssh` + `herdr`)
shows up in mirror panes with a ghost space after every character, and
delta frames interleave glyphs at wrong positions:

```
expected: 주세요. 라벨은 저장소마다 달라 생략했습니다.
mirrored: 주 세 요 . 라정벨해은뒀 저 장 소r마m다t 달 라  생 략 했 습 니 다 .
```

Verified it is **not** an encoding/transport issue: reading the mirror
pane's text via `herdr pane read` shows intact UTF-8 (0 replacement
chars) — only the column layout is wrong.

## Root cause

The grid and renderer are width-naive while the frame wire format is
column-addressed:

- The remote herdr server emits per-cell frames (`ESC[r;cH` + char) and
  skips the spacer cell after a double-width char with a CUP jump of +2.
- `Grid::apply` advances `col += 1` per char regardless of display width,
  leaving the spacer slot as `None`.
- `Renderer::paint` emits one char per cell linearly and fills `None`
  cells with a real space. A wide char already occupies two terminal
  columns, so each one pushes the painted row right by one column.
  Subsequent delta frames then land on drifted columns, mixing glyphs.

ASCII-only content is unaffected (width 1 == 1 cell), which is why this
only shows up with CJK.

## Fix

- `Grid::apply`: advance `col` by the char's display width
  (`unicode-width`), and clear the spacer cell when a wide char
  overwrites previous narrow content so stale glyphs cannot survive
  delta frames.
- `Renderer::paint`: skip the spacer cell after a wide char so painted
  columns stay aligned with grid indices; blank a wide char that would
  straddle the right edge of the window.
- Adds `unicode-width = "0.2"` and two regression tests
  (`wide_chars_do_not_drift`, `wide_char_overwrites_stale_spacer`).

All 59 tests pass. Verified live against a mirrored macOS remote running
Korean TUI sessions — previously-corrupted lines now render identically
to a direct attach.

