### PR TITLE
fix: auto remote-bin resolution breaks fish-shelled remotes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub fn remote_bin_expr(remote_bin: Option<&str>) -> String {
         Some(b) if !b.is_empty() => b.to_string(),
         // Quotes around the substitution prevent word-splitting if the resolved
         // path contains spaces; ~ still expands inside the unquoted `echo` arg.
-        _ => "\"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\"".into(),
+        _ => "env \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\"".into(),
     }
 }
 
@@ -390,11 +390,11 @@ mod tests {
         assert_eq!(remote_bin_expr(Some("~/.local/bin/herdr")), "~/.local/bin/herdr");
         assert_eq!(
             remote_bin_expr(None),
-            "\"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
+            "env \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
         );
         assert_eq!(
             remote_bin_expr(Some("")),
-            "\"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
+            "env \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
         );
     }
 


### PR DESCRIPTION
## Problem

Since #29, when `remote_bin` is unset the remote command is built as

```
exec "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)" ...
```

The command an ssh exec channel runs goes through the remote user's **login shell**. When that shell is fish, every connection to the host fails — status probes, terminal session streams, and foreground polls alike — because fish has no command substitution in command position:

```
fish: command substitutions not allowed in command position. Try var=(your-cmd) $var ...
exec "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)" status --json
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```

The daemon ends up in a permanent reconnect loop against any fish-shelled host that worked fine on v0.1.16.

## Fix

Put `env` in front, moving the substitution into argument position:

```
exec env "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)" ...
```

- **POSIX sh/bash/zsh**: behaviour unchanged — `env` execs the resolved path with the same arguments.
- **fish**: $(...) in argument position (quoted form included) is supported since fish 3.4, and `||`, `2>/dev/null`, and `~` inside the substitution all behave the same.

An explicitly configured `remote_bin` is untouched, and the docker path already runs through `sh -c`, so this only affects the ssh auto-resolve case.

Verified against a live remote running fish 4.8.1 (both forms side by side — old fails as above, new resolves and runs) and against sh. `cargo test` passes with the updated expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code), but proudly reviewed as working and fix sanity by myself (I'm against full AI slop 😆 )