### PR TITLE
fix: wheel always sends semantic terminal.scroll, not raw forward on TUI foreground

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -369,6 +369,32 @@ fn parse_mouse(bytes: &[u8], at: usize) -> Option<(u32, u32, u32, bool, usize)> 
     None
 }
 
+/// How a parsed mouse event should be routed while in control mode.
+#[derive(Debug, PartialEq, Eq)]
+enum MouseAction {
+    /// wheel: send as a semantic terminal.scroll (server decides app vs scrollback)
+    Scroll { up: bool },
+    /// click/drag on a remote TUI: forward the raw SGR sequence
+    ForwardRaw,
+    /// click/drag at a shell (or unclassified): drop, keep mouse local
+    Drop,
+}
+
+/// Wheel always scrolls semantically, regardless of the foreground
+/// classification — the remote herdr server knows the real app's mouse mode
+/// and is a better judge than this side's process-name heuristic (e.g. a TUI
+/// that doesn't consume wheel events, like an agent CLI). Non-wheel
+/// clicks/drags keep the existing foreground-based routing.
+fn mouse_action(remote_is_shell: Option<bool>, btn: u32, press: bool) -> MouseAction {
+    if press && (btn == 64 || btn == 65) {
+        MouseAction::Scroll { up: btn == 64 }
+    } else if remote_is_shell == Some(false) {
+        MouseAction::ForwardRaw
+    } else {
+        MouseAction::Drop
+    }
+}
+
 fn contains_wheel_press(bytes: &[u8]) -> bool {
     let mut i = 0;
     while i < bytes.len() {
@@ -732,22 +758,21 @@ impl App {
         let mut scrolls: Vec<serde_json::Value> = Vec::new();
         while i < buf.len() {
             if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
-                if self.remote_is_shell == Some(false) {
-                    // remote foreground is a TUI → forward wheel and clicks raw
-                    rest.extend_from_slice(&buf[i..i + len]);
-                } else if press && (btn == 64 || btn == 65) {
-                    // shell / not-yet-classified: wheel becomes a semantic scroll
-                    scrolls.push(json!({
-                        "type": "terminal.scroll",
-                        "direction": if btn == 64 { "up" } else { "down" },
-                        "lines": 3,
-                        "source": "wheel",
-                        "column": x.saturating_sub(1),
-                        "row": y.saturating_sub(1),
-                        "modifiers": 0,
-                    }));
+                match mouse_action(self.remote_is_shell, btn, press) {
+                    MouseAction::Scroll { up } => {
+                        scrolls.push(json!({
+                            "type": "terminal.scroll",
+                            "direction": if up { "up" } else { "down" },
+                            "lines": 3,
+                            "source": "wheel",
+                            "column": x.saturating_sub(1),
+                            "row": y.saturating_sub(1),
+                            "modifiers": 0,
+                        }));
+                    }
+                    MouseAction::ForwardRaw => rest.extend_from_slice(&buf[i..i + len]),
+                    MouseAction::Drop => {}
                 }
-                // else: shell/unknown click → drop (keep mouse local)
                 i += len;
             } else {
                 rest.push(buf[i]);
@@ -932,6 +957,22 @@ pub async fn run(args: Args) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wheel_always_semantic_scroll_even_on_tui_foreground() {
+        // remote foreground classified as a TUI (e.g. `claude`) — wheel must
+        // still produce a semantic scroll, not a raw forward, or it silently
+        // does nothing when the TUI doesn't consume mouse wheel input
+        assert_eq!(mouse_action(Some(false), 64, true), MouseAction::Scroll { up: true });
+        assert_eq!(mouse_action(Some(false), 65, true), MouseAction::Scroll { up: false });
+        // unclassified/shell foreground: wheel still scrolls
+        assert_eq!(mouse_action(None, 64, true), MouseAction::Scroll { up: true });
+        assert_eq!(mouse_action(Some(true), 65, true), MouseAction::Scroll { up: false });
+        // non-wheel clicks/drags keep the existing foreground-based routing
+        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::ForwardRaw); // TUI click
+        assert_eq!(mouse_action(Some(true), 0, true), MouseAction::Drop); // shell click
+        assert_eq!(mouse_action(None, 0, true), MouseAction::Drop); // unclassified click
+    }
 
     #[test]
     fn mouse_parsing() {


### PR DESCRIPTION
## Problem

Mouse wheel does nothing in a mirror pane whenever the remote foreground is a coding-agent TUI.

In control mode, `on_input` routes mouse events on `remote_is_shell`:

```rust
if self.remote_is_shell == Some(false) {
    // remote foreground is a TUI → forward wheel and clicks raw
    rest.extend_from_slice(&buf[i..i + len]);
} else if press && (btn == 64 || btn == 65) {
    // shell / not-yet-classified: wheel becomes a semantic scroll
    scrolls.push(json!({ "type": "terminal.scroll", ... }));
}
```

`foreground.rs` classifies anything not in `SHELLS` as a TUI, so a remote pane running
`claude` (or codex / pi / any agent CLI) is classified as a TUI and the wheel is forwarded
raw to the remote pty. Claude Code doesn't enable mouse tracking, so the sequence lands
nowhere and the pane doesn't move. The mirror pane has no local scrollback of its own
(`max_offset_from_bottom: 0` — the content is painted frames), so herdr has nothing to
scroll locally either. Both paths dead-end.

The heuristic fails precisely on the panes herdr exists for — remote panes running agents.

Measured on herdr 0.7.5 / herdr-mirror v0.1.11, remote foreground:

```
foreground_processes: [{"argv0":"claude","cmdline":"claude","pid":8301}]
```

## Fix

Wheel always becomes a semantic `terminal.scroll`, regardless of the foreground
classification; non-wheel clicks/drags keep the existing routing (raw forward on a TUI,
dropped at a shell).

This is what the existing comment already says the message is for —
`// wheel becomes a semantic scroll (server decides app vs scrollback)`. The remote herdr
server knows the real app's mouse mode; a process-name heuristic on this side does not.

The routing decision is extracted into a pure `mouse_action()` helper so it can be unit
tested — `on_input` itself needs the async session state to construct. No other behavior
change.

## Verification

End-to-end against a real remote pane (herdr 0.7.5 both ends, remote foreground `claude`),
injecting SGR wheel sequences and reading the remote pane's viewport:

```
before                       offset_from_bottom = 0   (max 501)
wheel-up   ESC[<64;40;10M  → offset_from_bottom = 3
wheel-down ESC[<65;40;10M  → offset_from_bottom = 0
```

`cargo test`: 68 passed, 0 failed (1 pre-existing ignored docker test).
New test `wheel_always_semantic_scroll_even_on_tui_foreground` covers the TUI-foreground
wheel case plus the unchanged click routing.

## Note

Thanks for herdr-mirror — it's the only thing in the ecosystem that actually unifies remote
herdr sessions into one window, and it took about five minutes to get a second machine's
agents into the local sidebar with nothing installed on the remote.
