### PR TITLE
feat: sync remote split ratios into mirrored panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,6 @@ independently, exactly like multiple ssh hosts.
 - **Latency** above raw ssh: keystroke echo is a rendered frame round-trip, so
   there's a small constant delay. For latency-critical work, plain `ssh <host>`
   is always one command away.
-- **Layout geometry is copied, not linked**: pane content and typing are
-  always live — only sizes are a snapshot. Remote pane adds/removes reconcile,
-  but a split-ratio change at the remote doesn't resize an existing mirror.
 - **No git status on mirror rows** — herdr derives the sidebar git branch and
   ahead/behind from the local workspace cwd, and there's no API to feed it a
   remote repo's state, so mirror workspaces show no git chip. The remote's real

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -82,6 +82,10 @@ const BROADCAST_SUBS: &[&str] = &[
     "pane.created",
     "pane.closed",
     "pane.exited",
+    // a bare remote resize (no pane created/closed) has no other event to
+    // hang a converge off of; falls into the generic converge_at branch below
+    // like any subscription this daemon doesn't special-case.
+    "layout.updated",
 ];
 
 fn sub_list(pane_ids: &[String]) -> Vec<Value> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -410,6 +410,10 @@ async fn local_events_task(
             json!({ "type": "workspace.created" }),
             json!({ "type": "workspace.closed" }),
             json!({ "type": "pane.closed" }),
+            // resizing a mirror pane locally is an edit the remote should
+            // follow on a host we drive; the poke below is what gets it there
+            // promptly instead of on the next unrelated event
+            json!({ "type": "layout.updated" }),
         ];
         match local.subscribe(subs).await {
             Ok(mut stream) => {

--- a/src/layout_sync.rs
+++ b/src/layout_sync.rs
@@ -1,0 +1,704 @@
+// Pure layout reconciliation between a remote tab's split tree and its mirror.
+//
+// Split geometry is the one part of a mirror that can't be copied verbatim: the
+// local tree is built by replaying splits, and herdr's only in-place primitives
+// are `pane.split` (splits a LEAF, new pane always lands second),
+// `pane.swap` (exchanges two panes, shape and ratios untouched) and
+// `layout.set_split_ratio`. `pane.move` can't help: a move whose destination is
+// the pane's own tab returns unchanged (`PaneMoveReason::SameTab`), so a tab's
+// tree can never be re-parented after the fact. Everything here is therefore
+// built around getting the shape right AT PLACEMENT TIME and keeping it right.
+//
+// All of it is pure: `plan_placements` says where to split, `plan_sync` says
+// what to swap and which ratios to correct on which side. mirror.rs does the
+// I/O. That split is deliberate — the interesting cases (nesting, inverted
+// order, both sides resized at once) are exactly the ones that are miserable to
+// exercise against a live remote.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::mirror::LayoutNode;
+
+/// Ratio drift below this is ignored: both sides derive ratios from independent
+/// cell-grid math, and herdr stores them as f32 (a remote resize reports
+/// 0.45000002), so sub-percent wobble is not a real desync.
+pub const RATIO_EPSILON: f64 = 0.01;
+
+pub fn ratios_equal(a: f64, b: f64) -> bool {
+    (a - b).abs() <= RATIO_EPSILON
+}
+
+/// Where to mirror one not-yet-mirrored remote pane.
+///
+/// `target` is a REMOTE pane id whose mirror already exists; the caller maps it
+/// through its own pane table. `ratio` is the remote split's ratio verbatim,
+/// which is correct in both orders: the local split is created as
+/// `first = target, second = new`, and when the remote has them the other way
+/// round `swap` exchanges the two panes afterwards, which preserves the split's
+/// ratio and so lands the same geometry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Placement {
+    pub pane: String,
+    pub target: String,
+    pub direction: String,
+    pub ratio: f64,
+    pub swap: bool,
+}
+
+fn leaf_id(node: &LayoutNode) -> Option<&str> {
+    match node {
+        LayoutNode::Pane { pane_id, .. } => pane_id.as_deref().filter(|p| !p.is_empty()),
+        LayoutNode::Split { .. } => None,
+    }
+}
+
+pub fn pane_ids(node: &LayoutNode, out: &mut Vec<String>) {
+    match node {
+        LayoutNode::Pane { pane_id, .. } => {
+            if let Some(p) = pane_id.as_deref().filter(|p| !p.is_empty()) {
+                out.push(p.to_string());
+            }
+        }
+        LayoutNode::Split { first, second, .. } => {
+            pane_ids(first, out);
+            pane_ids(second, out);
+        }
+    }
+}
+
+/// The chain of splits from the root down to `pane`, each paired with which
+/// child the descent took (`true` = second).
+fn path_to<'a>(node: &'a LayoutNode, pane: &str, acc: &mut Vec<(&'a LayoutNode, bool)>) -> bool {
+    match node {
+        LayoutNode::Pane { .. } => leaf_id(node) == Some(pane),
+        LayoutNode::Split { first, second, .. } => {
+            acc.push((node, false));
+            if path_to(first, pane, acc) {
+                return true;
+            }
+            acc.pop();
+            acc.push((node, true));
+            if path_to(second, pane, acc) {
+                return true;
+            }
+            acc.pop();
+            false
+        }
+    }
+}
+
+fn mirrored_in(node: &LayoutNode, mirrored: &BTreeSet<String>) -> Vec<String> {
+    let mut all = Vec::new();
+    pane_ids(node, &mut all);
+    all.into_iter().filter(|p| mirrored.contains(p)).collect()
+}
+
+/// Where one pane attaches to the mirror as it stands.
+///
+/// The local tree is the remote tree with unmirrored panes pruned, so placing
+/// `pane` means finding the split where its branch leaves the already-mirrored
+/// part: the DEEPEST ancestor whose other side holds a mirrored pane. Splits
+/// below that one describe panes that don't exist locally yet, and splits above
+/// it separate `pane` from the wrong neighbour.
+/// Returns the placement and the attach split's depth (0 = root), which orders
+/// the reconstruction: a tree has to be rebuilt outside-in, and a pane placed
+/// out of turn can strand a shallower one against a subtree it can no longer
+/// split.
+fn attach_point(
+    remote: &LayoutNode,
+    pane: &str,
+    mirrored: &BTreeSet<String>,
+) -> Option<Result<(Placement, usize), ()>> {
+    let mut chain = Vec::new();
+    if !path_to(remote, pane, &mut chain) {
+        return None;
+    }
+    for (depth, (split, went_second)) in chain.iter().enumerate().rev() {
+        let LayoutNode::Split { direction, ratio, first, second } = split else { continue };
+        let other = if *went_second { first } else { second };
+        let neighbours = mirrored_in(other, mirrored);
+        match neighbours.len() {
+            0 => continue, // that whole side is unmirrored: keep climbing
+            1 => {
+                return Some(Ok((
+                    Placement {
+                        pane: pane.to_string(),
+                        target: neighbours[0].clone(),
+                        direction: direction.to_string(),
+                        ratio: *ratio,
+                        swap: !*went_second,
+                    },
+                    depth,
+                )))
+            }
+            // the neighbouring side is a multi-pane subtree, and pane.split
+            // splits a leaf: nothing can wrap a subtree in a new split
+            _ => return Some(Err(())),
+        }
+    }
+    Some(Err(()))
+}
+
+/// Ordered placements for every pane in `remote` that isn't mirrored yet, plus
+/// the ones that can't be placed faithfully.
+///
+/// A placement is only emitted when the new pane's remote sibling is a single
+/// pane that is already mirrored, because `pane.split` splits a leaf: there is
+/// no primitive that wraps a whole subtree in a new split. That is not as
+/// limiting as it sounds, since the remote grew the same way — herdr's own
+/// split replaces a leaf with `Split { leaf, new }` — so a pane's sibling is a
+/// lone leaf at the moment it is created. Panes are emitted in dependency
+/// order, which is what makes a burst of several new remote panes (a converge
+/// that fell behind, or a whole tab of them) reproduce exactly instead of
+/// flattening: each split lands against a sibling the previous step just made.
+///
+/// Anything left over (a remote `pane.move`/`swap` reshaped the tree, so a new
+/// pane's sibling is a multi-pane subtree) comes back in the second return
+/// value for the caller to place by its own fallback and log, rather than being
+/// silently mis-shaped.
+pub fn plan_placements(
+    remote: &LayoutNode,
+    mirrored: &BTreeSet<String>,
+) -> (Vec<Placement>, Vec<String>) {
+    let mut all = Vec::new();
+    pane_ids(remote, &mut all);
+    let mut pending: Vec<String> = all.into_iter().filter(|p| !mirrored.contains(p)).collect();
+    let mut placed: BTreeSet<String> = mirrored.clone();
+    let mut out = Vec::new();
+
+    // Fixpoint, shallowest attach point first: placing one pane can unblock the
+    // next (a pane whose only neighbour was itself new), and going outside-in is
+    // what keeps a burst from stranding a pane whose neighbouring side has
+    // meanwhile grown into a subtree.
+    loop {
+        let next = pending
+            .iter()
+            .enumerate()
+            .filter_map(|(i, pane)| match attach_point(remote, pane, &placed) {
+                Some(Ok((_, depth))) => Some((depth, i)),
+                _ => None,
+            })
+            .min();
+        let Some((_, i)) = next else { break };
+        let pane = pending.remove(i);
+        let Some(Ok((placement, _))) = attach_point(remote, &pane, &placed) else { continue };
+        out.push(placement);
+        placed.insert(pane);
+    }
+    (out, pending)
+}
+
+/// Which side a ratio correction is applied to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RatioFix {
+    pub path: Vec<bool>,
+    pub ratio: f64,
+    pub apply_to: Side,
+}
+
+#[derive(Debug, Default, PartialEq)]
+pub struct SyncPlan {
+    /// pairs of LOCAL pane ids to `pane.swap`, in order
+    pub swaps: Vec<(String, String)>,
+    pub ratios: Vec<RatioFix>,
+    /// path key -> the ratio both sides agree on after this plan is applied.
+    /// Persisted by the caller and fed back in as `base`, which is what makes
+    /// the sync two-way: without a base you can see that the sides differ but
+    /// not which one moved.
+    pub base: BTreeMap<String, f64>,
+    /// the trees disagree in shape, so nothing below the divergence is
+    /// comparable. Placement, not ratio sync, is what fixes this.
+    pub structural_mismatch: bool,
+}
+
+/// Stable key for a split path. `""` is the root; `F`/`T` descend into the
+/// first/second child, matching `layout.set_split_ratio`'s bool array.
+pub fn path_key(path: &[bool]) -> String {
+    path.iter().map(|b| if *b { 'T' } else { 'F' }).collect()
+}
+
+/// Reconcile one tab's geometry.
+///
+/// Ratios are a three-way merge against `base` (the last value both sides
+/// agreed on), so an edit propagates in whichever direction it was actually
+/// made: resize on the remote and the mirror follows, resize the mirror and the
+/// remote follows. Comparing the two sides alone can only say "these differ",
+/// which is why the naive version has to pick a permanent winner and revert the
+/// other side's resize. When both moved since `base`, `local_wins` breaks the
+/// tie: true for a host this daemon drives (the remote is headless, the local
+/// window is the only one anybody looks at), false for a watch-only host whose
+/// own layout is authoritative.
+///
+/// Pane identity is checked too, not just shape: a remote `pane.swap` leaves
+/// both trees the same shape with the panes exchanged, which a shape-only walk
+/// would happily "fix" by resizing, moving the wrong pane. Those come back as
+/// `swaps` (local pane ids) and must be applied before the ratios.
+pub fn plan_sync(
+    remote: &LayoutNode,
+    local: &LayoutNode,
+    map: &BTreeMap<String, String>,
+    base: &BTreeMap<String, f64>,
+    local_wins: bool,
+) -> SyncPlan {
+    let mut plan = SyncPlan::default();
+    // (pane sitting here, pane that should sit here), in traversal order
+    let mut seats: Vec<(String, String)> = Vec::new();
+    walk(remote, local, &mut Vec::new(), map, base, local_wins, &mut plan, &mut seats);
+    if !plan.structural_mismatch {
+        plan.swaps = plan_swaps(seats);
+    }
+    plan
+}
+
+#[allow(clippy::too_many_arguments)] // one walk, all of it needed per level
+fn walk(
+    remote: &LayoutNode,
+    local: &LayoutNode,
+    path: &mut Vec<bool>,
+    map: &BTreeMap<String, String>,
+    base: &BTreeMap<String, f64>,
+    local_wins: bool,
+    plan: &mut SyncPlan,
+    seats: &mut Vec<(String, String)>,
+) {
+    match (remote, local) {
+        (
+            LayoutNode::Split {
+                direction: rdir,
+                ratio: rratio,
+                first: rfirst,
+                second: rsecond,
+            },
+            LayoutNode::Split {
+                direction: ldir,
+                ratio: lratio,
+                first: lfirst,
+                second: lsecond,
+            },
+        ) => {
+            if rdir != ldir {
+                // same shape, different axis: a ratio here would resize the
+                // wrong dimension
+                plan.structural_mismatch = true;
+                return;
+            }
+            let key = path_key(path);
+            let agreed = decide(*rratio, *lratio, base.get(&key).copied(), local_wins);
+            if let Some(side) = agreed.apply {
+                plan.ratios.push(RatioFix { path: path.clone(), ratio: agreed.ratio, apply_to: side });
+            }
+            plan.base.insert(key, agreed.ratio);
+
+            path.push(false);
+            walk(rfirst, lfirst, path, map, base, local_wins, plan, seats);
+            path.pop();
+            path.push(true);
+            walk(rsecond, lsecond, path, map, base, local_wins, plan, seats);
+            path.pop();
+        }
+        (LayoutNode::Pane { .. }, LayoutNode::Pane { .. }) => {
+            let (Some(rid), Some(lid)) = (leaf_id(remote), leaf_id(local)) else {
+                plan.structural_mismatch = true;
+                return;
+            };
+            // a remote pane with no mirror yet: shape isn't converged, so
+            // ratios below here mean nothing
+            let Some(want) = map.get(rid) else {
+                plan.structural_mismatch = true;
+                return;
+            };
+            seats.push((lid.to_string(), want.clone()));
+        }
+        _ => plan.structural_mismatch = true,
+    }
+}
+
+struct Decision {
+    ratio: f64,
+    apply: Option<Side>,
+}
+
+/// Three-way merge of one split's ratio.
+fn decide(remote: f64, local: f64, base: Option<f64>, local_wins: bool) -> Decision {
+    if ratios_equal(remote, local) {
+        return Decision { ratio: remote, apply: None };
+    }
+    let Some(base) = base else {
+        // never synced: adopt the remote's geometry, which is the mirror's
+        // starting point in either mode
+        return Decision { ratio: remote, apply: Some(Side::Local) };
+    };
+    let local_moved = !ratios_equal(local, base);
+    let remote_moved = !ratios_equal(remote, base);
+    match (remote_moved, local_moved) {
+        (true, false) => Decision { ratio: remote, apply: Some(Side::Local) },
+        (false, true) => Decision { ratio: local, apply: Some(Side::Remote) },
+        // both moved since the last agreement, or neither did while the sides
+        // still differ (a write we never saw land): the configured owner wins
+        _ if local_wins => Decision { ratio: local, apply: Some(Side::Remote) },
+        _ => Decision { ratio: remote, apply: Some(Side::Local) },
+    }
+}
+
+/// Turn "pane X sits where pane Y should" into `pane.swap` pairs.
+///
+/// Decomposing the permutation this way costs at most n-1 swaps and, unlike
+/// emitting one swap per wrong seat, never undoes its own work.
+fn plan_swaps(seats: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut have: Vec<String> = seats.iter().map(|s| s.0.clone()).collect();
+    let want: Vec<String> = seats.iter().map(|s| s.1.clone()).collect();
+    let mut out = Vec::new();
+    for i in 0..have.len() {
+        if have[i] == want[i] {
+            continue;
+        }
+        // the wanted pane may be absent entirely (mid-converge); leave the seat
+        // alone rather than inventing a swap
+        if let Some(j) = (i + 1..have.len()).find(|&j| have[j] == want[i]) {
+            out.push((have[i].clone(), have[j].clone()));
+            have.swap(i, j);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leaf(id: &str) -> LayoutNode {
+        LayoutNode::Pane { pane_id: Some(id.into()), label: None }
+    }
+
+    fn split(direction: &str, ratio: f64, first: LayoutNode, second: LayoutNode) -> LayoutNode {
+        LayoutNode::Split {
+            direction: direction.into(),
+            ratio,
+            first: Box::new(first),
+            second: Box::new(second),
+        }
+    }
+
+    fn mirrored(ids: &[&str]) -> BTreeSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs.iter().map(|(r, l)| (r.to_string(), l.to_string())).collect()
+    }
+
+    fn base(pairs: &[(&str, f64)]) -> BTreeMap<String, f64> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    /// The ordinary case: split a remote pane, mirror splits its sibling with
+    /// the same direction and ratio, new pane second on both sides.
+    #[test]
+    fn places_a_new_pane_against_its_mirrored_sibling() {
+        let remote = split("right", 0.3, leaf("p1"), leaf("p2"));
+        let (places, stuck) = plan_placements(&remote, &mirrored(&["p1"]));
+        assert!(stuck.is_empty());
+        assert_eq!(
+            places,
+            vec![Placement {
+                pane: "p2".into(),
+                target: "p1".into(),
+                direction: "right".into(),
+                ratio: 0.3,
+                swap: false,
+            }]
+        );
+    }
+
+    /// The remote has the new pane as the split's FIRST child (it was created
+    /// before its sibling, or a remote swap reordered them). `pane.split`
+    /// always puts the new pane second, so the placement asks for a swap
+    /// afterwards; the ratio still travels verbatim because `pane.swap` leaves
+    /// the split's ratio where it is.
+    #[test]
+    fn inverted_order_asks_for_a_swap_not_an_inverted_ratio() {
+        let remote = split("down", 0.35, leaf("new"), leaf("old"));
+        let (places, stuck) = plan_placements(&remote, &mirrored(&["old"]));
+        assert!(stuck.is_empty());
+        assert_eq!(
+            places,
+            vec![Placement {
+                pane: "new".into(),
+                target: "old".into(),
+                direction: "down".into(),
+                ratio: 0.35,
+                swap: true,
+            }]
+        );
+    }
+
+    /// Several new panes at once (a converge that fell behind) must be ordered
+    /// so each split lands against a sibling that already exists, which is what
+    /// reproduces nesting instead of flattening every pane onto one target.
+    #[test]
+    fn orders_a_burst_so_nesting_is_reproduced() {
+        // p1 | (p2 / p3), with only p1 mirrored: p2 must be placed before p3,
+        // and p3 against p2 — not against p1
+        let remote = split("right", 0.5, leaf("p1"), split("down", 0.4, leaf("p2"), leaf("p3")));
+        let (places, stuck) = plan_placements(&remote, &mirrored(&["p1"]));
+        assert!(stuck.is_empty());
+        assert_eq!(places.len(), 2);
+        assert_eq!((places[0].pane.as_str(), places[0].target.as_str()), ("p2", "p1"));
+        assert_eq!(places[0].ratio, 0.5);
+        assert_eq!((places[1].pane.as_str(), places[1].target.as_str()), ("p3", "p2"));
+        assert_eq!(places[1].direction, "down");
+        assert_eq!(places[1].ratio, 0.4);
+    }
+
+    /// Four panes, one mirrored: the reconstruction has to go outside-in. Taking
+    /// panes in tree order instead places p2 beside p1 first, which turns the
+    /// root's other side into a two-pane subtree and strands p3 for good.
+    #[test]
+    fn rebuilds_a_deep_tree_outside_in() {
+        let remote = split(
+            "down",
+            0.5,
+            split("right", 0.3, leaf("p1"), leaf("p2")),
+            split("right", 0.6, leaf("p3"), leaf("p4")),
+        );
+        let (places, stuck) = plan_placements(&remote, &mirrored(&["p1"]));
+        assert!(stuck.is_empty(), "stranded {stuck:?}");
+        let steps: Vec<(&str, &str, &str, f64, bool)> = places
+            .iter()
+            .map(|p| (p.pane.as_str(), p.target.as_str(), p.direction.as_str(), p.ratio, p.swap))
+            .collect();
+        assert_eq!(
+            steps,
+            vec![
+                // p3 branches off at the root, so it goes first
+                ("p3", "p1", "down", 0.5, false),
+                ("p2", "p1", "right", 0.3, false),
+                ("p4", "p3", "right", 0.6, false),
+            ]
+        );
+    }
+
+    /// A new pane whose remote sibling is a multi-pane SUBTREE can't be
+    /// reproduced: splitting a leaf can't wrap a subtree. Report it instead of
+    /// applying an outer split's ratio to a brand-new inner split.
+    #[test]
+    fn reports_panes_it_cannot_place_faithfully() {
+        // (p1|p2) | p3 with p1,p2 mirrored: p3's sibling is the (p1|p2) subtree
+        let remote = split("right", 0.6, split("down", 0.5, leaf("p1"), leaf("p2")), leaf("p3"));
+        let (places, stuck) = plan_placements(&remote, &mirrored(&["p1", "p2"]));
+        assert!(places.is_empty());
+        assert_eq!(stuck, vec!["p3".to_string()]);
+    }
+
+    #[test]
+    fn nothing_to_place_when_every_pane_is_mirrored() {
+        let remote = split("right", 0.5, leaf("p1"), leaf("p2"));
+        let (places, stuck) = plan_placements(&remote, &mirrored(&["p1", "p2"]));
+        assert!(places.is_empty() && stuck.is_empty());
+    }
+
+    /// First sync of a tab: no base yet, so the mirror adopts the remote's
+    /// geometry regardless of which side owns the layout.
+    #[test]
+    fn first_sync_adopts_the_remote_ratio() {
+        let remote = split("right", 0.3, leaf("p1"), leaf("p2"));
+        let local = split("right", 0.5, leaf("l1"), leaf("l2"));
+        let m = map(&[("p1", "l1"), ("p2", "l2")]);
+        for local_wins in [false, true] {
+            let plan = plan_sync(&remote, &local, &m, &BTreeMap::new(), local_wins);
+            assert_eq!(
+                plan.ratios,
+                vec![RatioFix { path: vec![], ratio: 0.3, apply_to: Side::Local }]
+            );
+            assert_eq!(plan.base.get(""), Some(&0.3));
+            assert!(plan.swaps.is_empty() && !plan.structural_mismatch);
+        }
+    }
+
+    /// The remote was resized since the last agreement: the mirror follows,
+    /// even on a host where local edits win ties.
+    #[test]
+    fn remote_resize_flows_to_the_mirror() {
+        let remote = split("right", 0.3, leaf("p1"), leaf("p2"));
+        let local = split("right", 0.5, leaf("l1"), leaf("l2"));
+        let plan = plan_sync(
+            &remote,
+            &local,
+            &map(&[("p1", "l1"), ("p2", "l2")]),
+            &base(&[("", 0.5)]),
+            true,
+        );
+        assert_eq!(plan.ratios, vec![RatioFix { path: vec![], ratio: 0.3, apply_to: Side::Local }]);
+    }
+
+    /// The mirror was resized since the last agreement: the REMOTE follows.
+    /// This is the direction the one-way version can't express — it reverts the
+    /// local resize on the next pass instead.
+    #[test]
+    fn local_resize_flows_to_the_remote() {
+        let remote = split("right", 0.5, leaf("p1"), leaf("p2"));
+        let local = split("right", 0.7, leaf("l1"), leaf("l2"));
+        let plan = plan_sync(
+            &remote,
+            &local,
+            &map(&[("p1", "l1"), ("p2", "l2")]),
+            &base(&[("", 0.5)]),
+            false, // even a watch-only host: nobody else moved it
+        );
+        assert_eq!(plan.ratios, vec![RatioFix { path: vec![], ratio: 0.7, apply_to: Side::Remote }]);
+        assert_eq!(plan.base.get(""), Some(&0.7));
+    }
+
+    /// Both sides moved since the last agreement. Unresolvable on the evidence,
+    /// so the configured owner wins: the local window for a driven headless
+    /// remote, the remote for a machine with its own display.
+    #[test]
+    fn simultaneous_resizes_go_to_the_configured_owner() {
+        let remote = split("right", 0.4, leaf("p1"), leaf("p2"));
+        let local = split("right", 0.7, leaf("l1"), leaf("l2"));
+        let m = map(&[("p1", "l1"), ("p2", "l2")]);
+        let b = base(&[("", 0.5)]);
+
+        let drive = plan_sync(&remote, &local, &m, &b, true);
+        assert_eq!(drive.ratios, vec![RatioFix { path: vec![], ratio: 0.7, apply_to: Side::Remote }]);
+
+        let watch = plan_sync(&remote, &local, &m, &b, false);
+        assert_eq!(watch.ratios, vec![RatioFix { path: vec![], ratio: 0.4, apply_to: Side::Local }]);
+    }
+
+    /// In sync: no writes, and the agreement is recorded so the next pass can
+    /// still tell which side moved.
+    #[test]
+    fn agreement_records_a_base_without_writing() {
+        let remote = split("right", 0.3, leaf("p1"), split("down", 0.25, leaf("p2"), leaf("p3")));
+        let local = split("right", 0.3, leaf("l1"), split("down", 0.25, leaf("l2"), leaf("l3")));
+        let plan = plan_sync(
+            &remote,
+            &local,
+            &map(&[("p1", "l1"), ("p2", "l2"), ("p3", "l3")]),
+            &BTreeMap::new(),
+            false,
+        );
+        assert!(plan.ratios.is_empty() && plan.swaps.is_empty());
+        assert_eq!(plan.base.get(""), Some(&0.3));
+        assert_eq!(plan.base.get("T"), Some(&0.25));
+    }
+
+    /// Sub-percent wobble is not a desync: herdr stores ratios as f32, so a
+    /// remote resize reports values like 0.45000002.
+    #[test]
+    fn sub_epsilon_wobble_is_not_a_correction() {
+        let remote = split("right", 0.45000002, leaf("p1"), leaf("p2"));
+        let local = split("right", 0.45, leaf("l1"), leaf("l2"));
+        let plan =
+            plan_sync(&remote, &local, &map(&[("p1", "l1"), ("p2", "l2")]), &BTreeMap::new(), false);
+        assert!(plan.ratios.is_empty());
+    }
+
+    /// Nested splits at depth, addressed by the bool path
+    /// `layout.set_split_ratio` expects.
+    #[test]
+    fn corrects_nested_splits_by_path() {
+        let remote = split(
+            "right",
+            0.5,
+            leaf("p1"),
+            split("down", 0.7, leaf("p2"), split("right", 0.2, leaf("p3"), leaf("p4"))),
+        );
+        let local = split(
+            "right",
+            0.5,
+            leaf("l1"),
+            split("down", 0.4, leaf("l2"), split("right", 0.2, leaf("l3"), leaf("l4"))),
+        );
+        let plan = plan_sync(
+            &remote,
+            &local,
+            &map(&[("p1", "l1"), ("p2", "l2"), ("p3", "l3"), ("p4", "l4")]),
+            &BTreeMap::new(),
+            false,
+        );
+        assert_eq!(
+            plan.ratios,
+            vec![RatioFix { path: vec![true], ratio: 0.7, apply_to: Side::Local }]
+        );
+        assert_eq!(plan.base.get("TT"), Some(&0.2));
+    }
+
+    /// A remote swap leaves both trees the same shape with the panes
+    /// exchanged. Resizing would move the wrong pane, so this must come back
+    /// as a swap.
+    #[test]
+    fn exchanged_panes_come_back_as_swaps() {
+        let remote = split("right", 0.5, leaf("p2"), leaf("p1"));
+        let local = split("right", 0.5, leaf("l1"), leaf("l2"));
+        let plan =
+            plan_sync(&remote, &local, &map(&[("p1", "l1"), ("p2", "l2")]), &BTreeMap::new(), false);
+        assert_eq!(plan.swaps, vec![("l1".to_string(), "l2".to_string())]);
+        assert!(plan.ratios.is_empty() && !plan.structural_mismatch);
+    }
+
+    /// Three panes rotated: one swap per displaced pair, never more than n-1,
+    /// and no swap that undoes an earlier one.
+    #[test]
+    fn rotated_panes_decompose_into_minimal_swaps() {
+        let remote = split("right", 0.5, leaf("p2"), split("down", 0.5, leaf("p3"), leaf("p1")));
+        let local = split("right", 0.5, leaf("l1"), split("down", 0.5, leaf("l2"), leaf("l3")));
+        let plan = plan_sync(
+            &remote,
+            &local,
+            &map(&[("p1", "l1"), ("p2", "l2"), ("p3", "l3")]),
+            &BTreeMap::new(),
+            false,
+        );
+        assert_eq!(
+            plan.swaps,
+            vec![("l1".to_string(), "l2".to_string()), ("l1".to_string(), "l3".to_string())]
+        );
+    }
+
+    /// Shapes disagree: stop. Placement fixes this, and a ratio applied across
+    /// a divergence resizes something unrelated.
+    #[test]
+    fn structural_mismatch_blocks_everything() {
+        let remote = split("right", 0.3, leaf("p1"), split("down", 0.5, leaf("p2"), leaf("p3")));
+        let local = split("right", 0.5, leaf("l1"), leaf("l2"));
+        let plan = plan_sync(
+            &remote,
+            &local,
+            &map(&[("p1", "l1"), ("p2", "l2"), ("p3", "l3")]),
+            &BTreeMap::new(),
+            false,
+        );
+        assert!(plan.structural_mismatch);
+        assert!(plan.swaps.is_empty());
+    }
+
+    /// Same shape, different axis: a ratio here would resize the wrong
+    /// dimension, so it counts as a structural mismatch.
+    #[test]
+    fn direction_mismatch_is_structural() {
+        let remote = split("right", 0.3, leaf("p1"), leaf("p2"));
+        let local = split("down", 0.5, leaf("l1"), leaf("l2"));
+        let plan =
+            plan_sync(&remote, &local, &map(&[("p1", "l1"), ("p2", "l2")]), &BTreeMap::new(), false);
+        assert!(plan.structural_mismatch);
+        assert!(plan.ratios.is_empty());
+    }
+
+    /// A remote pane with no mirror yet means the shape isn't converged, so
+    /// ratios are not yet meaningful.
+    #[test]
+    fn unmirrored_pane_is_structural() {
+        let remote = split("right", 0.3, leaf("p1"), leaf("p2"));
+        let local = split("right", 0.5, leaf("l1"), leaf("l2"));
+        let plan = plan_sync(&remote, &local, &map(&[("p1", "l1")]), &BTreeMap::new(), false);
+        assert!(plan.structural_mismatch);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod daemon;
 mod docker;
 mod foreground;
 mod grid;
+mod layout_sync;
 mod mirror;
 mod pane;
 mod predict;

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -145,59 +145,26 @@ pub enum LayoutNode {
 }
 
 /// Locate `pane_id` in a split tree: the parent split's direction (already
-/// "right"/"down", pane.split's vocabulary) and ratio, plus the sibling
-/// subtree's pane ids ordered nearest-to-the-split-point first. This is
-/// exact — the tree records how the panes were actually split, so no
-/// geometry heuristics.
-pub fn locate_in_layout(node: &LayoutNode, pane_id: &str) -> Option<(String, f64, Vec<String>)> {
-    let LayoutNode::Split { direction, ratio, first, second } = node else { return None };
+/// "right"/"down", pane.split's vocabulary) plus the sibling subtree's pane ids
+/// ordered nearest-to-the-split-point first. Fallback for a pane
+/// `layout_sync::plan_placements` can't place faithfully; the shape-preserving
+/// path lives there.
+pub fn locate_in_layout(node: &LayoutNode, pane_id: &str) -> Option<(String, Vec<String>)> {
+    let LayoutNode::Split { direction, first, second, .. } = node else { return None };
     let is_the_pane =
         |n: &LayoutNode| matches!(n, LayoutNode::Pane { pane_id: Some(p), .. } if p == pane_id);
     if is_the_pane(first) {
         let mut sibs = Vec::new();
         walk_pane_ids(second, &mut sibs);
-        return Some((direction.clone(), *ratio, sibs));
+        return Some((direction.clone(), sibs));
     }
     if is_the_pane(second) {
         let mut sibs = Vec::new();
         walk_pane_ids(first, &mut sibs);
         sibs.reverse();
-        return Some((direction.clone(), *ratio, sibs));
+        return Some((direction.clone(), sibs));
     }
     locate_in_layout(first, pane_id).or_else(|| locate_in_layout(second, pane_id))
-}
-
-/// Ratio drift below this is ignored — both sides derive ratios from
-/// independent cell-grid math, so sub-percent wobble isn't a real desync.
-const RATIO_EPSILON: f64 = 0.01;
-
-/// Walk the remote and local split trees together and collect every split
-/// path whose remote ratio has drifted from the local one. Stops descending
-/// wherever the two trees' shapes disagree at that point — a structural
-/// mismatch (a pane the topology sync hasn't placed yet, mid-converge) is a
-/// different problem, not something a ratio correction should paper over.
-fn ratio_corrections(remote: &LayoutNode, local: &LayoutNode) -> Vec<(Vec<bool>, f64)> {
-    fn walk(remote: &LayoutNode, local: &LayoutNode, path: &mut Vec<bool>, out: &mut Vec<(Vec<bool>, f64)>) {
-        let (
-            LayoutNode::Split { ratio: rratio, first: rfirst, second: rsecond, .. },
-            LayoutNode::Split { ratio: lratio, first: lfirst, second: lsecond, .. },
-        ) = (remote, local)
-        else {
-            return;
-        };
-        if (rratio - lratio).abs() > RATIO_EPSILON {
-            out.push((path.clone(), *rratio));
-        }
-        path.push(false);
-        walk(rfirst, lfirst, path, out);
-        path.pop();
-        path.push(true);
-        walk(rsecond, lsecond, path, out);
-        path.pop();
-    }
-    let mut out = Vec::new();
-    walk(remote, local, &mut Vec::new(), &mut out);
-    out
 }
 
 fn walk_pane_ids(node: &LayoutNode, out: &mut Vec<String>) {
@@ -379,6 +346,145 @@ pub(crate) fn cmd_for_pane(
 /// single-quote for a POSIX shell command line
 fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Reconcile one mirrored tab's geometry: exchange panes into the arrangement
+/// the remote has, then merge every split ratio three ways so a resize
+/// propagates in whichever direction it was actually made.
+///
+/// `always_control` decides ties. It already means "this daemon drives the
+/// remote's pane sizes" (the remote is headless, the local window is the only
+/// one anyone looks at), so the local side wins there; a watch-only host has its
+/// own display and its layout is authoritative.
+async fn reconcile_tab_geometry(
+    deps: &ConvergeDeps,
+    state: &mut HostState,
+    remote_tab: &str,
+    local_tab: &str,
+    remote_panes: &[&PaneInfo],
+) {
+    #[derive(Deserialize)]
+    struct Exported {
+        layout: ExportedLayout,
+    }
+    #[derive(Deserialize)]
+    struct ExportedLayout {
+        root: LayoutNode,
+    }
+    let remote_layout =
+        deps.remote.request_t::<Exported>("layout.export", json!({ "tab_id": remote_tab })).await;
+    let local_layout =
+        deps.local.request_t::<Exported>("layout.export", json!({ "tab_id": local_tab })).await;
+    let (Ok(remote), Ok(local)) = (remote_layout, local_layout) else { return };
+
+    let map: BTreeMap<String, String> = remote_panes
+        .iter()
+        .filter_map(|p| {
+            state
+                .panes
+                .get(&p.pane_id)
+                .filter(|e| !e.is_tombstoned())
+                .map(|e| (p.pane_id.clone(), e.local_id.clone()))
+        })
+        .collect();
+    let prefix = format!("{remote_tab}|");
+    let base: BTreeMap<String, f64> = state
+        .ratios
+        .iter()
+        .filter_map(|(k, v)| k.strip_prefix(&prefix).map(|path| (path.to_string(), *v)))
+        .collect();
+    let plan = crate::layout_sync::plan_sync(
+        &remote.layout.root,
+        &local.layout.root,
+        &map,
+        &base,
+        deps.host.always_control,
+    );
+
+    if plan.structural_mismatch {
+        // Shapes disagree, so ratios aren't comparable. Forget the agreement so
+        // that whenever the shapes line up again the remote's geometry is
+        // adopted cleanly, and say so once — the base is empty on later passes,
+        // so this logs on the pass where it diverges, not on every one after.
+        if !base.is_empty() {
+            log_geometry_drift(&deps.log, remote_tab);
+        }
+        state.ratios.retain(|k, _| !k.starts_with(&prefix));
+        return;
+    }
+
+    // swaps first: a ratio describes a position, so it only means the right
+    // thing once the right pane is sitting in it
+    for (source, target) in &plan.swaps {
+        if let Err(e) = deps
+            .local
+            .request("pane.swap", json!({ "source_pane_id": source, "target_pane_id": target }))
+            .await
+        {
+            deps.log.log(&format!("{remote_tab}: pane swap failed ({e}) — retrying next pass"));
+            return;
+        }
+    }
+
+    let mut failed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for fix in &plan.ratios {
+        let (api, tab) = match fix.apply_to {
+            crate::layout_sync::Side::Local => (&deps.local, local_tab),
+            crate::layout_sync::Side::Remote => (&deps.remote, remote_tab),
+        };
+        let params = json!({ "tab_id": tab, "path": fix.path, "ratio": fix.ratio });
+        if let Err(e) = api.request("layout.set_split_ratio", params).await {
+            deps.log.log(&format!("{remote_tab}: split ratio sync failed: {e}"));
+            failed.insert(crate::layout_sync::path_key(&fix.path));
+        }
+    }
+    // Only remember what actually landed. Recording an agreement we failed to
+    // write would make the next pass read the difference as an edit on the
+    // other side and push it the wrong way.
+    for (path, ratio) in plan.base {
+        if failed.contains(&path) {
+            continue;
+        }
+        state.ratios.insert(format!("{prefix}{path}"), ratio);
+    }
+}
+
+fn log_geometry_drift(log: &Logger, remote_tab: &str) {
+    log.log(&format!(
+        "{remote_tab}: mirror no longer matches the remote's split shape — sizes won't track until it does"
+    ));
+}
+
+/// Split `target` and return the new local pane id. `ratio` is the remote
+/// split's own ratio when the placement is faithful, and None when we're
+/// falling back, so herdr's default stands rather than a ratio describing a
+/// different split.
+async fn split_mirror_pane(
+    local: &ApiClient,
+    target: &str,
+    direction: &str,
+    ratio: Option<f64>,
+    cwd: &str,
+) -> Result<String> {
+    #[derive(Deserialize)]
+    struct Split {
+        pane: SplitPane,
+    }
+    #[derive(Deserialize)]
+    struct SplitPane {
+        pane_id: String,
+    }
+    let mut params = json!({
+        "target_pane_id": target,
+        "direction": direction,
+        "cwd": cwd,
+        "focus": false,
+    });
+    if let Some(r) = ratio {
+        params["ratio"] = json!(r);
+    }
+    let split: Split = local.request_t("pane.split", params).await?;
+    Ok(split.pane.pane_id)
 }
 
 /// Exec the streamer into an already-created plain pane. Not `agent.start` (or a
@@ -799,53 +905,91 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                 // non-git cwd so herdr shows no (misleading) sidebar git status
                 // for the mirror; the pane exec's the streamer regardless
                 let cwd = mirror_pane_cwd(&deps.state_dir).display().to_string();
-                for rp in &remote_panes_in_tab {
+                // Place new panes where the REMOTE tree says they live, in
+                // dependency order, so a burst of several (a converge that fell
+                // behind, or a whole nested tab) reproduces the remote's shape
+                // instead of flattening every new pane onto one target. Each
+                // split carries the remote split's ratio; `swap` covers the
+                // case where the remote has the new pane as the FIRST child,
+                // which pane.split can't do directly.
+                let mirrored: std::collections::BTreeSet<String> = state
+                    .panes
+                    .iter()
+                    .filter(|(_, e)| !e.is_tombstoned())
+                    .map(|(rid, _)| rid.clone())
+                    .collect();
+                let (placements, unplaceable) =
+                    crate::layout_sync::plan_placements(&exported.layout.root, &mirrored);
+                let in_this_tab = |rid: &String| remote_panes_in_tab.iter().any(|p| &p.pane_id == rid);
+                for place in placements.iter().filter(|p| in_this_tab(&p.pane)) {
+                    if state.panes.contains_key(&place.pane) {
+                        continue;
+                    }
+                    let Some(target) = state.panes.get(&place.target).map(|e| e.local_id.clone())
+                    else {
+                        continue;
+                    };
+                    let local_id = split_mirror_pane(
+                        &deps.local,
+                        &target,
+                        &place.direction,
+                        Some(place.ratio),
+                        &cwd,
+                    )
+                    .await?;
+                    // the remote has this pane on the split's first side, and
+                    // pane.split always lands the new one second. Swapping puts
+                    // it where the remote has it; the split's ratio rides along
+                    // untouched, so the geometry matches exactly.
+                    if place.swap {
+                        let _ = deps
+                            .local
+                            .request(
+                                "pane.swap",
+                                json!({ "source_pane_id": local_id, "target_pane_id": target }),
+                            )
+                            .await;
+                    }
+                    spawn_streamer_pane(&deps.local, &local_id, &cmd_for(&place.pane), &deps.log)
+                        .await;
+                    state.panes.insert(
+                        place.pane.clone(),
+                        PaneEntry { local_id, tombstone: None, seq: 0, reported: None },
+                    );
+                }
+                // A pane whose remote sibling is a multi-pane subtree can't be
+                // reproduced: pane.split splits a leaf, and nothing wraps a
+                // subtree in a new split. Place it by the old heuristic so the
+                // mirror is never missing a pane, and say so — the tab's ratio
+                // sync will report a structural mismatch from here on.
+                for rp in remote_panes_in_tab.iter().filter(|p| unplaceable.contains(&p.pane_id)) {
                     if state.panes.contains_key(&rp.pane_id) {
                         continue;
                     }
-                    // place the mirror where the REMOTE layout says the pane
-                    // lives: split its nearest already-mirrored layout sibling
-                    // in the tree's recorded direction and ratio. Falls back
-                    // to the old first-pane/right/default-ratio when the
-                    // layout doesn't resolve.
-                    let placed = locate_in_layout(&exported.layout.root, &rp.pane_id).and_then(
-                        |(dir, ratio, sibs)| {
+                    let fallback = locate_in_layout(&exported.layout.root, &rp.pane_id)
+                        .and_then(|(dir, sibs)| {
                             sibs.iter()
                                 .find_map(|rid| state.panes.get(rid).map(|e| e.local_id.clone()))
-                                .map(|t| (t, dir, Some(ratio)))
-                        },
-                    );
-                    let Some((target, direction, ratio)) = placed.or_else(|| {
-                        remote_panes_in_tab
-                            .iter()
-                            .find_map(|p| state.panes.get(&p.pane_id).map(|e| e.local_id.clone()))
-                            .map(|t| (t, "right".to_string(), None))
-                    }) else {
-                        continue;
-                    };
-                    #[derive(Deserialize)]
-                    struct Split {
-                        pane: SplitPane,
-                    }
-                    #[derive(Deserialize)]
-                    struct SplitPane {
-                        pane_id: String,
-                    }
-                    let mut split_params = json!({
-                        "target_pane_id": target,
-                        "direction": direction,
-                        "cwd": cwd,
-                        "focus": false,
-                    });
-                    if let Some(r) = ratio {
-                        split_params["ratio"] = json!(r);
-                    }
-                    let split: Split =
-                        deps.local.request_t("pane.split", split_params).await?;
-                    spawn_streamer_pane(&deps.local, &split.pane.pane_id, &cmd_for(&rp.pane_id), &deps.log).await;
+                                .map(|t| (t, dir))
+                        })
+                        .or_else(|| {
+                            remote_panes_in_tab
+                                .iter()
+                                .find_map(|p| state.panes.get(&p.pane_id).map(|e| e.local_id.clone()))
+                                .map(|t| (t, "right".to_string()))
+                        });
+                    let Some((target, direction)) = fallback else { continue };
+                    log.log(&format!(
+                        "{}: remote pane {} sits beside a subtree — mirroring it beside {target} instead; split sizes for this tab won't track",
+                        rtab.tab_id, rp.pane_id
+                    ));
+                    let local_id =
+                        split_mirror_pane(&deps.local, &target, &direction, None, &cwd).await?;
+                    spawn_streamer_pane(&deps.local, &local_id, &cmd_for(&rp.pane_id), &deps.log)
+                        .await;
                     state.panes.insert(
                         rp.pane_id.clone(),
-                        PaneEntry { local_id: split.pane.pane_id, tombstone: None, seq: 0, reported: None },
+                        PaneEntry { local_id, tombstone: None, seq: 0, reported: None },
                     );
                 }
             }
@@ -861,35 +1005,25 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                     .await;
             }
 
-            // topology sync above only sets a ratio for a split it JUST
-            // created; a remote resize of an already-mirrored split has no
-            // topology change to hang off of, so it needs its own check every
-            // pass (cheap: one export each side) or it silently drifts out of
-            // sync forever. `layout.updated` is in daemon.rs's broadcast
-            // subscriptions, so a bare remote resize (no create/close) still
-            // reaches this via the normal debounced converge.
-            #[derive(Deserialize)]
-            struct Exported {
-                layout: ExportedLayout,
-            }
-            #[derive(Deserialize)]
-            struct ExportedLayout {
-                root: LayoutNode,
-            }
-            let remote_layout =
-                deps.remote.request_t::<Exported>("layout.export", json!({ "tab_id": rtab.tab_id })).await;
-            let local_layout =
-                deps.local.request_t::<Exported>("layout.export", json!({ "tab_id": tab_local })).await;
-            if let (Ok(r), Ok(l)) = (remote_layout, local_layout) {
-                for (path, ratio) in ratio_corrections(&r.layout.root, &l.layout.root) {
-                    let params = json!({ "tab_id": tab_local, "path": path, "ratio": ratio });
-                    if let Err(e) = deps.local.request("layout.set_split_ratio", params).await {
-                        log.log(&format!("split ratio sync failed for {}: {e}", rtab.tab_id));
-                    }
-                }
+            // Placement above only sets a ratio for a split it JUST created. A
+            // resize of an existing split has no topology change to hang off
+            // of, so it needs its own check: `layout.updated` is subscribed on
+            // both sides (see daemon.rs), and each converge diffs the two
+            // exports and moves whichever side didn't change.
+            //
+            // A tab with fewer than two panes has no split to reconcile, which
+            // is most tabs, so it costs nothing there.
+            if remote_panes_in_tab.len() > 1 {
+                reconcile_tab_geometry(deps, state, &rtab.tab_id, tab_local, &remote_panes_in_tab)
+                    .await;
             }
         }
     }
+
+    // remembered ratio agreements for tabs that are gone would otherwise
+    // accumulate in the state file forever
+    let live_tabs: HashSet<String> = state.tabs.keys().cloned().collect();
+    state.ratios.retain(|k, _| k.split('|').next().is_some_and(|t| live_tabs.contains(t)));
 
     // 5. push authoritative agent status onto mirror panes
     push_statuses(deps, &remote_snap, state).await;
@@ -1214,59 +1348,25 @@ mod tests {
         LayoutNode::Split { direction: direction.into(), ratio, first: Box::new(first), second: Box::new(second) }
     }
 
-    /// `locate_in_layout` must report the split's ratio (used to replicate a
-    /// new remote pane's placement with `pane.split --ratio`), not just its
-    /// direction — the ratio-blind version was the reported gap: a remote
-    /// split at 0.3 mirrored locally at the server's 0.5 default.
+    /// The fallback path, used only for a pane `layout_sync::plan_placements`
+    /// won't place (its remote sibling is a whole subtree, which `pane.split`
+    /// can't wrap). Ratio deliberately not reported: the shape-preserving
+    /// placements carry it, and here it would describe a different split.
     #[test]
-    fn locate_in_layout_reports_direction_and_ratio() {
+    fn locate_in_layout_reports_direction_and_siblings() {
         let tree = split("right", 0.3, leaf("p1"), leaf("p2"));
-        let (dir, ratio, sibs) = locate_in_layout(&tree, "p2").unwrap();
+        let (dir, sibs) = locate_in_layout(&tree, "p2").unwrap();
         assert_eq!(dir, "right");
-        assert_eq!(ratio, 0.3);
         assert_eq!(sibs, vec!["p1".to_string()]);
 
-        // nested: p3 is under a "down" split with its own ratio, inside the
-        // "right" split's second branch
+        // nested: p3 is under a "down" split inside the "right" split's second
+        // branch, so the nearest sibling is p2, not p1
         let tree = split("right", 0.3, leaf("p1"), split("down", 0.4, leaf("p2"), leaf("p3")));
-        let (dir, ratio, sibs) = locate_in_layout(&tree, "p3").unwrap();
+        let (dir, sibs) = locate_in_layout(&tree, "p3").unwrap();
         assert_eq!(dir, "down");
-        assert_eq!(ratio, 0.4);
         assert_eq!(sibs, vec!["p2".to_string()]);
 
         assert!(locate_in_layout(&tree, "nope").is_none());
-    }
-
-    /// Only a split whose ratio actually drifted (beyond RATIO_EPSILON) is
-    /// reported, at the path `layout.set_split_ratio` expects (verified
-    /// against a live server: `false` = descend into `first`, `true` =
-    /// `second`, `path: []` = the root split). Descent stops the moment the
-    /// two trees' shapes disagree instead of guessing.
-    #[test]
-    fn ratio_corrections_finds_drifted_splits_by_path() {
-        // root split: remote resized 0.5 -> 0.3, no other change
-        let remote = split("right", 0.3, leaf("p1"), leaf("p2"));
-        let local = split("right", 0.5, leaf("p1"), leaf("p2"));
-        assert_eq!(ratio_corrections(&remote, &local), vec![(vec![], 0.3)]);
-
-        // in sync: no corrections
-        let local_synced = split("right", 0.3, leaf("p1"), leaf("p2"));
-        assert!(ratio_corrections(&remote, &local_synced).is_empty());
-
-        // sub-epsilon wobble is not a correction
-        let local_close = split("right", 0.301, leaf("p1"), leaf("p2"));
-        assert!(ratio_corrections(&remote, &local_close).is_empty());
-
-        // nested split drifted, root split in sync
-        let remote = split("right", 0.5, leaf("p1"), split("down", 0.7, leaf("p2"), leaf("p3")));
-        let local = split("right", 0.5, leaf("p1"), split("down", 0.4, leaf("p2"), leaf("p3")));
-        assert_eq!(ratio_corrections(&remote, &local), vec![(vec![true], 0.7)]);
-
-        // structural mismatch (local hasn't mirrored the nested split yet) —
-        // stop at the divergence, don't force a path that doesn't exist locally
-        let remote = split("right", 0.5, leaf("p1"), split("down", 0.7, leaf("p2"), leaf("p3")));
-        let local = split("right", 0.5, leaf("p1"), leaf("p2"));
-        assert!(ratio_corrections(&remote, &local).is_empty());
     }
 
     /// Characterization test: the ssh pane argv is a cross-process contract.

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -145,25 +145,59 @@ pub enum LayoutNode {
 }
 
 /// Locate `pane_id` in a split tree: the parent split's direction (already
-/// "right"/"down", pane.split's vocabulary) plus the sibling subtree's pane
-/// ids ordered nearest-to-the-split-point first. This is exact — the tree
-/// records how the panes were actually split, so no geometry heuristics.
-pub fn locate_in_layout(node: &LayoutNode, pane_id: &str) -> Option<(String, Vec<String>)> {
-    let LayoutNode::Split { direction, first, second, .. } = node else { return None };
+/// "right"/"down", pane.split's vocabulary) and ratio, plus the sibling
+/// subtree's pane ids ordered nearest-to-the-split-point first. This is
+/// exact — the tree records how the panes were actually split, so no
+/// geometry heuristics.
+pub fn locate_in_layout(node: &LayoutNode, pane_id: &str) -> Option<(String, f64, Vec<String>)> {
+    let LayoutNode::Split { direction, ratio, first, second } = node else { return None };
     let is_the_pane =
         |n: &LayoutNode| matches!(n, LayoutNode::Pane { pane_id: Some(p), .. } if p == pane_id);
     if is_the_pane(first) {
         let mut sibs = Vec::new();
         walk_pane_ids(second, &mut sibs);
-        return Some((direction.clone(), sibs));
+        return Some((direction.clone(), *ratio, sibs));
     }
     if is_the_pane(second) {
         let mut sibs = Vec::new();
         walk_pane_ids(first, &mut sibs);
         sibs.reverse();
-        return Some((direction.clone(), sibs));
+        return Some((direction.clone(), *ratio, sibs));
     }
     locate_in_layout(first, pane_id).or_else(|| locate_in_layout(second, pane_id))
+}
+
+/// Ratio drift below this is ignored — both sides derive ratios from
+/// independent cell-grid math, so sub-percent wobble isn't a real desync.
+const RATIO_EPSILON: f64 = 0.01;
+
+/// Walk the remote and local split trees together and collect every split
+/// path whose remote ratio has drifted from the local one. Stops descending
+/// wherever the two trees' shapes disagree at that point — a structural
+/// mismatch (a pane the topology sync hasn't placed yet, mid-converge) is a
+/// different problem, not something a ratio correction should paper over.
+fn ratio_corrections(remote: &LayoutNode, local: &LayoutNode) -> Vec<(Vec<bool>, f64)> {
+    fn walk(remote: &LayoutNode, local: &LayoutNode, path: &mut Vec<bool>, out: &mut Vec<(Vec<bool>, f64)>) {
+        let (
+            LayoutNode::Split { ratio: rratio, first: rfirst, second: rsecond, .. },
+            LayoutNode::Split { ratio: lratio, first: lfirst, second: lsecond, .. },
+        ) = (remote, local)
+        else {
+            return;
+        };
+        if (rratio - lratio).abs() > RATIO_EPSILON {
+            out.push((path.clone(), *rratio));
+        }
+        path.push(false);
+        walk(rfirst, lfirst, path, out);
+        path.pop();
+        path.push(true);
+        walk(rsecond, lsecond, path, out);
+        path.pop();
+    }
+    let mut out = Vec::new();
+    walk(remote, local, &mut Vec::new(), &mut out);
+    out
 }
 
 fn walk_pane_ids(node: &LayoutNode, out: &mut Vec<String>) {
@@ -771,20 +805,21 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                     }
                     // place the mirror where the REMOTE layout says the pane
                     // lives: split its nearest already-mirrored layout sibling
-                    // in the tree's recorded direction. Falls back to the old
-                    // first-pane/right when the layout doesn't resolve.
+                    // in the tree's recorded direction and ratio. Falls back
+                    // to the old first-pane/right/default-ratio when the
+                    // layout doesn't resolve.
                     let placed = locate_in_layout(&exported.layout.root, &rp.pane_id).and_then(
-                        |(dir, sibs)| {
+                        |(dir, ratio, sibs)| {
                             sibs.iter()
                                 .find_map(|rid| state.panes.get(rid).map(|e| e.local_id.clone()))
-                                .map(|t| (t, dir))
+                                .map(|t| (t, dir, Some(ratio)))
                         },
                     );
-                    let Some((target, direction)) = placed.or_else(|| {
+                    let Some((target, direction, ratio)) = placed.or_else(|| {
                         remote_panes_in_tab
                             .iter()
                             .find_map(|p| state.panes.get(&p.pane_id).map(|e| e.local_id.clone()))
-                            .map(|t| (t, "right".to_string()))
+                            .map(|t| (t, "right".to_string(), None))
                     }) else {
                         continue;
                     };
@@ -796,18 +831,17 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                     struct SplitPane {
                         pane_id: String,
                     }
-                    let split: Split = deps
-                        .local
-                        .request_t(
-                            "pane.split",
-                            json!({
-                                "target_pane_id": target,
-                                "direction": direction,
-                                "cwd": cwd,
-                                "focus": false,
-                            }),
-                        )
-                        .await?;
+                    let mut split_params = json!({
+                        "target_pane_id": target,
+                        "direction": direction,
+                        "cwd": cwd,
+                        "focus": false,
+                    });
+                    if let Some(r) = ratio {
+                        split_params["ratio"] = json!(r);
+                    }
+                    let split: Split =
+                        deps.local.request_t("pane.split", split_params).await?;
                     spawn_streamer_pane(&deps.local, &split.pane.pane_id, &cmd_for(&rp.pane_id), &deps.log).await;
                     state.panes.insert(
                         rp.pane_id.clone(),
@@ -825,6 +859,34 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                     .local
                     .request("tab.rename", json!({ "tab_id": tab_local, "label": rtab.label }))
                     .await;
+            }
+
+            // topology sync above only sets a ratio for a split it JUST
+            // created; a remote resize of an already-mirrored split has no
+            // topology change to hang off of, so it needs its own check every
+            // pass (cheap: one export each side) or it silently drifts out of
+            // sync forever. `layout.updated` is in daemon.rs's broadcast
+            // subscriptions, so a bare remote resize (no create/close) still
+            // reaches this via the normal debounced converge.
+            #[derive(Deserialize)]
+            struct Exported {
+                layout: ExportedLayout,
+            }
+            #[derive(Deserialize)]
+            struct ExportedLayout {
+                root: LayoutNode,
+            }
+            let remote_layout =
+                deps.remote.request_t::<Exported>("layout.export", json!({ "tab_id": rtab.tab_id })).await;
+            let local_layout =
+                deps.local.request_t::<Exported>("layout.export", json!({ "tab_id": tab_local })).await;
+            if let (Ok(r), Ok(l)) = (remote_layout, local_layout) {
+                for (path, ratio) in ratio_corrections(&r.layout.root, &l.layout.root) {
+                    let params = json!({ "tab_id": tab_local, "path": path, "ratio": ratio });
+                    if let Err(e) = deps.local.request("layout.set_split_ratio", params).await {
+                        log.log(&format!("split ratio sync failed for {}: {e}", rtab.tab_id));
+                    }
+                }
             }
         }
     }
@@ -1142,6 +1204,69 @@ mod tests {
             remote_bin: "~/.local/bin/herdr".into(),
             always_control: true,
         }
+    }
+
+    fn leaf(pane_id: &str) -> LayoutNode {
+        LayoutNode::Pane { pane_id: Some(pane_id.into()), label: None }
+    }
+
+    fn split(direction: &str, ratio: f64, first: LayoutNode, second: LayoutNode) -> LayoutNode {
+        LayoutNode::Split { direction: direction.into(), ratio, first: Box::new(first), second: Box::new(second) }
+    }
+
+    /// `locate_in_layout` must report the split's ratio (used to replicate a
+    /// new remote pane's placement with `pane.split --ratio`), not just its
+    /// direction — the ratio-blind version was the reported gap: a remote
+    /// split at 0.3 mirrored locally at the server's 0.5 default.
+    #[test]
+    fn locate_in_layout_reports_direction_and_ratio() {
+        let tree = split("right", 0.3, leaf("p1"), leaf("p2"));
+        let (dir, ratio, sibs) = locate_in_layout(&tree, "p2").unwrap();
+        assert_eq!(dir, "right");
+        assert_eq!(ratio, 0.3);
+        assert_eq!(sibs, vec!["p1".to_string()]);
+
+        // nested: p3 is under a "down" split with its own ratio, inside the
+        // "right" split's second branch
+        let tree = split("right", 0.3, leaf("p1"), split("down", 0.4, leaf("p2"), leaf("p3")));
+        let (dir, ratio, sibs) = locate_in_layout(&tree, "p3").unwrap();
+        assert_eq!(dir, "down");
+        assert_eq!(ratio, 0.4);
+        assert_eq!(sibs, vec!["p2".to_string()]);
+
+        assert!(locate_in_layout(&tree, "nope").is_none());
+    }
+
+    /// Only a split whose ratio actually drifted (beyond RATIO_EPSILON) is
+    /// reported, at the path `layout.set_split_ratio` expects (verified
+    /// against a live server: `false` = descend into `first`, `true` =
+    /// `second`, `path: []` = the root split). Descent stops the moment the
+    /// two trees' shapes disagree instead of guessing.
+    #[test]
+    fn ratio_corrections_finds_drifted_splits_by_path() {
+        // root split: remote resized 0.5 -> 0.3, no other change
+        let remote = split("right", 0.3, leaf("p1"), leaf("p2"));
+        let local = split("right", 0.5, leaf("p1"), leaf("p2"));
+        assert_eq!(ratio_corrections(&remote, &local), vec![(vec![], 0.3)]);
+
+        // in sync: no corrections
+        let local_synced = split("right", 0.3, leaf("p1"), leaf("p2"));
+        assert!(ratio_corrections(&remote, &local_synced).is_empty());
+
+        // sub-epsilon wobble is not a correction
+        let local_close = split("right", 0.301, leaf("p1"), leaf("p2"));
+        assert!(ratio_corrections(&remote, &local_close).is_empty());
+
+        // nested split drifted, root split in sync
+        let remote = split("right", 0.5, leaf("p1"), split("down", 0.7, leaf("p2"), leaf("p3")));
+        let local = split("right", 0.5, leaf("p1"), split("down", 0.4, leaf("p2"), leaf("p3")));
+        assert_eq!(ratio_corrections(&remote, &local), vec![(vec![true], 0.7)]);
+
+        // structural mismatch (local hasn't mirrored the nested split yet) —
+        // stop at the divergence, don't force a path that doesn't exist locally
+        let remote = split("right", 0.5, leaf("p1"), split("down", 0.7, leaf("p2"), leaf("p3")));
+        let local = split("right", 0.5, leaf("p1"), leaf("p2"));
+        assert!(ratio_corrections(&remote, &local).is_empty());
     }
 
     /// Characterization test: the ssh pane argv is a cross-process contract.

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,6 +75,13 @@ pub struct HostState {
     /// so a remote that reconnects mid-restore doesn't mass-close mirrors.
     #[serde(default)]
     pub prev_remote_ids: std::collections::BTreeSet<String>,
+    /// last split ratio both sides agreed on, keyed `<remote tab id>|<path>`
+    /// (see layout_sync::path_key). This is the base of the three-way merge
+    /// that makes ratio sync two-way: without it a converge can see that the
+    /// two sides differ but not which one was resized, so it has to pick a
+    /// permanent winner and revert the other side's drag.
+    #[serde(default)]
+    pub ratios: BTreeMap<String, f64>,
 }
 
 pub fn state_path(state_dir: &Path, host: &str) -> PathBuf {


### PR DESCRIPTION
## Problem

Mirrored splits always render at ratio 0.5, whichever ratio the remote uses.

Topology already reconciles — split a remote pane and the mirror grows a matching pane — but
the ratio never does, so a deliberately lopsided remote layout arrives as an even split, and
a later remote resize changes nothing locally. The README lists this under Limitations
("only sizes are a snapshot ... a split-ratio change at the remote doesn't resize an existing
mirror"); this makes both the initial ratio and later resizes follow.

## Fix

- `locate_in_layout` also returns the split ratio, which is passed to `pane.split --ratio`
  when the mirror pane is placed.
- New pure `ratio_corrections()` walks the remote and local `LayoutNode` trees in parallel and
  collects split paths whose ratio drifted (epsilon tolerance, stops at any structural
  mismatch rather than trying to force a fix).
- `converge_inner` exports both layouts for each mirrored tab, diffs them, and applies
  `layout.set_split_ratio`.
- `layout.updated` is added to the daemon's broadcast subscriptions so a pure resize — no
  topology change — also lands in the existing debounce-converge path.

## Verification

Against a live remote (scratch tab, since removed):

```
remote: pane split --ratio 0.3           → remote ratio 0.3          local mirror ratio 0.3
remote: pane resize --amount 0.15        → remote ratio 0.45000002   local mirror ratio 0.45000002
```

Before the change the local side read 0.5 in both cases.

`cargo test`: 69 passed. New tests `locate_in_layout_reports_direction_and_ratio` and
`ratio_corrections_finds_drifted_splits_by_path` (epsilon tolerance, nested splits, and no
correction on structural mismatch).

## Note

`layout.set_split_ratio`'s `path` is a boolean array — `false` descends into the first child,
`true` into the second, `[]` is the root. That isn't documented anywhere I could find; it was
determined empirically against a local session. If that convention ever changes, this would
fail silently, since nothing validates it.
