### PR TITLE
feat: resolve remote herdr via PATH before ~/.local/bin/herdr

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,11 +11,14 @@ use crate::util::{err, Result};
 ///
 /// A configured path is used as-is (unquoted so remote-shell `~` expands).
 /// When unset, the remote shell resolves `herdr` via PATH, falling back to
-/// `~/.local/bin/herdr` if `command -v` finds nothing.
+/// `~/.local/bin/herdr` if `command -v` finds nothing. The auto form is
+/// double-quoted so a path with spaces (PATH entry or `$HOME`) stays one word.
 pub fn remote_bin_expr(remote_bin: Option<&str>) -> String {
     match remote_bin {
         Some(b) if !b.is_empty() => b.to_string(),
-        _ => "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)".into(),
+        // Quotes around the substitution prevent word-splitting if the resolved
+        // path contains spaces; ~ still expands inside the unquoted `echo` arg.
+        _ => "\"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\"".into(),
     }
 }
 
@@ -387,11 +390,11 @@ mod tests {
         assert_eq!(remote_bin_expr(Some("~/.local/bin/herdr")), "~/.local/bin/herdr");
         assert_eq!(
             remote_bin_expr(None),
-            "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)"
+            "\"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
         );
         assert_eq!(
             remote_bin_expr(Some("")),
-            "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)"
+            "\"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,18 @@ use serde::Deserialize;
 
 use crate::util::{err, Result};
 
+/// Shell expression for `exec <expr> ...` on the remote.
+///
+/// A configured path is used as-is (unquoted so remote-shell `~` expands).
+/// When unset, the remote shell resolves `herdr` via PATH, falling back to
+/// `~/.local/bin/herdr` if `command -v` finds nothing.
+pub fn remote_bin_expr(remote_bin: Option<&str>) -> String {
+    match remote_bin {
+        Some(b) if !b.is_empty() => b.to_string(),
+        _ => "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)".into(),
+    }
+}
+
 /// How to reach a host. `Ssh` is the default and the only kind that existed
 /// before container support; every existing hosts.toml parses to it.
 #[derive(Debug, Clone, PartialEq)]
@@ -66,7 +78,9 @@ pub struct HostConfig {
     pub kind: HostKind,
     pub docker_bin: String,
     pub prefix: String,
-    pub remote_bin: String,
+    /// Remote herdr binary. `None` = auto-resolve on the remote: PATH first
+    /// (`command -v herdr`), then `~/.local/bin/herdr`. See `remote_bin_expr`.
+    pub remote_bin: Option<String>,
     /// ssh hosts only; see `ApiTransport`. Default `Auto`.
     pub api_transport: ApiTransport,
     /// keep each mirror pane in control (writable, no idle release, and sized to
@@ -247,7 +261,8 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
         };
         hosts.push(HostConfig {
             prefix: h.prefix.unwrap_or_else(|| name.clone()),
-            remote_bin: h.remote_bin.unwrap_or_else(|| "~/.local/bin/herdr".into()),
+            // empty string is treated as unset (auto PATH → ~/.local/bin/herdr)
+            remote_bin: h.remote_bin.filter(|s| !s.is_empty()),
             always_control: h.always_control.unwrap_or(global_always_control),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
             api_transport,
@@ -299,7 +314,7 @@ mod tests {
         let h = &c.hosts[0];
         assert_eq!(h.name, "work");
         assert_eq!(h.prefix, "work");
-        assert_eq!(h.remote_bin, "~/.local/bin/herdr");
+        assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert!(h.always_control); // default on
     }
 
@@ -331,6 +346,7 @@ mod tests {
         assert_eq!(c.poll_seconds, 30);
         assert_eq!(c.hosts.len(), 1);
         assert_eq!(c.hosts[0].prefix, "v");
+        assert_eq!(c.hosts[0].remote_bin.as_deref(), Some("/opt/herdr"));
         assert_eq!(c.default_host().unwrap().name, "vps");
     }
 
@@ -362,7 +378,21 @@ mod tests {
         let c = parse_config("[hosts.work]\ntarget = \"work\"\n").unwrap();
         assert_eq!(c.hosts[0].kind, HostKind::Ssh);
         assert_eq!(c.hosts[0].target, "work");
-        assert_eq!(c.hosts[0].remote_bin, "~/.local/bin/herdr");
+        assert_eq!(c.hosts[0].remote_bin, None);
+    }
+
+    #[test]
+    fn remote_bin_expr_configured_vs_auto() {
+        assert_eq!(remote_bin_expr(Some("/opt/herdr")), "/opt/herdr");
+        assert_eq!(remote_bin_expr(Some("~/.local/bin/herdr")), "~/.local/bin/herdr");
+        assert_eq!(
+            remote_bin_expr(None),
+            "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)"
+        );
+        assert_eq!(
+            remote_bin_expr(Some("")),
+            "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)"
+        );
     }
 
     #[test]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -180,7 +180,8 @@ impl Container {
     /// never sources `/etc/profile*`. Matching that matters because the output
     /// is parsed as JSON — an image whose profile prints a welcome banner would
     /// otherwise make every connect fail with "expected value at line 1
-    /// column 1". Tilde expansion in `remote_bin` works either way.
+    /// column 1". Tilde expansion and `command -v` in `remote_bin_expr` work
+    /// either way.
     pub async fn exec(&self, command: &str, timeout_ms: u64) -> Result<String> {
         let fut = Command::new(&self.docker_bin)
             .args(["exec", &self.id, "sh", "-c", command])

--- a/src/foreground.rs
+++ b/src/foreground.rs
@@ -46,14 +46,14 @@ pub fn classify(json: &str) -> Option<bool> {
 /// on any failure (ssh/network/parse) so the caller keeps its last known value.
 pub async fn poll(
     ssh_target: &str,
-    remote_bin: &str,
+    remote_bin: Option<&str>,
     pane: &str,
     ctl_path: Option<&str>,
     container: Option<&crate::pane::ContainerArg>,
 ) -> Option<bool> {
-    // remote_bin stays unquoted for remote-shell ~ expansion, matching the
-    // observe session's command construction
-    let cmd = format!("exec {} pane process-info --pane {}", remote_bin, sh_quote(pane));
+    // same expression as the observe session (configured path or PATH auto)
+    let bin = crate::config::remote_bin_expr(remote_bin);
+    let cmd = format!("exec {} pane process-info --pane {}", bin, sh_quote(pane));
     let mut sc = match container {
         Some(ct) => {
             // async resolve, not the blocking one: this runs on the pane's

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -367,9 +367,12 @@ pub(crate) fn cmd_for_pane(
             "pane".into(),
             target.clone(),
             pane_id.to_string(),
-            "--remote-bin".into(),
-            remote_bin.clone(),
         ];
+        // omit --remote-bin when auto (PATH then ~/.local/bin/herdr); pane
+        // defaults to the same resolution so the argv stays short
+        if let Some(bin) = &remote_bin {
+            argv.extend(["--remote-bin".into(), bin.clone()]);
+        }
         if always_control {
             argv.push("--always-control".into());
         }
@@ -1460,7 +1463,7 @@ mod tests {
             kind: crate::config::HostKind::Ssh,
             docker_bin: "docker".into(),
             prefix: "vps".into(),
-            remote_bin: "~/.local/bin/herdr".into(),
+            remote_bin: None,
             always_control: true,
             api_transport: crate::config::ApiTransport::Auto,
         }
@@ -1557,8 +1560,7 @@ mod tests {
                 "pane",
                 "vps",
                 "w1:p1",
-                "--remote-bin",
-                "~/.local/bin/herdr",
+                // no --remote-bin: auto (PATH then ~/.local/bin/herdr)
                 "--always-control",
                 "--ctl-path",
                 "/state/vps.ctl",
@@ -1566,6 +1568,29 @@ mod tests {
         );
         // argv[0] is the resolved exe path, which varies by install
         assert!(argv[0].ends_with("herdr-mirror") || argv[0].contains("herdr_mirror"), "{}", argv[0]);
+    }
+
+    /// When remote_bin is set, it must appear on the argv (cross-process contract
+    /// with the pane parser) rather than being re-resolved by the streamer.
+    #[test]
+    fn ssh_pane_argv_carries_explicit_remote_bin() {
+        let mut host = ssh_host();
+        host.remote_bin = Some("/opt/herdr".into());
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let argv = cmd("w1:p1");
+        assert_eq!(
+            argv[1..],
+            [
+                "pane",
+                "vps",
+                "w1:p1",
+                "--remote-bin",
+                "/opt/herdr",
+                "--always-control",
+                "--ctl-path",
+                "/state/vps.ctl",
+            ]
+        );
     }
 
     /// Docker hosts append their flags *after* the ssh-shaped prefix, so the
@@ -1585,8 +1610,6 @@ mod tests {
                 "pane",
                 "/Users/n/proj",
                 "w1:p1",
-                "--remote-bin",
-                "~/.local/bin/herdr",
                 "--always-control",
                 // no identity token at all: healing asks herdr per pane
                 "--container-folder",
@@ -1629,7 +1652,7 @@ mod tests {
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
-            ["pane", "vps", "w1:p1", "--remote-bin", "~/.local/bin/herdr", "--ctl-path", "/state/vps.ctl"]
+            ["pane", "vps", "w1:p1", "--ctl-path", "/state/vps.ctl"]
         );
     }
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -7,7 +7,7 @@
 //   herdr-mirror pane <ssh-target> <pane-target> [options]
 //
 // options:
-//   --remote-bin PATH   remote herdr binary (default ~/.local/bin/herdr)
+//   --remote-bin PATH   remote herdr binary (default: PATH, then ~/.local/bin/herdr)
 //   --cols N --rows N   observe request size (default 240x72; must be >= the
 //                       remote PTY size or the server clips bottom rows away)
 //   --dump              headless mode: print plain-text screen per frame
@@ -48,7 +48,9 @@ use crate::predict::Predictor;
 pub struct Args {
     pub ssh_target: String,
     pub pane_target: String,
-    pub remote_bin: String,
+    /// Configured remote herdr path. `None` = auto-resolve on the remote
+    /// (PATH, then `~/.local/bin/herdr`). See `config::remote_bin_expr`.
+    pub remote_bin: Option<String>,
     pub cols: usize,
     pub rows: usize,
     pub dump: bool,
@@ -81,7 +83,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
     let mut args = Args {
         ssh_target: String::new(),
         pane_target: String::new(),
-        remote_bin: "~/.local/bin/herdr".into(),
+        remote_bin: None,
         cols: 240,
         rows: 72,
         dump: false,
@@ -102,7 +104,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
             it.next().cloned().ok_or_else(|| err(format!("{flag} needs a value")))
         };
         match a.as_str() {
-            "--remote-bin" => args.remote_bin = next("--remote-bin")?,
+            "--remote-bin" => args.remote_bin = Some(next("--remote-bin")?),
             "--cols" => {
                 args.cols = next("--cols")?.parse().map_err(|_| err("--cols must be a number"))?;
                 args.size_fixed = true;
@@ -203,11 +205,12 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         .as_ref()
         .map(|s| format!(" --session {}", sh_quote(s)))
         .unwrap_or_default();
-    // remote_bin stays unquoted on purpose: the default ~/.local/bin/herdr
-    // relies on remote-shell tilde expansion
+    // Configured paths stay unquoted so remote-shell ~ expands; auto mode is a
+    // command-substitution expression (see config::remote_bin_expr).
+    let bin = crate::config::remote_bin_expr(args.remote_bin.as_deref());
     let cmd = format!(
         "exec {}{} terminal session {} {} --cols {} --rows {}",
-        args.remote_bin,
+        bin,
         session_flag,
         mode.as_str(),
         sh_quote(&args.pane_target),
@@ -555,8 +558,14 @@ impl App {
         let ctl = self.args.ctl_path.clone();
         let container = self.args.container.clone();
         tokio::spawn(async move {
-            let v =
-                crate::foreground::poll(&ssh, &bin, &pane, ctl.as_deref(), container.as_ref()).await;
+            let v = crate::foreground::poll(
+                &ssh,
+                bin.as_deref(),
+                &pane,
+                ctl.as_deref(),
+                container.as_ref(),
+            )
+            .await;
             let _ = tx.send(Msg::Foreground(v)).await;
         });
     }
@@ -1107,7 +1116,7 @@ mod tests {
         let a = parse_args(&argv).unwrap();
         assert_eq!(a.ssh_target, "work");
         assert_eq!(a.pane_target, "w9:p1");
-        assert_eq!(a.remote_bin, "/opt/herdr");
+        assert_eq!(a.remote_bin.as_deref(), Some("/opt/herdr"));
         assert_eq!((a.cols, a.rows), (176, 66));
         assert!(a.size_fixed);
         assert!(parse_args(&["onlyone".to_string()]).is_err());

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -250,7 +250,8 @@ impl RemoteHost {
     }
 
     pub async fn status(&self) -> Result<RemoteStatus> {
-        let out = self.exec(&format!("exec {} status --json", self.cfg.remote_bin), 15000).await?;
+        let bin = crate::config::remote_bin_expr(self.cfg.remote_bin.as_deref());
+        let out = self.exec(&format!("exec {} status --json", bin), 15000).await?;
         #[derive(Deserialize)]
         struct Client {
             version: Option<String>,


### PR DESCRIPTION
## Summary
- When `remote_bin` is **unset**, the remote shell resolves herdr with `command -v herdr`, then falls back to `~/.local/bin/herdr`.
- When `remote_bin` is **set**, that path is used as before.
- Daemon only passes `--remote-bin` to pane streamers when the host config pins a path.

## Test plan
- [x] `cargo test`
- [ ] Mirror a host with `herdr` only on remote PATH (not at `~/.local/bin/herdr`)
- [ ] Mirror a host with herdr only at `~/.local/bin/herdr` (not on PATH)
- [ ] Pin `remote_bin = "/opt/herdr"` and confirm that path is used