### PR TITLE
feat: remote-invoke UX: stable CLI link, failure toasts, context guard, exec heal

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,18 +68,55 @@ echo "installed ${ASSET} v${VERSION} at ${DEST}"
 # the absolute ~/.local/bin/herdr-mirror (herdr runs shell bindings through a
 # login sh that never reads ~/.zshrc, so PATH can't be trusted there), and
 # `herdr-mirror <cmd>` should work from a shell. Refreshed on every update;
-# anything at that path we don't manage is left alone.
+# a live file or link we don't manage is left alone.
+#
+# The link must NOT target pwd: herdr runs this build in
+# <plugins>/.tmp-install-*/checkout and only afterwards renames the checkout
+# to <plugins>/github/<id>-<hash>, deleting the temp dir — a link to pwd
+# dangles the moment the install succeeds. Derive that final path instead
+# (<hash> = first 12 hex chars of sha256(<id>), herdr's managed-path scheme;
+# the link briefly dangles until herdr's rename lands, which is fine). Run by
+# hand in a dev checkout (no .tmp-* ancestor under a plugins dir) it links
+# the checkout itself. `herdr-mirror status` reports link health, and the
+# daemon toasts if it ever goes stale, so a future herdr layout change is
+# loud, not a silent dead key.
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  else
+    shasum -a 256 | cut -d' ' -f1
+  fi
+}
+final_bin_path() {
+  dir="$(pwd)"
+  while [ "$dir" != "/" ]; do
+    case "$(basename "$dir")" in
+      .tmp-*)
+        if [ "$(basename "$(dirname "$dir")")" = "plugins" ]; then
+          ID="$(sed -n 's/^id = "\(.*\)"/\1/p' herdr-plugin.toml | head -1)"
+          HASH="$(printf %s "$ID" | sha256_hex | cut -c1-12)"
+          echo "$(dirname "$dir")/github/${ID}-${HASH}/${DEST}"
+          return 0
+        fi
+        ;;
+    esac
+    dir="$(dirname "$dir")"
+  done
+  echo "$(pwd)/${DEST}"
+}
 LINK="${HOME}/.local/bin/herdr-mirror"
-TARGET="$(pwd)/${DEST}"
+TARGET="$(final_bin_path)"
 
