### PR TITLE
feat: remote-invoke — forward any plugin action to the mirrored host

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ action instead of erroring, so one binding can replace the native key entirely.
 Exception: on a non-mirrored pane inside a mirror workspace, `remote-split-*`
 errors rather than splitting locally, which would desync the mirrored layout.
 
+**Invoke any remote plugin** — keys you bind locally are consumed by the local
+herdr before a mirror pane ever sees them, so a plugin installed on the remote
+can't be driven by typing its bindings into a mirror. `remote-invoke
+<plugin>.<action>` bridges that: inside a mirror it runs the action on the
+mirrored host via `plugin.action.invoke`, handing it the *remote* workspace,
+pane, and cwd behind your focused mirror pane; outside a mirror it invokes the
+same action on the local herdr, so one key covers both worlds here too. The
+plugin must be installed on whichever end the action runs, and the remote
+herdr must be new enough to have `plugin.action.invoke`. Layout changes the
+action makes mirror back like any other remote change (UI it opens — popups,
+notifications — renders on the remote's session, not yours).
+
 **Continuous streaming** — every mirror pane streams its remote pane live for
 its whole lifetime, each over its own connection, so panes are never
 blank and a busy pane can't contend with or drop another's stream. Sidebar
@@ -160,6 +172,20 @@ Outside a mirror, `remote-new-workspace` targets `default_host` and the others
 act locally. The remaining actions — `mirror.status`, `mirror.once`,
 `mirror.ensure` — are lifecycle/diagnostic and are usually run from the CLI
 rather than bound.
+
+`remote-invoke` takes the action to forward as an argument, which plugin
+actions can't carry — bind it as a `shell` command instead (the `HERDR_ACTIVE_*`
+variables herdr hands shell bindings give it the same invocation context).
+Put the `herdr-mirror` binary somewhere stable on PATH, e.g.
+`ln -s ~/.config/herdr/plugins/github/mirror-*/target/release/herdr-mirror ~/.local/bin/`
+(or your checkout's `target/release` for a linked dev install):
+
+```toml
+[[keys.command]]
+key = "prefix+alt+e"
+type = "shell"
+command = "herdr-mirror remote-invoke lilexe.some-action"
+```
 
 **If you live in mirrors, drop the alt variants.** Since these fall back to the
 native behaviour anyway, hand them the native keys and keep one set of muscle

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 //   herdr-mirror pane <host> <target>   # data plane: one per mirror pane
 //   herdr-mirror start|pause|ensure|status|once|restore|teardown
 //   herdr-mirror remote-workspace|remote-tab|remote-split <right|down>
+//   herdr-mirror remote-invoke <plugin>.<action>
 
 mod api;
 mod closes;
@@ -86,8 +87,14 @@ fn run_on(rt: &tokio::runtime::Runtime, cmd: &str, rest: &[String]) -> Result<()
             "split",
             rest.get(1).map(String::as_str),
         )),
+        "remote-invoke" => {
+            let spec = rest
+                .get(1)
+                .ok_or_else(|| util::err("usage: herdr-mirror remote-invoke <plugin>.<action>"))?;
+            rt.block_on(remote_action::invoke(Env::resolve()?, spec))
+        }
         other => Err(util::err(format!(
-            "unknown command: {other} (daemon|pane|start|pause|ensure|status|once|restore|teardown|remote-workspace|remote-tab|remote-split)"
+            "unknown command: {other} (daemon|pane|start|pause|ensure|status|once|restore|teardown|remote-workspace|remote-tab|remote-split|remote-invoke)"
         ))),
     }
 }

--- a/src/remote_action.rs
+++ b/src/remote_action.rs
@@ -6,6 +6,7 @@
 //   herdr-mirror remote-workspace           # new workspace on the context's host
 //   herdr-mirror remote-tab                 # new tab in the mirrored remote workspace
 //   herdr-mirror remote-split right|down    # split the mirrored remote pane
+//   herdr-mirror remote-invoke <plugin>.<action>  # invoke a plugin action on the remote
 //
 // Resolution: the invocation context's local workspace/tab/pane ids are
 // reverse-looked-up in the per-host id maps. Inside a mirror, that pins both
@@ -24,6 +25,16 @@
 //
 // Anything created inside a mirror is a REMOTE object; the daemon mirrors it
 // back within a couple of seconds. Local mirror objects stay daemon-owned.
+//
+// `remote-invoke` generalizes the trio to plugins the local herdr can't see:
+// keys bound locally never reach a mirror pane's stdin, so a remote plugin's
+// bindings are unreachable by typing. Instead, bind a local key to
+// `remote-invoke <plugin>.<action>` and it calls `plugin.action.invoke` on the
+// mirrored host with the invocation context translated to the REMOTE ids.
+// Outside a mirror it invokes the same action on the local herdr — the same
+// one-key-for-both-worlds degrade as remote-tab/split. The action runs on
+// whichever end is chosen, so the plugin must be installed there; anything it
+// does to the remote layout mirrors back like any other remote change.
 
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -140,6 +151,89 @@ async fn local_split(env: &Env, ctx: &InvocationContext, direction: &str) -> Res
         ctx.focused_pane_id.as_deref().unwrap_or("focused"),
         res.pointer("/pane/pane_id").and_then(|v| v.as_str()).unwrap_or("?")
     );
+    Ok(())
+}
+
+/// Context for the local-invoke fallback: the plugin-action JSON verbatim when
+/// present (full fidelity — cwd, tab, selection all pass through), else the
+/// `HERDR_ACTIVE_*` fields a shell binding gets.
+fn local_context_value(ctx: &InvocationContext) -> Value {
+    if let Some(v) = std::env::var("HERDR_PLUGIN_CONTEXT_JSON")
+        .ok()
+        .and_then(|s| serde_json::from_str::<Value>(&s).ok())
+        .filter(Value::is_object)
+    {
+        return v;
+    }
+    let mut out = json!({});
+    if let Some(ws) = &ctx.workspace_id {
+        out["workspace_id"] = json!(ws);
+    }
+    if let Some(pane) = &ctx.focused_pane_id {
+        out["focused_pane_id"] = json!(pane);
+    }
+    if let Some(cwd) = std::env::var("HERDR_ACTIVE_PANE_CWD").ok().filter(|s| !s.is_empty()) {
+        out["focused_pane_cwd"] = json!(cwd);
+    }
+    out
+}
+
+/// `remote-invoke <plugin>.<action>`: run a plugin action on the mirrored
+/// host, with the invocation context translated to the remote ids. Outside a
+/// mirror the action is invoked on the local herdr instead. A bare action id
+/// (no dot) is passed without a plugin_id for the server to resolve.
+pub async fn invoke(env: Env, spec: &str) -> Result<()> {
+    let (plugin_id, action_id) = match spec.split_once('.') {
+        Some((p, a)) if !p.is_empty() && !a.is_empty() => (Some(p), a),
+        Some(_) => return Err(err(format!("bad action spec {spec:?}: want <plugin>.<action>"))),
+        None => (None, spec),
+    };
+
+    let ctx = invocation_context();
+    // Same deliberate non-`?` as run(): the local fallback needs no host config.
+    let config = load_config(&env.config_search);
+    let resolved = config.as_ref().ok().and_then(|c| resolve_context(&env, &c.hosts, &ctx));
+
+    let Some(resolved) = resolved else {
+        let api = crate::api::ApiClient::connect(&env.local_socket).await?;
+        let mut params = json!({ "action_id": action_id, "context": local_context_value(&ctx) });
+        if let Some(p) = plugin_id {
+            params["plugin_id"] = json!(p);
+        }
+        api.request("plugin.action.invoke", params).await?;
+        println!("invoked {spec} locally");
+        return Ok(());
+    };
+
+    let mut remote = RemoteHost::new(&resolved.host, &env.state_dir);
+    let (api, _status) = remote.connect_api().await?;
+
+    // the remote action sees the REMOTE objects behind the invoking mirror,
+    // including the real cwd of the pane it will act on
+    let mut context = json!({ "invocation_source": "mirror" });
+    if let Some(ws) = &resolved.remote_ws_id {
+        context["workspace_id"] = json!(ws);
+    }
+    if let Some(pane_id) = &resolved.remote_pane_id {
+        context["focused_pane_id"] = json!(pane_id);
+        let snap = fetch_snapshot(&api).await?;
+        if let Some(pane) = snap.panes.iter().find(|p| &p.pane_id == pane_id) {
+            if let Some(cwd) = pane.foreground_cwd.clone().or_else(|| pane.cwd.clone()) {
+                context["focused_pane_cwd"] = json!(cwd);
+            }
+        }
+    }
+    let mut params = json!({ "action_id": action_id, "context": context });
+    if let Some(p) = plugin_id {
+        params["plugin_id"] = json!(p);
+    }
+    api.request("plugin.action.invoke", params).await.map_err(|e| {
+        err(format!(
+            "remote invoke {spec} on {}: {e} (needs the plugin installed there, and a herdr with plugin.action.invoke)",
+            resolved.host.name
+        ))
+    })?;
+    println!("invoked {spec} on {}", resolved.host.name);
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

Keys bound in the local herdr are consumed by its dispatcher before a mirror pane's stdin ever sees them, so a plugin installed on the remote can't be driven by typing its bindings into a mirror — the keystroke dies locally. The `remote-*` actions exist because of exactly this, but they cover only the natives they hand-replicate (`tab.create`, `pane.split`, …). Every remote plugin anyone wants to drive from a mirror would need the same one-off treatment.

## Fix

One generic bridge instead of per-action replication, built on `plugin.action.invoke` (present in current herdr; protocol 17 verified):

```
herdr-mirror remote-invoke <plugin>.<action>
```

Inside a mirror it resolves the host and the remote workspace/pane behind the focused pane through the existing `resolve_context()` reverse-lookup, then calls `plugin.action.invoke` on that host with the invocation context translated to the **remote** ids — including the remote pane's real cwd from its snapshot, since local cwds are meaningless over there. The context also carries `invocation_source: "mirror"` so actions can tell.

Outside a mirror it invokes the same action on the local herdr, passing the local invocation context through verbatim — the same one-key-for-both-worlds degrade as `remote-tab`/`remote-split`. A bare action id without a dot is passed without `plugin_id` for the server to resolve.

No new invariant risk: unlike `remote-split`, an unmirrored focused pane inside a mirror workspace doesn't error — the action still goes remote, just without a `focused_pane_id`, since nothing here can desync layout_sync.

## Binding it

Plugin actions can't carry arguments, so `remote-invoke` binds as a `shell` command; the `HERDR_ACTIVE_*` variables herdr hands shell bindings feed the same context path that plugin actions use (`invocation_context()` already merged the two):

```toml
[[keys.command]]
key = "prefix+alt+e"
type = "shell"
command = "herdr-mirror remote-invoke someplugin.some-action"
```

README documents this, plus the two scope notes: the plugin must be installed on whichever end the action runs, and UI the action opens (popups, notifications) renders on the remote's session — layout changes mirror back like any other remote change.

## Testing

- Local degrade path against a live server: bad spec → usage error; nonexistent plugin → the server's `plugin not found` surfaces verbatim; `remote-invoke mirror.status` invokes end-to-end.
- Remote path against a live ssh mirror driving a plugin installed only on the remote host: action fires on the remote with the right pane context, and its layout changes mirror back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
