### PR TITLE
feat: paste clipboard images into mirror panes via ctrl+v

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,24 @@ the file already binds, and reloads herdr, so the key is live immediately;
 `unbind` removes only blocks that `bind` wrote. `remote-actions` also prints a
 paste-ready binding block.
 
+### Image paste
+
+herdr's native image paste (`remote_image_paste`, ctrl+v) only exists in
+`herdr --remote` — a mirror pane is attached to your *local* server, and the
+stream driving the remote carries no image message. Mirror panes close that
+gap themselves: press **ctrl+v** in a mirror pane and, if the local clipboard
+holds an image, it is uploaded over the pane's own transport (ssh, reusing the
+daemon's ControlMaster; or docker exec) to `~/.cache/herdr-mirror/pastes/` on
+the remote, and the resulting absolute path is pasted as bracketed text — an
+agent over there (claude, codex, …) reads the image from that path.
+
+When the clipboard has no image, the ctrl+v is forwarded unchanged (vim's
+visual-block and shell quoted-insert keep working); the only cost is the
+clipboard probe's latency on that one keystroke. Reading the clipboard uses
+`pngpaste` if installed, else AppleScript on macOS; `wl-paste` or `xclip` on
+Linux. Uploads are never cleaned up automatically — they're small, but
+`rm -rf ~/.cache/herdr-mirror/pastes` on the remote is always safe.
+
 ### Mouse
 
 Mirror panes adapt to what's running on the remote pane:

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod grid;
 mod layout_sync;
 mod mirror;
 mod pane;