-# A link is foreign when it's live, isn't our target, and points outside
-# herdr's plugin dirs — e.g. a dev checkout the user linked deliberately.
+# A link is foreign when it's live, isn't our target, and points outside a
+# herdr plugins dir — e.g. a dev checkout the user linked deliberately.
+# A dangling link is never foreign: whatever it was, it's broken, and
+# replacing it is what makes the documented keybindings work again.
 is_foreign_link() {
   [ -L "$LINK" ] && [ -e "$LINK" ] || return 1
   CUR="$(readlink "$LINK")"
   [ "$CUR" = "$TARGET" ] && return 1
   case "$CUR" in
-    "${HOME}/.config/herdr/plugins/"*) return 1 ;; # an older install of ours
+    */herdr/plugins/* | */herdr-dev/plugins/*) return 1 ;; # an older install of ours
   esac
   return 0
 }
@@ -89,7 +126,11 @@ if [ -e "$LINK" ] && [ ! -L "$LINK" ]; then
 elif is_foreign_link; then
   echo "note: ${LINK} -> ${CUR} left untouched; not managed by this install"
 else
-  mkdir -p "${HOME}/.local/bin"
-  ln -sf "$TARGET" "$LINK"
-  echo "linked ${LINK} -> ${TARGET}"
+  # linking is best-effort: the binary is already installed, so a failure here
+  # (say, an unwritable ~/.local/bin) must not fail the whole plugin install
+  if mkdir -p "${HOME}/.local/bin" && rm -f "$LINK" && ln -s "$TARGET" "$LINK"; then
+    echo "linked ${LINK} -> ${TARGET}"
+  else
+    echo "note: could not link ${LINK}; run the plugin's Mirror: start action to repair it"
+  fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,3 +63,33 @@ EXPECTED="$(grep " ${ASSET}\$" "${TMP}/SHA256SUMS")" ||
 mkdir -p "$(dirname "$DEST")"
 install -m 755 "${TMP}/${ASSET}" "$DEST"
 echo "installed ${ASSET} v${VERSION} at ${DEST}"
+
+# Link the CLI at the stable path the README documents. Keybindings must use
+# the absolute ~/.local/bin/herdr-mirror (herdr runs shell bindings through a
+# login sh that never reads ~/.zshrc, so PATH can't be trusted there), and
+# `herdr-mirror <cmd>` should work from a shell. Refreshed on every update;
+# anything at that path we don't manage is left alone.
+LINK="${HOME}/.local/bin/herdr-mirror"
+TARGET="$(pwd)/${DEST}"
+
+# A link is foreign when it's live, isn't our target, and points outside
+# herdr's plugin dirs — e.g. a dev checkout the user linked deliberately.
+is_foreign_link() {
+  [ -L "$LINK" ] && [ -e "$LINK" ] || return 1
+  CUR="$(readlink "$LINK")"
+  [ "$CUR" = "$TARGET" ] && return 1
+  case "$CUR" in
+    "${HOME}/.config/herdr/plugins/"*) return 1 ;; # an older install of ours
+  esac
+  return 0
+}
+
+if [ -e "$LINK" ] && [ ! -L "$LINK" ]; then
+  echo "note: ${LINK} exists and is not a symlink; left untouched (README keybindings expect herdr-mirror there)"
+elif is_foreign_link; then
+  echo "note: ${LINK} -> ${CUR} left untouched; not managed by this install"
+else
+  mkdir -p "${HOME}/.local/bin"
+  ln -sf "$TARGET" "$LINK"
+  echo "linked ${LINK} -> ${TARGET}"
+fi

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -525,6 +525,21 @@ pub async fn cmd_run(env: Env) -> Result<()> {
     }
 
     let local = ApiClient::connect(&env.local_socket).await?;
+    // Detect-and-report only: a broken CLI link means every keybinding through
+    // it dies silently, but the repair stays behind the explicit `start`
+    // command — the daemon never rewrites the filesystem in the background.
+    if let Some(problem) = crate::util::cli_link_problem() {
+        log.log(&format!("warning: {problem} — keybindings using it can't fire; run start to repair"));
+        let _ = local
+            .request(
+                "notification.show",
+                json!({
+                    "title": "mirror: CLI link broken",
+                    "body": format!("{problem} — run Mirror: start (or herdr-mirror start) to repair"),
+                }),
+            )
+            .await;
+    }
     let closes = crate::closes::new_closes();
     let mut pokers: Vec<mpsc::Sender<()>> = Vec::new();
     let mut tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
@@ -668,6 +683,19 @@ pub fn cmd_status(env: &Env) -> Result<()> {
             "daemon: not running{}",
             if is_paused(env) { " (paused — resume with start)" } else { "" }
         ),
+    }
+    match crate::util::cli_link_state() {
+        crate::util::CliLink::Ok(t) => println!("cli link: ok (-> {})", t.display()),
+        crate::util::CliLink::Missing => {
+            println!("cli link: MISSING ({}) — keybindings using it can't fire; start repairs it", crate::util::cli_link_path().display())
+        }
+        crate::util::CliLink::Dangling(t) => {
+            println!("cli link: BROKEN (-> {}) — keybindings using it can't fire; start repairs it", t.display())
+        }
+        crate::util::CliLink::Other(t) => println!("cli link: -> {} (not this binary; left alone)", t.display()),
+        crate::util::CliLink::File => {
+            println!("cli link: {} is a regular file (not managed)", crate::util::cli_link_path().display())
+        }
     }
     let config = load_config(&env.config_search)?;
     if let Some(src) = &config.source {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -433,7 +433,7 @@ async fn heal_zombie_mirrors(
         let cmd_for = crate::mirror::cmd_for_pane(h, state_dir, &HashMap::new());
         for (remote_pane_id, local_pane_id) in dead {
             let argv = cmd_for(&remote_pane_id);
-            crate::mirror::spawn_streamer_pane(local, &local_pane_id, &argv, log).await;
+            crate::mirror::spawn_streamer_pane(local, state_dir, &local_pane_id, &argv, log).await;
         }
         let _ = pokers[i].try_send(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,9 @@ fn run_on(rt: &tokio::runtime::Runtime, cmd: &str, rest: &[String]) -> Result<()
             let args = pane::parse_args(&rest[1..])?;
             rt.block_on(pane::run(args))
         }
-        "remote-workspace" => rt.block_on(remote_action::run(Env::resolve()?, "workspace", None)),
-        "remote-tab" => rt.block_on(remote_action::run(Env::resolve()?, "tab", None)),
-        "remote-split" => rt.block_on(remote_action::run(
+        "remote-workspace" => rt.block_on(remote_action::run_cmd(Env::resolve()?, "workspace", None)),
+        "remote-tab" => rt.block_on(remote_action::run_cmd(Env::resolve()?, "tab", None)),
+        "remote-split" => rt.block_on(remote_action::run_cmd(
             Env::resolve()?,
             "split",
             rest.get(1).map(String::as_str),
@@ -91,7 +91,7 @@ fn run_on(rt: &tokio::runtime::Runtime, cmd: &str, rest: &[String]) -> Result<()
             let spec = rest
                 .get(1)
                 .ok_or_else(|| util::err("usage: herdr-mirror remote-invoke <plugin>.<action>"))?;
-            rt.block_on(remote_action::invoke(Env::resolve()?, spec))
+            rt.block_on(remote_action::invoke_cmd(Env::resolve()?, spec))
         }
         other => Err(util::err(format!(
             "unknown command: {other} (daemon|pane|start|pause|ensure|status|once|restore|teardown|remote-workspace|remote-tab|remote-split|remote-invoke)"

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,11 @@ fn run_on(rt: &tokio::runtime::Runtime, cmd: &str, rest: &[String]) -> Result<()
         "start" => {
             let env = Env::resolve()?;
             daemon::set_paused(&env, false); // explicit start lifts a manual pause
+            // explicit start is also the sanctioned moment to repair the CLI
+            // link (the daemon and the ensure hook only ever report it broken)
+            if let Some(msg) = util::repair_cli_link() {
+                println!("{msg}");
+            }
             daemon::cmd_start(&env)
         }
         "pause" | "stop" => {

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -553,7 +553,13 @@ async fn split_mirror_pane(
 /// layout `command`), which set `launch_argv` and would surface every mirror pane
 /// as an agent row; a shell `exec` keeps it non-agent until a real agent is
 /// reported onto it.
-pub(crate) async fn spawn_streamer_pane(local: &ApiClient, local_pane_id: &str, argv: &[String], log: &Logger) {
+pub(crate) async fn spawn_streamer_pane(
+    local: &ApiClient,
+    state_dir: &std::path::Path,
+    local_pane_id: &str,
+    argv: &[String],
+    log: &Logger,
+) {
     let line = format!(
         "exec {}\n",
         argv.iter().map(|a| sh_quote(a)).collect::<Vec<_>>().join(" ")
@@ -563,7 +569,46 @@ pub(crate) async fn spawn_streamer_pane(local: &ApiClient, local_pane_id: &str, 
         .await
     {
         log.log(&format!("spawn streamer {local_pane_id}: {e}"));
+        return;
     }
+
+    // Typed input can be eaten by interactive shell startup (oh-my-zsh's
+    // update prompt swallows the first key — in EVERY new shell until it's
+    // answered). Verify the streamer registered its pidfile and retype the
+    // exec if not, off-loop so a slow shell never stalls reconcile. The
+    // alive-check right before each resend keeps a late-starting streamer
+    // from getting the line typed into its stdin (which would forward it to
+    // the remote pane as text).
+    let (Some(ssh_target), Some(pane_target)) = (argv.get(2).cloned(), argv.get(3).cloned())
+    else {
+        return;
+    };
+    let (local, log, state_dir) = (local.clone(), log.clone(), state_dir.to_path_buf());
+    let pane_id = local_pane_id.to_string();
+    tokio::spawn(async move {
+        for wait_ms in [3000u64, 4000] {
+            tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+            if crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target) {
+                return;
+            }
+            log.log(&format!(
+                "streamer for {pane_target} not up in {pane_id} — shell startup likely ate the exec; retyping"
+            ));
+            if local
+                .request("pane.send_text", json!({ "pane_id": pane_id, "text": line }))
+                .await
+                .is_err()
+            {
+                return; // pane gone (closed meanwhile) — nothing to heal
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(4000)).await;
+        if !crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target) {
+            log.log(&format!(
+                "streamer for {pane_target} still not up in {pane_id} after retries — pane left as a shell"
+            ));
+        }
+    });
 }
 
 /// cwd every mirror pane runs in, doubling as the loop-guard marker: it's set at
@@ -979,7 +1024,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                         PaneEntry { local_id: local_id.clone(), tombstone: None, seq, reported: None },
                     );
                     // plain pane created above; exec the streamer into it
-                    spawn_streamer_pane(&deps.local, &local_id, &cmd_for(rid), &deps.log).await;
+                    spawn_streamer_pane(&deps.local, &deps.state_dir, &local_id, &cmd_for(rid), &deps.log).await;
                 }
             } else {
                 // tab exists — add mirrors for individual new remote panes as
@@ -1034,7 +1079,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                             )
                             .await;
                     }
-                    spawn_streamer_pane(&deps.local, &local_id, &cmd_for(&place.pane), &deps.log)
+                    spawn_streamer_pane(&deps.local, &deps.state_dir, &local_id, &cmd_for(&place.pane), &deps.log)
                         .await;
                     state.panes.insert(
                         place.pane.clone(),
@@ -1069,7 +1114,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                     ));
                     let local_id =
                         split_mirror_pane(&deps.local, &target, &direction, None, &cwd).await?;
-                    spawn_streamer_pane(&deps.local, &local_id, &cmd_for(&rp.pane_id), &deps.log)
+                    spawn_streamer_pane(&deps.local, &deps.state_dir, &local_id, &cmd_for(&rp.pane_id), &deps.log)
                         .await;
                     state.panes.insert(
                         rp.pane_id.clone(),

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -872,7 +872,31 @@ impl App {
 // ---------------------------------------------------------------------------
 // main
 
+/// Removes the streamer pidfile on any exit path out of `run` (stale files
+/// from a hard kill are harmless — the daemon checks the pid is alive).
+struct PidfileGuard(std::path::PathBuf);
+impl Drop for PidfileGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
 pub async fn run(args: Args) -> Result<()> {
+    // announce ourselves so the daemon can tell its typed `exec` took
+    // (see util::streamer_pid_path); --dump is a human diagnostic, not a
+    // daemon-spawned streamer, so it must not claim the slot
+    let _pidfile = (!args.dump).then(|| {
+        let state_dir =
+            crate::util::home_dir().join(".local").join("state").join("herdr-mirror");
+        let path =
+            crate::util::streamer_pid_path(&state_dir, &args.ssh_target, &args.pane_target);
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let _ = std::fs::write(&path, std::process::id().to_string());
+        PidfileGuard(path)
+    });
+
     let tty = !args.dump && unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1;
     let raw = if tty {
         // 1002/1006: button-event mouse tracking with SGR encoding, so wheel and

--- a/src/remote_action.rs
+++ b/src/remote_action.rs
@@ -36,6 +36,8 @@
 // whichever end is chosen, so the plugin must be installed there; anything it
 // does to the remote layout mirrors back like any other remote change.
 
+use std::io::IsTerminal;
+
 use serde::Deserialize;
 use serde_json::{json, Value};
 
@@ -154,6 +156,37 @@ async fn local_split(env: &Env, ctx: &InvocationContext, direction: &str) -> Res
     Ok(())
 }
 
+/// Entry points for main. Run the action; on failure post a toast to the
+/// local herdr before propagating. Key-bound and plugin-action invocations
+/// have their output discarded, so without the toast a failed keypress is
+/// indistinguishable from a dead key. Interactive runs (stderr is a tty)
+/// already see the error and skip it. Best effort on every leg: a herdr
+/// without notification.show, or none reachable, changes nothing.
+pub async fn invoke_cmd(env: Env, spec: &str) -> Result<()> {
+    let what = format!("remote-invoke {spec}");
+    report_failure(&env, &what, invoke(&env, spec).await).await
+}
+
+pub async fn run_cmd(env: Env, kind: &str, direction: Option<&str>) -> Result<()> {
+    let what = format!("remote-{kind}");
+    report_failure(&env, &what, run(&env, kind, direction).await).await
+}
+
+async fn report_failure(env: &Env, what: &str, result: Result<()>) -> Result<()> {
+    let Err(e) = result else { return Ok(()) };
+    if !std::io::stderr().is_terminal() {
+        if let Ok(api) = crate::api::ApiClient::connect(&env.local_socket).await {
+            let _ = api
+                .request(
+                    "notification.show",
+                    json!({ "title": format!("mirror: {what} failed"), "body": e.to_string() }),
+                )
+                .await;
+        }
+    }
+    Err(e)
+}
+
 /// Context for the local-invoke fallback: the plugin-action JSON verbatim when
 /// present (full fidelity — cwd, tab, selection all pass through), else the
 /// `HERDR_ACTIVE_*` fields a shell binding gets.
@@ -182,7 +215,7 @@ fn local_context_value(ctx: &InvocationContext) -> Value {
 /// host, with the invocation context translated to the remote ids. Outside a
 /// mirror the action is invoked on the local herdr instead. A bare action id
 /// (no dot) is passed without a plugin_id for the server to resolve.
-pub async fn invoke(env: Env, spec: &str) -> Result<()> {
+async fn invoke(env: &Env, spec: &str) -> Result<()> {
     let (plugin_id, action_id) = match spec.split_once('.') {
         Some((p, a)) if !p.is_empty() && !a.is_empty() => (Some(p), a),
         Some(_) => return Err(err(format!("bad action spec {spec:?}: want <plugin>.<action>"))),
@@ -192,7 +225,7 @@ pub async fn invoke(env: Env, spec: &str) -> Result<()> {
     let ctx = invocation_context();
     // Same deliberate non-`?` as run(): the local fallback needs no host config.
     let config = load_config(&env.config_search);
-    let resolved = config.as_ref().ok().and_then(|c| resolve_context(&env, &c.hosts, &ctx));
+    let resolved = config.as_ref().ok().and_then(|c| resolve_context(env, &c.hosts, &ctx));
 
     let Some(resolved) = resolved else {
         let api = crate::api::ApiClient::connect(&env.local_socket).await?;
@@ -237,7 +270,7 @@ pub async fn invoke(env: Env, spec: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn run(env: Env, kind: &str, direction: Option<&str>) -> Result<()> {
+async fn run(env: &Env, kind: &str, direction: Option<&str>) -> Result<()> {
     if kind == "split" && !matches!(direction, Some("right") | Some("down")) {
         return Err(err("remote-split needs a direction: right|down"));
     }
@@ -249,7 +282,7 @@ pub async fn run(env: Env, kind: &str, direction: Option<&str>) -> Result<()> {
     // hosts.toml yet, with an error about SSH hosts they never asked for.
     let config = load_config(&env.config_search);
     let resolved =
-        config.as_ref().ok().and_then(|c| resolve_context(&env, &c.hosts, &ctx));
+        config.as_ref().ok().and_then(|c| resolve_context(env, &c.hosts, &ctx));
 
     // One key for both worlds: inside a mirror these take the remote path
     // below; anywhere else they degrade to the plain local action instead of
@@ -259,9 +292,9 @@ pub async fn run(env: Env, kind: &str, direction: Option<&str>) -> Result<()> {
     // daemon-owned workspace.
     if resolved.is_none() {
         match kind {
-            "tab" => return local_tab(&env, &ctx).await,
+            "tab" => return local_tab(env, &ctx).await,
             // direction was validated at the top of this fn
-            "split" => return local_split(&env, &ctx, direction.unwrap()).await,
+            "split" => return local_split(env, &ctx, direction.unwrap()).await,
             _ => {}
         }
     }

--- a/src/remote_action.rs
+++ b/src/remote_action.rs
@@ -216,11 +216,15 @@ fn local_context_value(ctx: &InvocationContext) -> Value {
 /// mirror the action is invoked on the local herdr instead. A bare action id
 /// (no dot) is passed without a plugin_id for the server to resolve.
 async fn invoke(env: &Env, spec: &str) -> Result<()> {
-    let (plugin_id, action_id) = match spec.split_once('.') {
-        Some((p, a)) if !p.is_empty() && !a.is_empty() => (Some(p), a),
-        Some(_) => return Err(err(format!("bad action spec {spec:?}: want <plugin>.<action>"))),
-        None => (None, spec),
-    };
+    // The spec goes to the server verbatim as action_id: herdr matches it
+    // against bare action ids AND qualified <plugin>.<action> ids, and plugin
+    // ids may themselves contain dots (jt.command-palette), so any client-side
+    // split at a dot would pick the wrong plugin. Ambiguity is the server's
+    // call too — it errors asking for the qualified form.
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Err(err("usage: herdr-mirror remote-invoke <plugin>.<action>"));
+    }
 
     let ctx = invocation_context();
     // Same deliberate non-`?` as run(): the local fallback needs no host config.
@@ -229,10 +233,7 @@ async fn invoke(env: &Env, spec: &str) -> Result<()> {
 
     let Some(resolved) = resolved else {
         let api = crate::api::ApiClient::connect(&env.local_socket).await?;
-        let mut params = json!({ "action_id": action_id, "context": local_context_value(&ctx) });
-        if let Some(p) = plugin_id {
-            params["plugin_id"] = json!(p);
-        }
+        let params = json!({ "action_id": spec, "context": local_context_value(&ctx) });
         api.request("plugin.action.invoke", params).await?;
         println!("invoked {spec} locally");
         return Ok(());
@@ -256,10 +257,7 @@ async fn invoke(env: &Env, spec: &str) -> Result<()> {
             }
         }
     }
-    let mut params = json!({ "action_id": action_id, "context": context });
-    if let Some(p) = plugin_id {
-        params["plugin_id"] = json!(p);
-    }
+    let params = json!({ "action_id": spec, "context": context });
     api.request("plugin.action.invoke", params).await.map_err(|e| {
         err(format!(
             "remote invoke {spec} on {}: {e} (needs the plugin installed there, and a herdr with plugin.action.invoke)",

--- a/src/remote_action.rs
+++ b/src/remote_action.rs
@@ -35,6 +35,9 @@
 // one-key-for-both-worlds degrade as remote-tab/split. The action runs on
 // whichever end is chosen, so the plugin must be installed there; anything it
 // does to the remote layout mirrors back like any other remote change.
+// Inside a mirror workspace it requires a MIRRORED focused pane, like
+// remote-split: the remote backfills omitted context from its own focused
+// pane, so an untranslated pane would target an arbitrary remote object.
 
 use std::io::IsTerminal;
 
@@ -238,6 +241,17 @@ async fn invoke(env: &Env, spec: &str) -> Result<()> {
         println!("invoked {spec} locally");
         return Ok(());
     };
+
+    // Same guard as remote-split, for a different reason: herdr backfills any
+    // context field the client omits from the REMOTE's currently active
+    // workspace, so invoking without a translated pane would hand the action
+    // whatever pane/cwd happens to be focused over there — possibly an
+    // unrelated project. Erroring beats silently acting on the wrong pane.
+    if resolved.remote_pane_id.is_none() {
+        return Err(err(format!(
+            "remote invoke {spec}: the focused pane is not a mirrored pane, so the remote would fall back to its own focused pane — focus a mirror pane and retry"
+        )));
+    }
 
     let mut remote = RemoteHost::new(&resolved.host, &env.state_dir);
     let (api, _status) = remote.connect_api().await?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,6 +62,71 @@ pub fn default_config_dir() -> PathBuf {
     home_dir().join(".config").join("herdr-mirror")
 }
 
+/// The stable CLI path install.sh links and the README's keybindings use.
+pub fn cli_link_path() -> PathBuf {
+    home_dir().join(".local").join("bin").join("herdr-mirror")
+}
+
+pub enum CliLink {
+    /// resolves to the running binary
+    Ok(PathBuf),
+    /// nothing at the path
+    Missing,
+    /// a symlink whose target no longer exists
+    Dangling(PathBuf),
+    /// a live symlink to some other binary — a deliberate arrangement
+    Other(PathBuf),
+    /// a regular file we don't manage
+    File,
+}
+
+pub fn cli_link_state() -> CliLink {
+    let link = cli_link_path();
+    match fs::read_link(&link) {
+        // read_link fails for both "missing" and "not a symlink"
+        Err(_) if !link.exists() => CliLink::Missing,
+        Err(_) => CliLink::File,
+        Ok(target) => {
+            let resolved = fs::canonicalize(&link).ok();
+            let exe = std::env::current_exe().ok().and_then(|e| fs::canonicalize(e).ok());
+            match resolved {
+                None => CliLink::Dangling(target),
+                Some(r) if exe.as_ref() == Some(&r) => CliLink::Ok(target),
+                Some(_) => CliLink::Other(target),
+            }
+        }
+    }
+}
+
+/// The states worth interrupting the user about: keybindings through the link
+/// cannot fire at all. `Other`/`File` are deliberate arrangements, not
+/// breakage, so they never warn — `status` still shows them.
+pub fn cli_link_problem() -> Option<String> {
+    match cli_link_state() {
+        CliLink::Missing => Some(format!("{} is missing", cli_link_path().display())),
+        CliLink::Dangling(t) => {
+            Some(format!("{} dangles (-> {})", cli_link_path().display(), t.display()))
+        }
+        _ => None,
+    }
+}
+
+/// Repair a missing/dangling link by pointing it at the running binary.
+/// Reserved for the explicit `start` command — the daemon only reports (see
+/// cli_link_problem), so nothing rewrites the filesystem in the background.
+/// A live foreign link or real file is never replaced.
+pub fn repair_cli_link() -> Option<String> {
+    cli_link_problem()?;
+    let link = cli_link_path();
+    let exe = std::env::current_exe().ok()?;
+    let _ = fs::create_dir_all(link.parent()?);
+    let _ = fs::remove_file(&link);
+    Some(match std::os::unix::fs::symlink(&exe, &link) {
+        Ok(()) => format!("relinked {} -> {}", link.display(), exe.display()),
+        Err(e) => format!("could not relink {}: {e}", link.display()),
+    })
+}
+
 /// Config dirs to search, most specific first.
 ///
 /// Order matters more than it looks. herdr injects `HERDR_PLUGIN_CONFIG_DIR`

--- a/src/util.rs
+++ b/src/util.rs
@@ -220,6 +220,28 @@ pub fn pid_alive(pid: i32) -> bool {
     pid > 0 && unsafe { libc::kill(pid, 0) } == 0
 }
 
+/// Pidfile a pane streamer writes at startup. The daemon starts streamers by
+/// TYPING `exec ...` into a fresh shell pane, and interactive shell startup
+/// can eat keystrokes (oh-my-zsh's update prompt swallows the leading `e` —
+/// and re-prompts in every new shell until answered, so it fails every spawn,
+/// not one in a fortnight). The pidfile is how the daemon can tell the exec
+/// took, and retype it when it didn't.
+pub fn streamer_pid_path(state_dir: &Path, ssh_target: &str, pane_target: &str) -> PathBuf {
+    let sane = |s: &str| {
+        s.chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+            .collect::<String>()
+    };
+    state_dir.join("streamer-pids").join(format!("{}--{}.pid", sane(ssh_target), sane(pane_target)))
+}
+
+pub fn streamer_alive(state_dir: &Path, ssh_target: &str, pane_target: &str) -> bool {
+    fs::read_to_string(streamer_pid_path(state_dir, ssh_target, pane_target))
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .is_some_and(pid_alive)
+}
+
 /// Sleep until the earliest deadline; pend forever when none.
 pub async fn sleep_until_earliest<I>(deadlines: I)
 where


### PR DESCRIPTION
## Problem

The `remote-invoke` engine merged in #28 works, but there was no sound way to actually use it: the README told users to hand-symlink a versioned plugin path onto PATH, shell keybindings ran under a login `sh` whose PATH can't be trusted, and every failure was silent because herdr discards key-bound command output. Testing against real plugins and a real vps surfaced deeper problems: the symlink advice would dangle after every managed install (herdr builds plugins in a temp dir it deletes), client-side spec parsing broke plugins with dotted ids, an unmirrored focused pane made the remote backfill context from whatever pane happened to be focused over there, and the typed `exec` that boots every mirror pane loses keystrokes to interactive shell startup (oh-my-zsh's update prompt ate the leading `e` on literally every spawn until answered).

## Fix

- **install.sh links `~/.local/bin/herdr-mirror`** at herdr's *final* managed checkout path, derived from the temp build dir's location (a link to `pwd` dangles the moment a managed install finishes). Guarded: a working file or link the install doesn't manage is left alone; a broken link is repaired; linking failure can't fail the install. Dev runs of the script link the checkout itself.
- **Link lifecycle is explicit, never background**: `status` prints link health, the daemon detects a broken link and posts a toast telling the user, and only the explicit `start` command repairs it.
- **Failures toast**: `remote-invoke` and the `remote-*` create actions report errors through `notification.show` on the local herdr, since key-bound output goes nowhere. Interactive runs (stderr is a tty) skip the toast; the call is best-effort so old herdrs and a dead socket change nothing.
- **Specs pass to the server verbatim**: herdr's resolver matches bare and qualified action ids itself, and plugin ids may contain dots (`jt.command-palette`), so any client-side split at a dot picks the wrong plugin.
- **Non-mirrored focused pane inside a mirror workspace now errors**, like `remote-split`: herdr backfills omitted context fields from the remote's own focused pane, so proceeding would hand the action an arbitrary remote pane and cwd.
- **Streamer exec is verified and retyped**: pane streamers write a pidfile at startup, and after typing `exec ...` into a fresh shell pane the daemon checks it at ~3s/~7s, retyping up to twice when shell startup consumed the input. The alive-check immediately before each resend keeps a late-starting streamer from getting the line typed into its stdin. Covers all spawn paths including zombie-heal.

README intentionally untouched: docs land separately once the feature set is final.

## Testing

All against a live vps mirror with `smarzban/herdr-file-viewer` installed remotely:

- install.sh link derivation exercised in a simulated herdr install layout: managed installs link `plugins/github/mirror-<hash>/...` (matching the real hash), dev runs link the checkout, dangling links self-heal, foreign files and live foreign links are preserved (six guard cases).
- Keybinding-context invokes fire on the focused mirror's host and the new remote pane mirrors back; the local-degrade failure path toasts.
- The exec-eaten failure was reproduced on demand (oh-my-zsh update prompt), then observed self-healing end to end: daemon logged `streamer for w1P:p8 not up in w7N:p9 ... retyping` and the streamer came up with no manual help.
- `status` link reporting and `start` repair verified live; dotted-id resolution verified against herdr's `find_plugin_action`.
