### PR TITLE
fix: run the auto remote-bin resolver under sh so any login shell works

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,15 +10,20 @@ use crate::util::{err, Result};
 /// Shell expression for `exec <expr> ...` on the remote.
 ///
 /// A configured path is used as-is (unquoted so remote-shell `~` expands).
-/// When unset, the remote shell resolves `herdr` via PATH, falling back to
-/// `~/.local/bin/herdr` if `command -v` finds nothing. The auto form is
-/// double-quoted so a path with spaces (PATH entry or `$HOME`) stays one word.
+/// When unset, `herdr` is resolved via PATH, falling back to
+/// `~/.local/bin/herdr` if `command -v` finds nothing.
 pub fn remote_bin_expr(remote_bin: Option<&str>) -> String {
     match remote_bin {
         Some(b) if !b.is_empty() => b.to_string(),
-        // Quotes around the substitution prevent word-splitting if the resolved
-        // path contains spaces; ~ still expands inside the unquoted `echo` arg.
-        _ => "env \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\"".into(),
+        // The `$(...)` substitution must run under a POSIX sh, never the remote
+        // login shell: `ssh host cmd` hands the string to that shell, and fish
+        // rejects `$(...)` (in command position always; everywhere before fish
+        // 3.4), as does csh. The login shell only has to parse `sh -c
+        // '<literal>' herdr` plus the caller's trailing words, which every
+        // shell handles alike; the args land in `"$@"`. Quotes around the
+        // substitution prevent word-splitting if the resolved path contains
+        // spaces; ~ still expands inside the unquoted `echo` arg.
+        _ => "sh -c 'exec \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\" \"$@\"' herdr".into(),
     }
 }
 
@@ -388,14 +393,9 @@ mod tests {
     fn remote_bin_expr_configured_vs_auto() {
         assert_eq!(remote_bin_expr(Some("/opt/herdr")), "/opt/herdr");
         assert_eq!(remote_bin_expr(Some("~/.local/bin/herdr")), "~/.local/bin/herdr");
-        assert_eq!(
-            remote_bin_expr(None),
-            "env \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
-        );
-        assert_eq!(
-            remote_bin_expr(Some("")),
-            "env \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\""
-        );
+        let auto = "sh -c 'exec \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\" \"$@\"' herdr";
+        assert_eq!(remote_bin_expr(None), auto);
+        assert_eq!(remote_bin_expr(Some("")), auto);
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -205,8 +205,9 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         .as_ref()
         .map(|s| format!(" --session {}", sh_quote(s)))
         .unwrap_or_default();
-    // Configured paths stay unquoted so remote-shell ~ expands; auto mode is a
-    // command-substitution expression (see config::remote_bin_expr).
+    // Configured paths stay unquoted so remote-shell ~ expands; auto mode is an
+    // `sh -c` resolver that takes the trailing words as "$@" (see
+    // config::remote_bin_expr).
     let bin = crate::config::remote_bin_expr(args.remote_bin.as_deref());
     let cmd = format!(
         "exec {}{} terminal session {} {} --cols {} --rows {}",


### PR DESCRIPTION
Fixes #32.

## Problem

The v0.1.17 fix (#31) moved the `$(...)` substitution into argument position, which satisfies fish 3.4+. But fish older than 3.4 (still shipped by e.g. Ubuntu 20.04 and Debian 11) rejects `$(...)` everywhere, so a host whose login shell is an older fish still fails every remote call and never connects:

```
fish: $(...) is not supported. In fish, please use '(command)'.
```

csh/tcsh login shells were similarly broken.

## Fix

Stop asking the login shell to evaluate the substitution at all. The auto form is now

```
sh -c 'exec "$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)" "$@"' herdr
```

so callers still emit `exec <expr> <args...>` unchanged, the trailing args land in `"$@"`, and the substitution runs under a POSIX `sh`. The login shell only has to parse a single-quoted literal plus plain words, which every fish version, csh/tcsh, and POSIX shell handle identically. An explicitly configured `remote_bin` is untouched, as is the docker path (already `sh -c`).

## Verification

- fish 3.1.2 (Alpine 3.12 container): the old expression reproduces the exact error from #32; the new one resolves and passes args through, including a quoted `--pane '%5'` argument.
- fish 4.6.0: works (and the old form also worked there, confirming #31 only covered 3.4+).
- POSIX sh: works both when `herdr` is on PATH and via the `~/.local/bin/herdr` fallback with a clean PATH.
- `cargo test` passes (110 tests) with the updated expectation.