+mod paste;
 mod predict;
 mod remote;
 mod remote_action;

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -185,6 +185,7 @@ enum Msg {
     /// result of a background foreground-process poll: Some(true)=shell,
     /// Some(false)=TUI, None=poll failed (keep last value)
     Foreground(Option<bool>),
+    Paste(crate::paste::Outcome),
 }
 
 struct Session {
@@ -503,6 +504,7 @@ struct App {
     /// whether the local pane is currently in application cursor mode (?1h), held
     /// to match the remote's so forwarded arrows arrive in the form it expects
     app_cursor_keys: bool,
+    paste_inflight: bool,
 }
 
 /// minimum spacing between foreground polls — each is an ssh handshake, so we
@@ -777,6 +779,20 @@ impl App {
     }
 
     async fn handle_stdin(&mut self, buf: Vec<u8>) {
+        if buf.len() == 1 && buf[0] == 0x16 && !self.paste_inflight {
+            self.paste_inflight = true;
+            let tx = self.tx.clone();
+            let ssh = self.args.ssh_target.clone();
+            let ctl = self.args.ctl_path.clone();
+            let container = self.args.container.clone();
+            tokio::spawn(async move {
+                let outcome =
+                    crate::paste::clipboard_to_remote(&ssh, ctl.as_deref(), container.as_ref())
+                        .await;
+                let _ = tx.send(Msg::Paste(outcome)).await;
+            });
+            return;
+        }
         if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
             // no quit key: the wrapper's lifecycle belongs to the hosting pane
             if has_mouse_seq(&buf) {
@@ -868,6 +884,38 @@ impl App {
             }
         }
     }
+
+    async fn deliver_input(&mut self, buf: Vec<u8>) {
+        if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
+            self.control_sticky = false;
+            self.pending_input.push(buf);
+            self.switch_mode(Mode::Control);
+            return;
+        }
+        self.last_input = Instant::now();
+        if self.switching_to == Some(Mode::Control) || self.session.is_none() {
+            self.pending_input.push(buf);
+            if let Some((_, m)) = self.reconnect_at {
+                self.reconnect_at = Some((Instant::now(), m));
+            }
+            return;
+        }
+        self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&buf) })).await;
+    }
+
+    async fn handle_paste(&mut self, outcome: crate::paste::Outcome) {
+        self.paste_inflight = false;
+        match outcome {
+            crate::paste::Outcome::NoImage => self.deliver_input(vec![0x16]).await,
+            crate::paste::Outcome::Pasted(path) => {
+                self.deliver_input(crate::paste::bracketed(&path)).await;
+                self.hint(&format!("image → {path}"));
+            }
+            crate::paste::Outcome::Failed(e) => {
+                self.hint(&format!("image paste failed: {e}"));
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -955,6 +1003,7 @@ pub async fn run(args: Args) -> Result<()> {
         // startup leaves the pane in normal cursor mode; the first classification
         // moves it if the remote turns out to be a TUI
         app_cursor_keys: false,
+        paste_inflight: false,
     };
     // Control is authoritative on the remote: the server resizes the remote pty
     // to whatever we ask for, beating even a larger live client over there. So
@@ -1013,6 +1062,7 @@ pub async fn run(args: Args) -> Result<()> {
                         app.sync_mouse_grab();
                         app.sync_cursor_key_mode();
                     },
+                    Some(Msg::Paste(outcome)) => app.handle_paste(outcome).await,
                 }
             }
             _ = sigwinch.recv() => {

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -1,0 +1,169 @@
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::pane::ContainerArg;
+use crate::remote::SSH_COMMON_OPTS;
+use crate::util::{err, Result};
+
+const REMOTE_DIR: &str = ".cache/herdr-mirror/pastes";
+
+const CLIPBOARD_TIMEOUT: Duration = Duration::from_secs(5);
+const UPLOAD_TIMEOUT: Duration = Duration::from_secs(20);
+
+pub enum Outcome {
+    Pasted(String),
+    NoImage,
+    Failed(String),
+}
+
+pub async fn clipboard_to_remote(
+    ssh_target: &str,
+    ctl_path: Option<&str>,
+    container: Option<&ContainerArg>,
+) -> Outcome {
+    let png = match read_clipboard_image().await {
+        Some(b) if !b.is_empty() => b,
+        _ => return Outcome::NoImage,
+    };
+    match upload(&png, ssh_target, ctl_path, container).await {
+        Ok(path) => Outcome::Pasted(path),
+        Err(e) => Outcome::Failed(e.to_string()),
+    }
+}
+
+async fn read_clipboard_image() -> Option<Vec<u8>> {
+    if cfg!(target_os = "macos") {
+        if let Some(bytes) = run_capture("pngpaste", &["-"]).await {
+            return Some(bytes);
+        }
+        let out = run_capture("osascript", &["-e", "the clipboard as «class PNGf»"]).await?;
+        parse_osascript_data(&String::from_utf8_lossy(&out))
+    } else {
+        if let Some(bytes) = run_capture("wl-paste", &["-t", "image/png"]).await {
+            return Some(bytes);
+        }
+        run_capture("xclip", &["-selection", "clipboard", "-t", "image/png", "-o"]).await
+    }
+}
+
+async fn run_capture(bin: &str, args: &[&str]) -> Option<Vec<u8>> {
+    let child = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let out = timeout(CLIPBOARD_TIMEOUT, child.wait_with_output()).await.ok()?.ok()?;
+    (out.status.success() && !out.stdout.is_empty()).then_some(out.stdout)
+}
+
+fn parse_osascript_data(s: &str) -> Option<Vec<u8>> {
+    let hex = s.trim().strip_prefix("«data PNGf")?.strip_suffix('»')?;
+    if hex.is_empty() || hex.len() % 2 != 0 {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    let digits = hex.as_bytes();
+    for pair in digits.chunks(2) {
+        let hi = (pair[0] as char).to_digit(16)?;
+        let lo = (pair[1] as char).to_digit(16)?;
+        bytes.push((hi * 16 + lo) as u8);
+    }
+    Some(bytes)
+}
+
+async fn upload(
+    png: &[u8],
+    ssh_target: &str,
+    ctl_path: Option<&str>,
+    container: Option<&ContainerArg>,
+) -> Result<String> {
+    let name = format!(
+        "paste-{}-{}.png",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+        std::process::id()
+    );
+    let cmd = format!("mkdir -p ~/{REMOTE_DIR} && cat > ~/{REMOTE_DIR}/{name} && echo \"$HOME\"");
+    let mut c = match container {
+        Some(ct) => {
+            let ids = crate::docker::resolve(&ct.docker_bin, &ct.kind).await?;
+            let id = ids.into_iter().next().ok_or_else(|| err("container not found"))?;
+            let mut c = Command::new(&ct.docker_bin);
+            c.args(["exec", "-i", &id, "sh", "-c", &cmd]);
+            c
+        }
+        None => {
+            let mut c = Command::new("ssh");
+            if let Some(path) = ctl_path {
+                c.arg("-S").arg(path);
+            }
+            c.args(SSH_COMMON_OPTS).arg(ssh_target).arg(&cmd);
+            c
+        }
+    };
+    let mut child = c
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut stdin = child.stdin.take().ok_or_else(|| err("no child stdin"))?;
+    stdin.write_all(png).await?;
+    drop(stdin);
+    let out = timeout(UPLOAD_TIMEOUT, child.wait_with_output())
+        .await
+        .map_err(|_| err("upload timed out"))??;
+    if !out.status.success() {
+        let tail = String::from_utf8_lossy(&out.stderr);
+        let tail = tail.lines().map(str::trim).rfind(|l| !l.is_empty()).unwrap_or("upload failed");
+        return Err(err(tail.to_string()));
+    }
+    let home = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if home.is_empty() || !home.starts_with('/') {
+        return Err(err("remote gave no home directory back"));
+    }
+    Ok(format!("{home}/{REMOTE_DIR}/{name}"))
+}
+
+pub fn bracketed(path: &str) -> Vec<u8> {
+    let mut b: Vec<u8> = b"\x1b[200~".to_vec();
+    b.extend_from_slice(path.as_bytes());
+    b.extend_from_slice(b"\x1b[201~");
+    b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn osascript_data_literal_decodes() {
+        assert_eq!(parse_osascript_data("«data PNGf48656c6c6f»\n"), Some(b"Hello".to_vec()));
+        let png = parse_osascript_data("«data PNGf89504e470d0a1a0a»").unwrap();
+        assert_eq!(&png[..4], &[0x89, b'P', b'N', b'G']);
+    }
+
+    #[test]
+    fn osascript_data_rejects_garbage() {
+        assert_eq!(parse_osascript_data("execution error: ..."), None);
+        assert_eq!(parse_osascript_data("«data PNGf»"), None);
+        assert_eq!(parse_osascript_data("«data PNGf123»"), None);
+        assert_eq!(parse_osascript_data("«data PNGfzz»"), None);
+        assert_eq!(parse_osascript_data("«data TIFF4865»"), None);
+    }
+
+    #[test]
+    fn bracketed_paste_wraps_verbatim() {
+        let b = bracketed("/home/u/.cache/herdr-mirror/pastes/p.png");
+        assert!(b.starts_with(b"\x1b[200~"));
+        assert!(b.ends_with(b"\x1b[201~"));
+        assert_eq!(&b[6..b.len() - 6], b"/home/u/.cache/herdr-mirror/pastes/p.png");
+    }
+}


### PR DESCRIPTION
## Problem

herdr's native image paste (`remote_image_paste`, ctrl+v) only exists in `herdr --remote`, where the client ships the local clipboard image to the server it is attached to. A mirror pane is attached to the *local* server, and the terminal-session stream driving the remote carries only input/resize/scroll/release — there is no message an image could cross on. So pasting a screenshot into a remote agent (claude, codex, …) behind a mirror pane silently does nothing: the agent receives a bare ctrl+v and looks at the *remote* machine's clipboard.

## Approach

On a lone ctrl+v in a mirror pane, probe the local clipboard off-loop:

- **clipboard holds an image** → upload it over the transport the pane already uses (ssh, reusing the daemon's ControlMaster via `-S`, or `docker exec`) to `~/.cache/herdr-mirror/pastes/` on the remote, then paste the resulting absolute path as bracketed text. Agents read the image from that path. The pane shows an `image → <path>` hint on success.
- **no image** (the common case) → the original ctrl+v is delivered unchanged, so vim's visual-block and shell quoted-insert keep working; the only cost is the clipboard probe's latency on that one keystroke.

Clipboard readers: `pngpaste` if installed, else AppleScript (`the clipboard as «class PNGf»`, parsed from its hex literal — no temp file) on macOS; `wl-paste` then `xclip` on Linux. The upload is a single round trip (`mkdir -p && cat > file && echo $HOME`) with the image on stdin and the remote home on stdout, which turns the `~`-relative landing spot into the absolute path an agent can open. A `paste_inflight` guard keeps a double-tap from uploading twice, and the resolved outcome is routed exactly like typed input (takes control from observe, queues across a connect gap).

## Testing

- `cargo test` — new unit tests for the AppleScript hex-literal parser and the bracketed-paste framing.
- Live end-to-end against an ssh host (fish login shell): image on clipboard → ctrl+v in the mirror pane → file lands on the remote, absolute path pasted at the remote prompt; text-only clipboard → ctrl+v passes through, no upload, pane stays live.
- Several days of daily use driving a remote Claude Code session through a mirror pane.