### PR TITLE
fix: don't let a full-width row erase its own last column

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -244,6 +244,15 @@ impl Renderer {
             let is_status_row = r == out_rows - 1 && !self.status_text.is_empty();
             let painted = if is_status_row {
                 format!("\x1b[0;7m {} \x1b[0m\x1b[K", self.status_text)
+            } else if limit >= out_cols {
+                // A row painted to the full width leaves the cursor IN the last
+                // column with the terminal's deferred-wrap flag set — it has not
+                // moved to the next line yet. EL erases from the cursor, so it
+                // would wipe the cell just written, costing one character on
+                // every full-width row (i.e. every wrapped line). Nothing needs
+                // clearing anyway: the loop paints all `limit` columns, blank
+                // cells included.
+                format!("{line}\x1b[0m")
             } else {
                 format!("{line}\x1b[0m\x1b[K")
             };
@@ -360,6 +369,33 @@ mod tests {
         let mut r = Renderer::new();
         let out = r.paint(&g, 10, 1);
         assert!(!out.contains('b'), "stale spacer cell survived: {out:?}");
+    }
+
+    #[test]
+    fn a_full_width_row_is_not_erased_by_its_own_el() {
+        // EL after filling the last column erases the cell just written: the
+        // cursor is still IN that column with the deferred-wrap flag set, so
+        // "erase to end of line" starts there. Cost was one character on every
+        // row long enough to wrap — a wrapped line lost the char at the break.
+        let mut g = Grid::new();
+        g.resize(5, 1);
+        g.apply("\x1b[1;1Habcde");
+        let mut r = Renderer::new();
+        let out = r.paint(&g, 5, 1);
+        assert!(out.contains("abcde"), "got: {out:?}");
+        assert!(!out.contains("abcde\x1b[0m\x1b[K"), "EL would erase the 'e': {out:?}");
+    }
+
+    #[test]
+    fn a_short_row_still_clears_its_tail() {
+        // the other half: when the remote is narrower than the local pane the
+        // gutter must still be cleared, or stale content survives to the right
+        let mut g = Grid::new();
+        g.resize(3, 1);
+        g.apply("\x1b[1;1Hab");
+        let mut r = Renderer::new();
+        let out = r.paint(&g, 10, 1);
+        assert!(out.contains("\x1b[K"), "narrow grid must still emit EL: {out:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem


Mirror panes drop one character from every line long enough to wrap. Reading across the break the character at the join is simply gone:

<img width="743" height="115" alt="line-wrap-missing-char" src="https://github.com/user-attachments/assets/77041b60-337d-41d7-9278-27e05b6752f2" />


That is `deepseek-v4-flash` with the `a` missing. Same issue, further down the same session `config.yaml` lost its `f`. It reproduces on any wrapped line, in program output and in shell echo alike.

It is not a sizing problem — the remote pty and the local pane agree. Comparing what each side renders for the same two panes:

| pane | remote `pane read` | local `pane read` |
|---|---|---|
| `wK:p1` → `wP:p2` | 75 cols | 74 cols |
| `wK:p3` → `wP:p4` | 74 cols | 73 cols |

Exactly one column short, in both, with the local ptys measuring 75 and 74 respectively.

## Cause

`Renderer::paint` ends every row with EL (`\x1b[K`):

```rust
let painted = if is_status_row {
    format!("\x1b[0;7m {} \x1b[0m\x1b[K", self.status_text)
} else {
    format!("{line}\x1b[0m\x1b[K")
};
```

When the row fills the pane, writing the last column does not move the cursor to the next line — it stays *in* that column with the terminal's deferred-wrap flag set. EL erases from the cursor position, so it wipes the cell just written.

Isolated against herdr's own emulator, in a 152-column pane — same full-width line, the only difference being the trailing EL:

| row | trailing `\x1b[K` | characters surviving |
|---|---|---|
| 5 | yes | 151 |
| 10 | no | 152 |

A wrapped line is by definition a row painted to the full width, which is why the loss tracks wrapping so precisely.

## Fix

Skip EL when the row was painted to the full output width:

```rust
} else if limit >= out_cols {
    format!("{line}\x1b[0m")
} else {
    format!("{line}\x1b[0m\x1b[K")
};
```

Nothing needs clearing in that case — the paint loop always emits all `limit` columns, blank cells included, so the row is fully overwritten. When the remote grid is narrower than the local pane (`limit < out_cols`) the EL still runs and still clears the gutter, so the shrinking-remote case is unchanged.

## Test plan

- `a_full_width_row_is_not_erased_by_its_own_el` — a 5×1 grid painted into 5 columns must not emit `abcde\x1b[0m\x1b[K`
- `a_short_row_still_clears_its_tail` — a 3-wide grid painted into 10 columns must still emit EL, pinning the other direction so the fix cannot regress into leaving stale content to the right
- `cargo test` — 108 passed (106 before)
- `cargo clippy --all-targets` — clean
- Ran it against a live mirror (Linux/WSL2 local ↔ Linux VPS over ssh, herdr 0.8.0 both ends, v0.1.16 plugin): wrapped lines keep the character at the break.

## Notes

The patch was drafted with Claude Code.
