### PR TITLE
ssh: fall back to exec relay when streamlocal forwarding is unavailable (embedded sshds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ target = "work"
                                      # directly (don't drive its pane sizes)
 # enabled = true                     # false stops syncing this host without
                                      # deleting its config; mirrors stay put
+# api_transport = "auto"             # default. Reaches the remote API socket
+                                     # via ssh's streamlocal `-L` forward, and
+                                     # falls back to an exec relay (one ssh
+                                     # exec per API connection, no config
+                                     # needed on the remote beyond socat or
+                                     # python3) if that doesn't work — some
+                                     # sshds accept the forward but never
+                                     # service it. Set "socket" or "exec" to
+                                     # pin one and skip the probe.
 
 [hosts.vps]                          # add more hosts freely; each is independent
 target = "ssh://niko@203.0.113.7:2222"
@@ -261,6 +270,11 @@ independently, exactly like multiple ssh hosts.
   can't render a richer affordance (group headers, collapse, colour).
 - **Remote must be reachable and running herdr**; the daemon surfaces a
   readable status if a host is down or on too old a version.
+- **ssh hosts whose sshd won't service streamlocal forwards** (some embedded
+  Go sshds fronting container/VM workspaces accept the channel open and then
+  never move a byte) fall back automatically to an exec relay — see
+  `api_transport` above. The remote needs `socat` or `python3` for that path;
+  almost everything has one or the other.
 
 ## License
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,37 @@ impl HostKind {
     }
 }
 
