### PR TITLE
Ignore horizontal wheel events in mirror panes

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -428,6 +428,8 @@ enum MouseAction {
 fn mouse_action(remote_is_shell: Option<bool>, btn: u32, press: bool) -> MouseAction {
     if press && (btn == 64 || btn == 65) {
         MouseAction::Scroll { up: btn == 64 }
+    } else if btn == 66 || btn == 67 {
+        MouseAction::Drop
     } else if remote_is_shell == Some(false) {
         MouseAction::ForwardRaw
     } else {


### PR DESCRIPTION
This PR drops horizontal wheel events instead of forwarding them. Without this, it was effectively impossible to scroll using my MBP trackpad. It's not a pretty fix, but the way I see it, I'm not aware of any CLI apps that make use of horizontal scrolling so I think it's worth the trade off.