+/// How an ssh host's API socket is reached. Meaningless for docker hosts,
+/// which always bridge through `docker exec` (see docker.rs) — present on
+/// every host regardless of kind for the same reason `docker_bin` is present
+/// on ssh hosts: a field that is a no-op for the other kind is simpler than
+/// rejecting it.
+///
+/// `Auto` (the default) is what most hosts want: try the streamlocal `-L`
+/// socket forward first, since it is one process cheaper per connection, and
+/// fall back to an exec relay only if that turns out not to work. Some ssh
+/// servers — notably embedded Go sshds fronting container/VM workspaces —
+/// accept a direct-streamlocal channel open but never service it, which
+/// without a fallback looks like the remote herdr hanging rather than what it
+/// actually is: the transport silently going nowhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiTransport {
+    Auto,
+    Socket,
+    Exec,
+}
+
+impl ApiTransport {
+    fn parse(s: &str) -> Option<ApiTransport> {
+        match s {
+            "auto" => Some(ApiTransport::Auto),
+            "socket" => Some(ApiTransport::Socket),
+            "exec" => Some(ApiTransport::Exec),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct HostConfig {
     pub name: String,
@@ -36,6 +67,8 @@ pub struct HostConfig {
     pub docker_bin: String,
     pub prefix: String,
     pub remote_bin: String,
+    /// ssh hosts only; see `ApiTransport`. Default `Auto`.
+    pub api_transport: ApiTransport,
     /// keep each mirror pane in control (writable, no idle release, and sized to
     /// the local pane so it fills). Default on; ideal for headless remotes. Turn
     /// off per host for a remote a human is actively using directly.
@@ -101,6 +134,7 @@ struct RawHost {
     remote_bin: Option<String>,
     enabled: Option<bool>,
     always_control: Option<bool>,
+    api_transport: Option<String>,
 }
 
 /// Resolve `kind` + its ref fields, rejecting combinations that would silently
@@ -198,11 +232,25 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
                 continue;
             }
         };
+        let api_transport = match h.api_transport.as_deref() {
+            None => ApiTransport::Auto,
+            Some(s) => match ApiTransport::parse(s) {
+                Some(t) => t,
+                None => {
+                    warnings.push(format!(
+                        "skipping host: [hosts.{name}]: unknown api_transport \"{s}\" \
+                         (expected auto, socket, or exec)"
+                    ));
+                    continue;
+                }
+            },
+        };
         hosts.push(HostConfig {
             prefix: h.prefix.unwrap_or_else(|| name.clone()),
             remote_bin: h.remote_bin.unwrap_or_else(|| "~/.local/bin/herdr".into()),
             always_control: h.always_control.unwrap_or(global_always_control),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
+            api_transport,
             kind,
             target,
             name,
@@ -359,6 +407,32 @@ mod tests {
         for case in cases {
             assert!(parse_config(case).is_err(), "should reject: {case}");
         }
+    }
+
+    #[test]
+    fn api_transport_defaults_to_auto_and_parses_overrides() {
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert_eq!(c.hosts[0].api_transport, ApiTransport::Auto);
+
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\napi_transport = \"socket\"\n").unwrap();
+        assert_eq!(c.hosts[0].api_transport, ApiTransport::Socket);
+
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\napi_transport = \"exec\"\n").unwrap();
+        assert_eq!(c.hosts[0].api_transport, ApiTransport::Exec);
+    }
+
+    /// An unknown value must be as loud as any other malformed host: skipped
+    /// with a named reason, not silently coerced to a default.
+    #[test]
+    fn unknown_api_transport_is_skipped_with_reason() {
+        let c = parse_config(
+            "[hosts.good]\ntarget = \"g\"\n\
+             [hosts.bad]\ntarget = \"b\"\napi_transport = \"turbo\"\n",
+        )
+        .unwrap();
+        assert_eq!(c.hosts.len(), 1);
+        assert_eq!(c.hosts[0].name, "good");
+        assert!(c.warnings[0].contains("unknown api_transport"), "{:?}", c.warnings);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -153,6 +153,31 @@ async fn flush_status(ctx: &HostCtx, pending: HashMap<String, Value>) -> bool {
     need_converge
 }
 
+/// Which transport the next reconnect should try first.
+///
+/// A fallback to the exec relay is only remembered once it has happened twice
+/// running. The probe fails for transient reasons too (the remote herdr
+/// restarting, a mux hiccup, one slow ping), and remembering the first one
+/// pins a healthy host to the slower transport for the daemon's whole life
+/// with a single log line as the only clue. A genuinely broken host wastes one
+/// probe on the next reconnect and then sticks, which is what the memory is
+/// for.
+fn remember_transport(
+    last: Option<crate::config::ApiTransport>,
+    exec_streak: &mut u32,
+) -> Option<crate::config::ApiTransport> {
+    match last {
+        Some(crate::config::ApiTransport::Exec) => {
+            *exec_streak += 1;
+            (*exec_streak >= 2).then_some(crate::config::ApiTransport::Exec)
+        }
+        other => {
+            *exec_streak = 0;
+            other
+        }
+    }
+}
+
 /// Connected phase: subscribe, converge, then react to events/pokes/timers
 /// until the connection drops (returns Err).
 async fn run_connected(
@@ -160,6 +185,7 @@ async fn run_connected(
     poke: &mut mpsc::Receiver<()>,
     backoff_idx: &mut usize,
     remembered_transport: &mut Option<crate::config::ApiTransport>,
+    exec_streak: &mut u32,
 ) -> Result<()> {
     let mut remote_host = crate::remote::RemoteHost::new(&ctx.host, &ctx.env_state_dir);
     // a fresh RemoteHost is built on every reconnect, so what worked last
@@ -168,7 +194,7 @@ async fn run_connected(
     // for the life of the daemon
     remote_host.hint_transport(*remembered_transport);
     let (remote, _status) = remote_host.connect_api().await?;
-    *remembered_transport = remote_host.last_api_transport;
+    *remembered_transport = remember_transport(remote_host.last_api_transport, exec_streak);
     *backoff_idx = 0;
     let deps = ConvergeDeps {
         local: ctx.local.clone(),
@@ -272,8 +298,17 @@ async fn host_task(ctx: HostCtx, mut poke: mpsc::Receiver<()>) {
     // persists across reconnects for the daemon's whole lifetime — the
     // point of remembering at all (see `run_connected`)
     let mut remembered_transport: Option<crate::config::ApiTransport> = None;
+    let mut exec_streak = 0u32;
     loop {
-        let e = match run_connected(&ctx, &mut poke, &mut backoff_idx, &mut remembered_transport).await {
+        let e = match run_connected(
+            &ctx,
+            &mut poke,
+            &mut backoff_idx,
+            &mut remembered_transport,
+            &mut exec_streak,
+        )
+        .await
+        {
             Ok(()) => unreachable!("run_connected only returns on error"),
             Err(e) => e,
         };
@@ -747,6 +782,35 @@ pub async fn cmd_teardown(env: Env) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// One fallback is not evidence: the probe also fails when the remote herdr
+    /// is restarting or the mux hiccups, and pinning a healthy host to the
+    /// slower transport for the daemon's life is worse than re-probing once.
+    #[test]
+    fn a_single_fallback_is_not_remembered() {
+        use crate::config::ApiTransport;
+        let mut streak = 0u32;
+
+        // transient: fell back once, then the forward worked again
+        assert_eq!(remember_transport(Some(ApiTransport::Exec), &mut streak), None);
+        assert_eq!(remember_transport(Some(ApiTransport::Socket), &mut streak), Some(ApiTransport::Socket));
+        assert_eq!(streak, 0);
+
+        // genuinely broken: two in a row sticks, and stays stuck
+        assert_eq!(remember_transport(Some(ApiTransport::Exec), &mut streak), None);
+        assert_eq!(
+            remember_transport(Some(ApiTransport::Exec), &mut streak),
+            Some(ApiTransport::Exec)
+        );
+        assert_eq!(
+            remember_transport(Some(ApiTransport::Exec), &mut streak),
+            Some(ApiTransport::Exec)
+        );
+
+        // a later success clears it, so a fixed host returns to the forward
+        assert_eq!(remember_transport(Some(ApiTransport::Socket), &mut streak), Some(ApiTransport::Socket));
+        assert_eq!(remember_transport(Some(ApiTransport::Exec), &mut streak), None);
+    }
 
     fn argv(parts: &[&str]) -> Vec<Value> {
         parts.iter().map(|s| json!(s)).collect()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -159,9 +159,16 @@ async fn run_connected(
     ctx: &HostCtx,
     poke: &mut mpsc::Receiver<()>,
     backoff_idx: &mut usize,
+    remembered_transport: &mut Option<crate::config::ApiTransport>,
 ) -> Result<()> {
     let mut remote_host = crate::remote::RemoteHost::new(&ctx.host, &ctx.env_state_dir);
+    // a fresh RemoteHost is built on every reconnect, so what worked last
+    // time (specifically: an auto host that fell back to the exec relay)
+    // would otherwise be re-probed via streamlocal on every single reconnect
+    // for the life of the daemon
+    remote_host.hint_transport(*remembered_transport);
     let (remote, _status) = remote_host.connect_api().await?;
+    *remembered_transport = remote_host.last_api_transport;
     *backoff_idx = 0;
     let deps = ConvergeDeps {
         local: ctx.local.clone(),
@@ -262,8 +269,11 @@ const DORMANT_DELAY: u64 = 300;
 async fn host_task(ctx: HostCtx, mut poke: mpsc::Receiver<()>) {
     let mut backoff_idx = 0usize;
     let mut was_dormant = false;
+    // persists across reconnects for the daemon's whole lifetime — the
+    // point of remembering at all (see `run_connected`)
+    let mut remembered_transport: Option<crate::config::ApiTransport> = None;
     loop {
-        let e = match run_connected(&ctx, &mut poke, &mut backoff_idx).await {
+        let e = match run_connected(&ctx, &mut poke, &mut backoff_idx, &mut remembered_transport).await {
             Ok(()) => unreachable!("run_connected only returns on error"),
             Err(e) => e,
         };

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -159,7 +159,11 @@ pub async fn probe_socat(docker_bin: &str, cid: &str) -> Result<()> {
 /// The path comes from `herdr status --json` *inside the container*, which is
 /// the less-trusted side of the boundary, so it is validated rather than
 /// trusted.
-fn validate_socket_path(sock: &str) -> Result<()> {
+///
+/// Shared with `ssh_relay`, whose socket path comes from `herdr status --json`
+/// over ssh instead of over `docker exec` — the same trust boundary, so the
+/// same check.
+pub(crate) fn validate_socket_path(sock: &str) -> Result<()> {
     if !sock.starts_with('/') {
         return Err(err(format!("remote socket path is not absolute: {sock}")));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod pane;
 mod predict;
 mod remote;
 mod remote_action;
+mod ssh_relay;
 mod state;
 mod util;
 

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -1141,6 +1141,7 @@ mod tests {
             prefix: "vps".into(),
             remote_bin: "~/.local/bin/herdr".into(),
             always_control: true,
+            api_transport: crate::config::ApiTransport::Auto,
         }
     }
 

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -13,7 +13,7 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::api::ApiClient;
-use crate::config::HostConfig;
+use crate::config::{ApiTransport, HostConfig};
 use crate::util::{err, Logger, Result};
 
 /// Marker in the error text for "the container isn't running". A stopped
@@ -100,6 +100,19 @@ pub struct RemoteHost {
     /// docker hosts only: owns the relay listener. Dropping it stops serving
     /// and unlinks the socket, so a reconnect never inherits a dead one.
     relay: Option<crate::docker::RelayHandle>,
+    /// ssh hosts only: owns the exec-relay listener when the exec transport
+    /// is in use. Same lifecycle reasoning as `relay` above, one level up
+    /// the transport stack (ssh exec instead of `docker exec`).
+    exec_relay: Option<crate::ssh_relay::RelayHandle>,
+    /// ssh hosts only: which transport to try first. Seeded from `cfg` at
+    /// construction; `hint_transport` lets the daemon override it with what
+    /// last worked, since a fresh `RemoteHost` is built on every reconnect
+    /// and would otherwise re-probe streamlocal every time even after it is
+    /// known to be dead for this host.
+    transport_hint: ApiTransport,
+    /// ssh hosts only: which transport this connection actually used, so the
+    /// daemon can feed it back into the next `RemoteHost`'s `hint_transport`.
+    pub last_api_transport: Option<ApiTransport>,
     log: Logger,
 }
 
@@ -108,11 +121,26 @@ impl RemoteHost {
         RemoteHost {
             ctl_path: state_dir.join(format!("{}.ctl", cfg.name)),
             fwd_sock: state_dir.join(format!("{}-api.sock", cfg.name)),
+            transport_hint: cfg.api_transport,
             cfg: cfg.clone(),
             forwarded: false,
             container: None,
             relay: None,
+            exec_relay: None,
+            last_api_transport: None,
             log: Logger::new(state_dir, false),
+        }
+    }
+
+    /// Seed the transport hint from a daemon-remembered choice. A no-op
+    /// unless the host is configured `api_transport = "auto"` (the default):
+    /// an explicit `socket` or `exec` override always pins its own choice and
+    /// ignores anything remembered from a previous connection.
+    pub fn hint_transport(&mut self, hint: Option<ApiTransport>) {
+        if self.cfg.api_transport == ApiTransport::Auto {
+            if let Some(h) = hint {
+                self.transport_hint = h;
+            }
         }
     }
 
@@ -283,6 +311,83 @@ impl RemoteHost {
         Ok(self.fwd_sock.clone())
     }
 
+    /// Try the streamlocal `-L` forward, verified with a real ping — not just
+    /// that `ssh -O forward` reported success.
+    ///
+    /// The forward registering successfully is not proof the transport works:
+    /// some sshds (embedded Go sshds fronting container/VM workspaces are the
+    /// case this was written against) accept a direct-streamlocal channel
+    /// open and then never service it. Every byte written just sits there, so
+    /// the first sign of trouble is the API layer's own connect/ping timing
+    /// out or the channel closing with zero bytes read — which is exactly
+    /// what `ApiClient::connect`'s ping round-trip surfaces.
+    async fn try_socket_transport(&mut self, remote_socket: &str) -> Result<PathBuf> {
+        let sock = self.forward_api(remote_socket).await?;
+        ApiClient::connect(&sock).await?;
+        Ok(sock)
+    }
+
+    /// Bridge the remote socket over a plain ssh exec channel instead of a
+    /// streamlocal forward. See `ssh_relay` for the transport itself; this
+    /// only resolves the relay command once and (re)starts the listener,
+    /// mirroring the docker branch below one function down.
+    async fn exec_relay_transport(&mut self, remote_socket: &str) -> Result<PathBuf> {
+        // NEVER steal a healthy relay — same reasoning as the docker guard:
+        // the socket path is per-host but shared across processes (daemon,
+        // `remote-*` actions, `once`), and state_dir is a single fixed path.
+        if self.exec_relay.is_none() && ApiClient::connect(&self.fwd_sock).await.is_ok() {
+            return Ok(self.fwd_sock.clone());
+        }
+        self.exec_relay = None;
+        let relay_cmd = crate::ssh_relay::detect_relay_command(self, remote_socket).await?;
+        let handle = crate::ssh_relay::serve_relay(
+            self.ctl_path.clone(),
+            self.cfg.target.clone(),
+            relay_cmd,
+            self.fwd_sock.clone(),
+            self.log.clone(),
+        )?;
+        let path = handle.path.clone();
+        self.exec_relay = Some(handle);
+        Ok(path)
+    }
+
+    /// Choose and reach the ssh API transport: streamlocal socket forward, or
+    /// an exec relay. `api_transport = "socket"` / `"exec"` pin one and never
+    /// try the other; the default `"auto"` tries the socket transport first
+    /// (unless a prior connection in this daemon's lifetime already learned
+    /// it doesn't work here — see `hint_transport`) and falls back to the
+    /// exec relay on failure, logging the switch exactly once per fallback.
+    async fn connect_ssh_api(&mut self, remote_socket: &str) -> Result<PathBuf> {
+        let configured = self.cfg.api_transport;
+        let start_with_socket =
+            (if configured == ApiTransport::Auto { self.transport_hint } else { configured })
+                != ApiTransport::Exec;
+
+        if start_with_socket {
+            match self.try_socket_transport(remote_socket).await {
+                Ok(sock) => {
+                    self.last_api_transport = Some(ApiTransport::Socket);
+                    return Ok(sock);
+                }
+                // only auto may fall back; an explicit `socket` pin means the
+                // caller wants the real failure, not a silent transport swap
+                Err(e) if configured != ApiTransport::Auto => return Err(e),
+                Err(e) => {
+                    self.log.log(&format!(
+                        "[{}] streamlocal forward unavailable ({e}) — using exec relay",
+                        self.cfg.name
+                    ));
+                    self.transport_hint = ApiTransport::Exec;
+                }
+            }
+        }
+
+        let sock = self.exec_relay_transport(remote_socket).await?;
+        self.last_api_transport = Some(ApiTransport::Exec);
+        Ok(sock)
+    }
+
     pub async fn connect_api(&mut self) -> Result<(ApiClient, RemoteStatus)> {
         self.ensure_ready().await?;
         let status = match self.status().await {
@@ -297,7 +402,7 @@ impl RemoteHost {
             return Err(err(status.reason.clone().unwrap_or_else(|| "remote unsupported".into())));
         }
         let sock = match &self.container {
-            None => self.forward_api(&status.socket).await?,
+            None => self.connect_ssh_api(&status.socket).await?,
             Some(c) => {
                 // NEVER steal a healthy relay — the socket path is per-HOST but
                 // shared across processes (daemon, `remote-*` actions, `once`),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -104,6 +104,12 @@ pub struct RemoteHost {
     /// is in use. Same lifecycle reasoning as `relay` above, one level up
     /// the transport stack (ssh exec instead of `docker exec`).
     exec_relay: Option<crate::ssh_relay::RelayHandle>,
+    /// ssh hosts only: where the exec relay listens. Deliberately NOT
+    /// `fwd_sock`: sharing one path with the streamlocal forward makes the
+    /// relay's "is a healthy relay already serving this?" check answerable by
+    /// a live `-L` forward, which silently ignores `api_transport = "exec"`
+    /// and leaves the daemon believing it is on a relay it never started.
+    exec_sock: PathBuf,
     /// ssh hosts only: which transport to try first. Seeded from `cfg` at
     /// construction; `hint_transport` lets the daemon override it with what
     /// last worked, since a fresh `RemoteHost` is built on every reconnect
@@ -127,6 +133,7 @@ impl RemoteHost {
             container: None,
             relay: None,
             exec_relay: None,
+            exec_sock: state_dir.join(format!("{}-api-exec.sock", cfg.name)),
             last_api_transport: None,
             log: Logger::new(state_dir, false),
         }
@@ -321,10 +328,26 @@ impl RemoteHost {
     /// the first sign of trouble is the API layer's own connect/ping timing
     /// out or the channel closing with zero bytes read — which is exactly
     /// what `ApiClient::connect`'s ping round-trip surfaces.
-    async fn try_socket_transport(&mut self, remote_socket: &str) -> Result<PathBuf> {
+    ///
+    /// That ping is the client `connect_api` returns, not an extra probe on
+    /// top of it: a working host must not pay a round trip for a fallback it
+    /// never needs.
+    async fn try_socket_transport(&mut self, remote_socket: &str) -> Result<ApiClient> {
         let sock = self.forward_api(remote_socket).await?;
-        ApiClient::connect(&sock).await?;
-        Ok(sock)
+        ApiClient::connect(&sock).await
+    }
+
+    /// Drop a forward that just proved itself dead, so it doesn't sit
+    /// registered on the ControlMaster for the connection's life with its
+    /// socket file unlinked. Unlike `forward_api`'s guard this cannot steal a
+    /// healthy forward: it only runs after a real ping failed.
+    async fn cancel_forward(&mut self, remote_socket: &str) {
+        let spec = format!("{}:{}", self.fwd_sock.display(), remote_socket);
+        let mut args = self.base_args();
+        args.extend(["-O".into(), "cancel".into(), "-L".into(), spec, self.cfg.target.clone()]);
+        let _ = ssh(&args, 15000).await;
+        let _ = std::fs::remove_file(&self.fwd_sock);
+        self.forwarded = false;
     }
 
     /// Bridge the remote socket over a plain ssh exec channel instead of a
@@ -335,16 +358,23 @@ impl RemoteHost {
         // NEVER steal a healthy relay — same reasoning as the docker guard:
         // the socket path is per-host but shared across processes (daemon,
         // `remote-*` actions, `once`), and state_dir is a single fixed path.
-        if self.exec_relay.is_none() && ApiClient::connect(&self.fwd_sock).await.is_ok() {
-            return Ok(self.fwd_sock.clone());
+        // `exec_sock` is the relay's OWN path, so a live streamlocal forward
+        // can't answer for it and quietly cancel the exec transport.
+        if self.exec_relay.is_none() && ApiClient::connect(&self.exec_sock).await.is_ok() {
+            return Ok(self.exec_sock.clone());
         }
         self.exec_relay = None;
         let relay_cmd = crate::ssh_relay::detect_relay_command(self, remote_socket).await?;
+        self.log.log(&format!(
+            "[{}] exec relay via {} → {remote_socket}",
+            self.cfg.name,
+            relay_cmd.tool()
+        ));
         let handle = crate::ssh_relay::serve_relay(
             self.ctl_path.clone(),
             self.cfg.target.clone(),
             relay_cmd,
-            self.fwd_sock.clone(),
+            self.exec_sock.clone(),
             self.log.clone(),
         )?;
         let path = handle.path.clone();
@@ -358,7 +388,11 @@ impl RemoteHost {
     /// (unless a prior connection in this daemon's lifetime already learned
     /// it doesn't work here — see `hint_transport`) and falls back to the
     /// exec relay on failure, logging the switch exactly once per fallback.
-    async fn connect_ssh_api(&mut self, remote_socket: &str) -> Result<PathBuf> {
+    ///
+    /// Returns a CONNECTED client rather than a path: the connect is the
+    /// probe, so the socket transport costs a working host exactly what it
+    /// cost before this fallback existed.
+    async fn connect_ssh_api(&mut self, remote_socket: &str) -> Result<ApiClient> {
         let configured = self.cfg.api_transport;
         let start_with_socket =
             (if configured == ApiTransport::Auto { self.transport_hint } else { configured })
@@ -366,9 +400,9 @@ impl RemoteHost {
 
         if start_with_socket {
             match self.try_socket_transport(remote_socket).await {
-                Ok(sock) => {
+                Ok(api) => {
                     self.last_api_transport = Some(ApiTransport::Socket);
-                    return Ok(sock);
+                    return Ok(api);
                 }
                 // only auto may fall back; an explicit `socket` pin means the
                 // caller wants the real failure, not a silent transport swap
@@ -379,13 +413,16 @@ impl RemoteHost {
                         self.cfg.name
                     ));
                     self.transport_hint = ApiTransport::Exec;
+                    // it answered nothing; don't leave it registered
+                    self.cancel_forward(remote_socket).await;
                 }
             }
         }
 
         let sock = self.exec_relay_transport(remote_socket).await?;
+        let api = ApiClient::connect(&sock).await?;
         self.last_api_transport = Some(ApiTransport::Exec);
-        Ok(sock)
+        Ok(api)
     }
 
     pub async fn connect_api(&mut self) -> Result<(ApiClient, RemoteStatus)> {
@@ -401,8 +438,11 @@ impl RemoteHost {
         if !status.supported {
             return Err(err(status.reason.clone().unwrap_or_else(|| "remote unsupported".into())));
         }
-        let sock = match &self.container {
-            None => self.connect_ssh_api(&status.socket).await?,
+        // ssh hosts hand back a connected client (its ping doubles as the
+        // transport probe); the docker branch resolves a path and connects below
+        let container = self.container.clone();
+        let sock = match &container {
+            None => return Ok((self.connect_ssh_api(&status.socket).await?, status)),
             Some(c) => {
                 // NEVER steal a healthy relay — the socket path is per-HOST but
                 // shared across processes (daemon, `remote-*` actions, `once`),

--- a/src/ssh_relay.rs
+++ b/src/ssh_relay.rs
@@ -44,7 +44,19 @@ use crate::util::{err, Logger, Result};
 /// already remembers the *transport* choice across reconnects for the same
 /// reason.
 #[derive(Debug, Clone)]
-pub struct RelayCommand(String);
+pub struct RelayCommand {
+    cmd: String,
+    /// which bridge this is, for the log line: "is it socat or the python
+    /// bridge" is the first question when a host misbehaves, and a short-lived
+    /// relay child is not something you can catch in `ps` after the fact.
+    tool: &'static str,
+}
+
+impl RelayCommand {
+    pub fn tool(&self) -> &'static str {
+        self.tool
+    }
+}
 
 /// Find a relay command the remote can run: socat if present (cheap, no
 /// runtime dependency beyond the binary itself), else a python3 fallback.
@@ -52,18 +64,23 @@ pub struct RelayCommand(String);
 pub async fn detect_relay_command(host: &RemoteHost, remote_sock: &str) -> Result<RelayCommand> {
     validate_socket_path(remote_sock)?;
     if !host.exec("command -v socat", 8000).await.unwrap_or_default().trim().is_empty() {
-        // socat's address grammar is not a plain path (`,` starts an option
-        // list, `!!` a dual address); validated above, same reasoning as the
-        // docker relay.
-        return Ok(RelayCommand(format!("socat - UNIX-CONNECT:{remote_sock}")));
+        return Ok(RelayCommand { cmd: socat_bridge_command(remote_sock), tool: "socat" });
     }
     if !host.exec("command -v python3", 8000).await.unwrap_or_default().trim().is_empty() {
-        return Ok(RelayCommand(python_bridge_command(remote_sock)));
+        return Ok(RelayCommand { cmd: python_bridge_command(remote_sock), tool: "python3" });
     }
     Err(err(
         "remote has neither socat nor python3, which one of is needed to reach herdr's \
          socket over an exec relay — install either",
     ))
+}
+
+/// socat's stdio↔unix form. Its address grammar is not a plain path (`,` starts
+/// an option list, `!!` a dual address), so the path is validated by
+/// `detect_relay_command` before it reaches here — same reasoning as the docker
+/// relay.
+fn socat_bridge_command(remote_sock: &str) -> String {
+    format!("socat - UNIX-CONNECT:{remote_sock}")
 }
 
 /// Minimal stdio↔`AF_UNIX` bridge for hosts without socat.
@@ -72,7 +89,9 @@ pub async fn detect_relay_command(host: &RemoteHost, remote_sock: &str) -> Resul
 /// those wrap a buffered, text-capable layer that both delays bytes (bad for
 /// a request/response protocol waiting on a prompt-less socket) and risks
 /// re-encoding on non-UTF8 bytes. Raw fd I/O is the only way to get
-/// unbuffered, binary-safe transfer in either direction.
+/// unbuffered, binary-safe transfer in either direction. `os.write` is looped
+/// rather than called once: it returns a count, and a short write (a signal
+/// landing mid-transfer) would silently drop the tail of a response.
 ///
 /// The two directions run as separate strands (a background thread for
 /// stdin→socket, the main thread for socket→stdout) so they proceed
@@ -116,7 +135,12 @@ while True:
         break
     if not b:
         break
-    os.write(1,b)
+    while b:
+        try:
+            n=os.write(1,b)
+        except OSError:
+            sys.exit(0)
+        b=b[n:]
 "#;
     let sock_b64 = B64.encode(remote_sock.as_bytes());
     format!("python3 -c '{BRIDGE}' '{sock_b64}'")
@@ -141,7 +165,7 @@ impl ExecTarget {
             "-o",
             "BatchMode=yes",
             &self.ssh_target,
-            &self.relay_cmd.0,
+            &self.relay_cmd.cmd,
         ]);
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -307,10 +331,32 @@ async fn pump(target: &ExecTarget, stream: UnixStream, shutdown: watch::Receiver
 mod tests {
     use super::*;
 
+    /// The socat form is a cross-process contract with the remote's socat, and
+    /// the path must arrive whole: `UNIX-CONNECT:` takes the rest of the word
+    /// as the address.
     #[test]
     fn socat_command_uses_dash_stdio_form() {
-        let cmd = "socat - UNIX-CONNECT:/home/vscode/.config/herdr/herdr.sock";
-        assert!(cmd.starts_with("socat - UNIX-CONNECT:"));
+        let cmd = socat_bridge_command("/home/vscode/.config/herdr/herdr.sock");
+        assert_eq!(cmd, "socat - UNIX-CONNECT:/home/vscode/.config/herdr/herdr.sock");
+    }
+
+    /// A relay reports which bridge it is, so the log line can say so: catching
+    /// a per-request relay child in `ps` after the fact is not a diagnostic.
+    #[test]
+    fn relay_command_reports_its_tool() {
+        let socat = RelayCommand { cmd: socat_bridge_command("/tmp/x.sock"), tool: "socat" };
+        assert_eq!(socat.tool(), "socat");
+        let py = RelayCommand { cmd: python_bridge_command("/tmp/x.sock"), tool: "python3" };
+        assert_eq!(py.tool(), "python3");
+    }
+
+    /// The response half must be written in full. `os.write` returns a count,
+    /// so a single call can short-write and silently truncate a JSON response.
+    #[test]
+    fn python_bridge_loops_until_the_write_completes() {
+        let cmd = python_bridge_command("/tmp/x.sock");
+        assert!(cmd.contains("n=os.write(1,b)"), "{cmd}");
+        assert!(cmd.contains("b=b[n:]"), "expected the remainder to be re-written: {cmd}");
     }
 
     /// The socket path must never appear verbatim in the command line: it is
@@ -377,7 +423,8 @@ mod tests {
             .expect("ssh master spawn");
         assert!(start.success(), "ssh ControlMaster failed to start");
 
-        let relay_cmd = RelayCommand(python_bridge_command(&sock));
+        let relay_cmd =
+            RelayCommand { cmd: python_bridge_command(&sock), tool: "python3" };
         let handle = serve_relay(ctl_path.clone(), ssh_target.clone(), relay_cmd, local_sock.clone(), Logger::new(&dir, false))
             .unwrap();
 

--- a/src/ssh_relay.rs
+++ b/src/ssh_relay.rs
@@ -1,0 +1,409 @@
+// Exec-relay transport: reach a herdr server's unix socket over a plain ssh
+// exec channel, for ssh hosts whose sshd accepts `-L`-style direct-streamlocal
+// channel opens but never services them (observed against embedded Go sshds
+// fronting container/VM workspaces — e.g. DevPod-style remote dev
+// environments). `remote::connect_ssh_api` decides *when* to use this; this
+// module only implements the bridge once that decision is made.
+//
+// This is deliberately the same shape as docker.rs's container relay: one
+// exec (here, `ssh -S <ctlpath> <target> <relay-cmd>` instead of `docker exec
+// -i <cid> ...`) per accepted local connection, piping the child's
+// stdin/stdout to/from the unix socket at daemon → <state>/<host>-api.sock.
+//
+//   daemon → <state>/<host>-api.sock        (a local socket WE listen on)
+//              │ copy both directions
+//   ssh -S <ctlpath> <target> "<relay-cmd>"
+//              │ (multiplexed over the existing ControlMaster: no new
+//              │  handshake, and exec channels are the transport that is
+//              │  known to work where streamlocal is not)
+//              └→ /path/to/herdr.sock   (herdr, on the remote)
+//
+// `relay-cmd` is `socat - UNIX-CONNECT:<sock>` when the remote has socat, else
+// a small python3 stdio↔unix bridge (see `python_bridge_command`) — chosen
+// once per host by `detect_relay_command` and reused for every connection.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::process::Command;
+use tokio::sync::watch;
+use tokio::time::timeout;
+
+use crate::docker::validate_socket_path;
+use crate::remote::RemoteHost;
+use crate::util::{err, Logger, Result};
+
+/// A remote stdio↔unix bridge, run once and reused across probes: not worth
+/// re-detecting on every reconnect within a daemon's lifetime, and `remote`
+/// already remembers the *transport* choice across reconnects for the same
+/// reason.
+#[derive(Debug, Clone)]
+pub struct RelayCommand(String);
+
+/// Find a relay command the remote can run: socat if present (cheap, no
+/// runtime dependency beyond the binary itself), else a python3 fallback.
+/// Errors when neither exists — a clear "install one" beats a silent hang.
+pub async fn detect_relay_command(host: &RemoteHost, remote_sock: &str) -> Result<RelayCommand> {
+    validate_socket_path(remote_sock)?;
+    if !host.exec("command -v socat", 8000).await.unwrap_or_default().trim().is_empty() {
+        // socat's address grammar is not a plain path (`,` starts an option
+        // list, `!!` a dual address); validated above, same reasoning as the
+        // docker relay.
+        return Ok(RelayCommand(format!("socat - UNIX-CONNECT:{remote_sock}")));
+    }
+    if !host.exec("command -v python3", 8000).await.unwrap_or_default().trim().is_empty() {
+        return Ok(RelayCommand(python_bridge_command(remote_sock)));
+    }
+    Err(err(
+        "remote has neither socat nor python3, which one of is needed to reach herdr's \
+         socket over an exec relay — install either",
+    ))
+}
+
+/// Minimal stdio↔`AF_UNIX` bridge for hosts without socat.
+///
+/// Uses `os.read`/`os.write` on the raw fds rather than `sys.stdin`/`stdout`:
+/// those wrap a buffered, text-capable layer that both delays bytes (bad for
+/// a request/response protocol waiting on a prompt-less socket) and risks
+/// re-encoding on non-UTF8 bytes. Raw fd I/O is the only way to get
+/// unbuffered, binary-safe transfer in either direction.
+///
+/// The two directions run as separate strands (a background thread for
+/// stdin→socket, the main thread for socket→stdout) so they proceed
+/// concurrently — `os.read`/`socket.recv` release the GIL while blocked, so
+/// this is real concurrency, not a serialized illusion. A single-threaded
+/// version that alternated between the two would deadlock the JSON API the
+/// first time a request's bytes hadn't fully arrived before the response
+/// started: the client can't finish sending while the bridge is blocked
+/// reading the (still empty) response half.
+///
+/// EOF handling matches `docker::pump`'s reasoning exactly: stdin closing
+/// means the local side finished sending its request, which is NOT the end of
+/// the exchange (`socket.shutdown(SHUT_WR)` forwards that half-close without
+/// tearing down the read side); the socket closing IS the end of the exchange
+/// (herdr closes after each response), so that is what ends the process.
+///
+/// The socket path travels as a base64 argv element rather than interpolated
+/// into the script text, so it can never be read as anything but a string —
+/// no quoting of untrusted remote data survives into a shell or Python
+/// grammar at all.
+fn python_bridge_command(remote_sock: &str) -> String {
+    const BRIDGE: &str = r#"import os,socket,sys,threading,base64
+p=base64.b64decode(sys.argv[1]).decode()
+s=socket.socket(socket.AF_UNIX,socket.SOCK_STREAM)
+s.connect(p)
+def up():
+    while True:
+        b=os.read(0,65536)
+        if not b:
+            break
+        s.sendall(b)
+    try:
+        s.shutdown(socket.SHUT_WR)
+    except OSError:
+        pass
+threading.Thread(target=up,daemon=True).start()
+while True:
+    try:
+        b=s.recv(65536)
+    except OSError:
+        break
+    if not b:
+        break
+    os.write(1,b)
+"#;
+    let sock_b64 = B64.encode(remote_sock.as_bytes());
+    format!("python3 -c '{BRIDGE}' '{sock_b64}'")
+}
+
+/// Where and how to reach the remote: reuses the daemon's own ControlMaster
+/// (`-S ctl_path`) so a relay exec costs no new ssh handshake, exactly like
+/// every other multiplexed exec this daemon already runs.
+#[derive(Debug, Clone)]
+struct ExecTarget {
+    ctl_path: PathBuf,
+    ssh_target: String,
+    relay_cmd: RelayCommand,
+}
+
+impl ExecTarget {
+    fn relay_child(&self) -> Result<tokio::process::Child> {
+        let mut cmd = Command::new("ssh");
+        cmd.args([
+            "-S",
+            &self.ctl_path.display().to_string(),
+            "-o",
+            "BatchMode=yes",
+            &self.ssh_target,
+            &self.relay_cmd.0,
+        ]);
+        cmd.stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // kept, not nulled: an sshd that killed the channel, or a relay
+            // command that can't open the socket, is otherwise indistinguishable
+            // from a clean close and the real reason is lost
+            .stderr(Stdio::piped())
+            // if we drop the connection the child must die rather than linger
+            // holding an exec channel open on the ControlMaster
+            .kill_on_drop(true);
+        cmd.spawn().map_err(|e| err(format!("ssh exec (relay) failed: {e}")))
+    }
+}
+
+/// Serve `local_sock` by relaying every accepted connection into the remote
+/// over a fresh exec channel. Returns once the listener is bound, so callers
+/// can connect immediately.
+///
+/// Structurally identical to `docker::serve_relay` — see that function's
+/// comments for the accept-loop and shutdown reasoning, which apply unchanged
+/// here.
+pub fn serve_relay(
+    ctl_path: PathBuf,
+    ssh_target: String,
+    relay_cmd: RelayCommand,
+    local_sock: PathBuf,
+    log: Logger,
+) -> Result<RelayHandle> {
+    let target = ExecTarget { ctl_path, ssh_target, relay_cmd };
+    let _ = std::fs::remove_file(&local_sock);
+    if let Some(parent) = local_sock.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let listener = UnixListener::bind(&local_sock)
+        .map_err(|e| err(format!("cannot bind {}: {e}", local_sock.display())))?;
+    // anyone who can connect here drives the remote herdr API unauthenticated,
+    // which can start agents with arbitrary argv. ssh's -L forward is 0600, so
+    // match it rather than inheriting the ambient umask.
+    if let Err(e) = std::fs::set_permissions(&local_sock, std::fs::Permissions::from_mode(0o600)) {
+        log.log(&format!("relay: cannot restrict {}: {e}", local_sock.display()));
+    }
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let path = local_sock.clone();
+    let task = tokio::spawn(async move {
+        let mut consecutive_errors = 0u32;
+        loop {
+            let stream = tokio::select! {
+                accepted = listener.accept() => match accepted {
+                    Ok((s, _)) => s,
+                    Err(e) => {
+                        consecutive_errors += 1;
+                        log.log(&format!("exec relay accept failed ({consecutive_errors}): {e}"));
+                        if consecutive_errors >= 5 {
+                            log.log("exec relay: giving up on accept; host will reconnect");
+                            return;
+                        }
+                        tokio::time::sleep(Duration::from_millis(200 * consecutive_errors as u64))
+                            .await;
+                        continue;
+                    }
+                },
+                _ = wait_shutdown(shutdown_rx.clone()) => return,
+            };
+            consecutive_errors = 0;
+            let t = target.clone();
+            let log = log.clone();
+            let shutdown = shutdown_rx.clone();
+            tokio::spawn(async move {
+                if let Err(e) = pump(&t, stream, shutdown).await {
+                    log.log(&format!("exec relay connection failed: {e}"));
+                }
+            });
+        }
+    });
+    Ok(RelayHandle { path, task, shutdown: shutdown_tx })
+}
+
+async fn wait_shutdown(mut rx: watch::Receiver<bool>) {
+    while rx.changed().await.is_ok() {
+        if *rx.borrow() {
+            return;
+        }
+    }
+}
+
+/// Owns the relay. Dropping it stops accepting, terminates in-flight
+/// connections, and unlinks the socket. Same shape as `docker::RelayHandle`.
+pub struct RelayHandle {
+    pub path: PathBuf,
+    task: tokio::task::JoinHandle<()>,
+    shutdown: watch::Sender<bool>,
+}
+
+impl Drop for RelayHandle {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(true);
+        self.task.abort();
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Copy bytes both ways until the remote side closes or we are shut down.
+async fn pump(target: &ExecTarget, stream: UnixStream, shutdown: watch::Receiver<bool>) -> Result<()> {
+    let mut child = target.relay_child()?;
+    let mut cin = child.stdin.take().ok_or_else(|| err("relay: no child stdin"))?;
+    let mut cout = child.stdout.take().ok_or_else(|| err("relay: no child stdout"))?;
+    let mut cerr = child.stderr.take().ok_or_else(|| err("relay: no child stderr"))?;
+    let (mut lr, mut lw) = stream.into_split();
+
+    // Client → remote. Finishing means the client half-closed after sending
+    // its request, which is NOT the end of the exchange: forward the EOF and
+    // keep waiting for the response. Ending the pump here would truncate it.
+    let up = async move {
+        let mut buf = [0u8; 32 * 1024];
+        loop {
+            let n = match lr.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            if cin.write_all(&buf[..n]).await.is_err() || cin.flush().await.is_err() {
+                break;
+            }
+        }
+        let _ = cin.shutdown().await;
+    };
+
+    // Remote → client. This direction ending is the real end of the exchange:
+    // herdr closes after each response, and a dropped subscription closes
+    // here too.
+    let down = async {
+        let mut buf = [0u8; 32 * 1024];
+        loop {
+            let n = match cout.read(&mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            if lw.write_all(&buf[..n]).await.is_err() || lw.flush().await.is_err() {
+                break;
+            }
+        }
+    };
+
+    let upper = tokio::spawn(up);
+    tokio::select! {
+        _ = down => {}
+        _ = wait_shutdown(shutdown) => {}
+    }
+    upper.abort();
+
+    // surface why the relay gave up, instead of presenting every distinct
+    // fault as an indistinguishable "connection closed"
+    let mut errtext = String::new();
+    let _ = timeout(Duration::from_millis(200), cerr.read_to_string(&mut errtext)).await;
+    let errtext = errtext.trim();
+    if !errtext.is_empty() {
+        return Err(err(format!("relay: {errtext}")));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socat_command_uses_dash_stdio_form() {
+        let cmd = "socat - UNIX-CONNECT:/home/vscode/.config/herdr/herdr.sock";
+        assert!(cmd.starts_with("socat - UNIX-CONNECT:"));
+    }
+
+    /// The socket path must never appear verbatim in the command line: it is
+    /// base64'd so a path containing shell or python metacharacters can't
+    /// reach either grammar.
+    #[test]
+    fn python_bridge_never_interpolates_the_raw_path() {
+        let sock = "/tmp/x'; rm -rf ~ #.sock";
+        let cmd = python_bridge_command(sock);
+        assert!(!cmd.contains(sock), "raw socket path leaked into the command line: {cmd}");
+        let b64 = B64.encode(sock.as_bytes());
+        assert!(cmd.contains(&b64), "expected the base64 form present: {cmd}");
+    }
+
+    #[test]
+    fn python_bridge_script_has_no_single_quotes() {
+        // the whole script is wrapped in single quotes on the command line;
+        // an embedded one would end the quoting early and corrupt the command
+        let cmd = python_bridge_command("/tmp/x.sock");
+        let inner = cmd.split('\'').nth(1).expect("script segment");
+        assert!(!inner.contains('\''), "script must not contain single quotes: {inner}");
+    }
+
+    /// End-to-end relay check against a real unix socket over a real ssh
+    /// ControlMaster. Skipped unless the env vars below are set — this is the
+    /// piece unit tests cannot cover on their own machine, since it needs a
+    /// live ssh target with either socat or python3 and something herdr-like
+    /// listening on a unix socket:
+    ///
+    ///   HERDR_MIRROR_IT_SSH_TARGET=my-host.example \
+    ///   HERDR_MIRROR_IT_SSH_SOCK=/home/user/.config/herdr/herdr.sock \
+    ///   cargo test -- --ignored --nocapture relay_reaches_real_ssh_host
+    #[tokio::test]
+    #[ignore]
+    async fn relay_reaches_real_ssh_host() {
+        let Ok(ssh_target) = std::env::var("HERDR_MIRROR_IT_SSH_TARGET") else {
+            eprintln!("skipped: set HERDR_MIRROR_IT_SSH_TARGET");
+            return;
+        };
+        let sock = std::env::var("HERDR_MIRROR_IT_SSH_SOCK")
+            .unwrap_or_else(|_| "/home/vscode/.config/herdr/herdr.sock".into());
+
+        let dir = std::env::temp_dir().join(format!("herdr-mirror-it-ssh-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let ctl_path = dir.join("it.ctl");
+        let local_sock = dir.join("it-api.sock");
+
+        // establish a ControlMaster the relay child can multiplex onto
+        let start = Command::new("ssh")
+            .args([
+                "-M",
+                "-S",
+                ctl_path.to_str().unwrap(),
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ControlPersist=yes",
+                "-f",
+                "-N",
+                &ssh_target,
+            ])
+            .status()
+            .await
+            .expect("ssh master spawn");
+        assert!(start.success(), "ssh ControlMaster failed to start");
+
+        let relay_cmd = RelayCommand(python_bridge_command(&sock));
+        let handle = serve_relay(ctl_path.clone(), ssh_target.clone(), relay_cmd, local_sock.clone(), Logger::new(&dir, false))
+            .unwrap();
+
+        let mode = std::fs::metadata(&handle.path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "relay socket must be 0600, got {mode:o}");
+
+        let api = crate::api::ApiClient::connect(&handle.path).await.expect("ping through exec relay");
+        eprintln!("ping ok");
+
+        let snap = api
+            .request("session.snapshot", serde_json::json!({}))
+            .await
+            .expect("session.snapshot through exec relay");
+        assert!(snap.pointer("/snapshot/workspaces").is_some(), "snapshot shape: {snap}");
+        eprintln!("snapshot ok ({} bytes)", snap.to_string().len());
+
+        for _ in 0..5 {
+            api.request("session.snapshot", serde_json::json!({})).await.expect("repeat request");
+        }
+        eprintln!("5 sequential requests ok");
+
+        drop(handle);
+        let _ = Command::new("ssh")
+            .args(["-S", ctl_path.to_str().unwrap(), "-O", "exit", &ssh_target])
+            .status()
+            .await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Problem

Against ssh hosts fronted by certain embedded sshds (observed against DevPod
EKS workspaces, but not specific to that product — any Go `ssh` package
implementation that accepts a `direct-streamlocal@openssh.com` channel open
without wiring it to anything will do this), the mirror daemon never
connects. Every connection attempt fails with:

```
disconnected (api closed before response: ping) — retrying in 30s
```

forever, on every host behind that kind of sshd.

## Root cause

`RemoteHost::forward_api` reaches the remote herdr API socket via ssh's
streamlocal forwarding (`-L local.sock:remote.sock`, i.e. a
`direct-streamlocal` channel). The `ssh -O forward` command itself reports
success — the forward registers fine on the ControlMaster. But some sshds
**accept the channel open and then never service it**: no data flows in
either direction, so the very first API request (`ApiClient::connect`'s
ping) hangs until timeout and the connection is reported closed with zero
bytes read.

Control tests against the same hosts confirm the scope is narrow:

- **Plain ssh exec channels work fine** — every other remote invocation this
  daemon makes (`ssh host exec <remote_bin> status --json`, and the pane
  streamer's `exec ... terminal session ...`) succeeds normally.
- **TCP forwarding (`-L port:port`) works fine** too.
- **Only streamlocal forwarding is silently dead.**

## Fix

For ssh hosts, add a second way to reach the API socket: an **exec relay**,
structurally identical to the `docker exec` relay this project already uses
for devcontainer hosts (`docker.rs`) — one relay process per API connection,
bridging stdio to the remote unix socket, instead of a socket-level forward.
New module: `src/ssh_relay.rs`.

- **Auto-fallback, zero config.** New per-host option `api_transport`
  (`"auto"` | `"socket"` | `"exec"`, default `"auto"`), consistent with the
  existing per-host options (`target`/`remote_bin`/`prefix`/`always_control`/
  `enabled`). `"auto"` tries the streamlocal forward first (verified with a
  real ping, not just a successful `-O forward`) and falls back to the exec
  relay on failure, logging the switch once:
  `[host] streamlocal forward unavailable (...) — using exec relay`. The
  daemon remembers the choice across reconnects for its whole lifetime (a
  fresh `RemoteHost` is built on every reconnect, so without this the
  fallback would be silently re-probed, and briefly retried via the dead
  path, on every single reconnect). `"socket"`/`"exec"` pin one transport and
  skip the probe/fallback entirely.
- **Remote relay command auto-detection.** Prefers `socat - UNIX-CONNECT:<sock>`
  when socat exists on the remote; falls back to a small python3 one-liner
  bridge when it doesn't (many minimal remote images have python3 but not
  socat). The python bridge uses raw `os.read`/`os.write` on fds 0/1
  (unbuffered, binary-safe — `sys.stdin`/`stdout` would risk buffering and
  encoding surprises on a binary JSON-over-socket protocol) with the two
  directions on separate threads (stdin→socket on a background thread,
  socket→stdout on the main thread; both directions release the GIL on their
  blocking calls, so this is real concurrency) and correct half-close
  (stdin EOF → `socket.shutdown(SHUT_WR)`, forwarding the half-close instead
  of ending the exchange; socket EOF ends the process, matching how the
  existing docker relay reasons about the same two events). The socket path
  travels as a base64 argv element, never interpolated into the script or
  shell text, so it can't reach either grammar as anything but an opaque
  string.
- Reuses the existing `remote_bin`-style discovery of the remote socket path
  (`herdr status --json`, already run for the streamlocal path) — no new way
  of finding the socket.
- Follows the existing error/logging taxonomy (`[host] ...` log lines,
  `nonempty`-style error formatting).

## Testing

**Unit tests** (`cargo test`, `cargo clippy`, all green, no new warnings):
- `config.rs`: `api_transport` parsing, default, and unknown-value rejection
  (skip-with-reason, matching the existing bad-host handling).
- `ssh_relay.rs`: the python bridge command never interpolates the raw
  socket path (only its base64 form) and contains no single quotes (it's
  wrapped in single quotes on the remote command line).
- Ignored live-IT tests for both the docker and new ssh relay paths are
  present but require real infrastructure (see doc comments).

**Live verification**, against three real ssh hosts behind an embedded Go
sshd (generic DevPod-style EKS dev workspaces), each running a real herdr
0.7.5 server with **no socat installed but python3 present** — i.e. exactly
the fallback path that has to work, exercised for real rather than mocked:

```
[host-a] streamlocal forward unavailable (api closed before response: ping) — using exec relay
[host-b] streamlocal forward unavailable (api closed before response: ping) — using exec relay
[host-c] streamlocal forward unavailable (api closed before response: ping) — using exec relay
[host-a] connected and synced
[host-b] connected and synced
[host-c] connected and synced
```

`herdr-mirror status` afterward showed 1 mirror workspace + 1 mirror pane
for each of the three hosts, and the local `herdr workspace list` showed the
three mirrored workspaces. Killing one host's ssh ControlMaster to force a
reconnect produced a clean `disconnected (event stream closed) — retrying in
5s` → `connected and synced` cycle with **no repeated streamlocal probe or
fallback log line** — confirming the per-daemon-lifetime memory works as
intended.

Pane streaming (the `herdr-mirror pane` streamer) was unaffected throughout,
before and after this change — it already uses its own direct ssh exec
channels rather than streamlocal forwarding, so it was never in scope of
this bug. Noting it here since it's easy to assume otherwise from the
symptom.

## Why this matters

Without this fix, the mirror daemon is **completely non-functional** against
any ssh host whose sshd has this property — not degraded, not slow, just
permanently stuck retrying a dead transport. DevPod-style container/VM dev
environments using an embedded Go ssh server are one such case, and likely
not the only one.