### PR TITLE
fix: keep OSC 8 hyperlinks clickable in mirror panes

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -18,6 +18,10 @@ fn cw(ch: char) -> usize {
 pub struct Cell {
     /// Rc: runs of cells share one SGR allocation
     pub sgr: Rc<str>,
+    /// OSC 8 target URI, when this cell sits inside a hyperlink. Carried
+    /// per-cell for the same reason as `sgr`: the renderer repaints arbitrary
+    /// rows in isolation, so it cannot rely on stream order to know the state.
+    pub link: Option<Rc<str>>,
     pub ch: char,
 }
 
@@ -61,6 +65,7 @@ impl Grid {
         let mut row = 0usize;
         let mut col = 0usize;
         let mut sgr: Rc<str> = Rc::from("");
+        let mut link: Option<Rc<str>> = None;
         let mut i = 0usize;
         while i < chars.len() {
             if chars[i] == '\x1b' {
@@ -82,6 +87,11 @@ impl Grid {
                     continue;
                 }
                 if let Some(len) = parse_osc(&chars[i..]) {
+                    // OSC is presentation-free apart from OSC 8, which carries
+                    // the hyperlink a click needs; everything else still drops.
+                    if let Some(uri) = parse_osc8(&chars[i..i + len]) {
+                        link = uri;
+                    }
                     i += len;
                     continue;
                 }
@@ -93,7 +103,7 @@ impl Grid {
                 let ch = if ch == '\t' { ' ' } else { ch };
                 let w = cw(ch);
                 if row < self.height && col < self.width {
-                    self.rows[row][col] = Some(Cell { sgr: sgr.clone(), ch });
+                    self.rows[row][col] = Some(Cell { sgr: sgr.clone(), link: link.clone(), ch });
                     // wide char spans two columns: clear any stale cell in the
                     // spacer slot so delta frames cannot leave mixed glyphs
                     if w == 2 && col + 1 < self.width {
@@ -179,6 +189,19 @@ fn parse_osc(chars: &[char]) -> Option<usize> {
     None
 }
 
+/// OSC 8 hyperlink: ESC ] 8 ; params ; URI (BEL | ESC \). `params` (the
+/// optional `id=` and friends) is ignored — it only affects hover grouping.
+///
+/// Returns None when `seq` is some other OSC, `Some(None)` for the closing
+/// form (empty URI), and `Some(Some(uri))` to open a link.
+fn parse_osc8(seq: &[char]) -> Option<Option<Rc<str>>> {
+    let body: String = seq.iter().collect();
+    let body = body.strip_prefix("\x1b]")?;
+    let body = body.strip_suffix('\x07').or_else(|| body.strip_suffix("\x1b\\"))?;
+    let (_params, uri) = body.strip_prefix("8;")?.split_once(';')?;
+    Some((!uri.is_empty()).then(|| Rc::from(uri)))
+}
+
 // ---------------------------------------------------------------------------
 // renderer: paints a window of the grid onto the local terminal
 
@@ -219,6 +242,9 @@ impl Renderer {
             let cells = grid.rows.get(r + offset_r).unwrap_or(&empty);
             let mut line = String::new();
             let mut prev_sgr: Option<&str> = None;
+            // No link is open at the start of a row: every row is repainted from
+            // its own CUP, so hyperlink state never carries in from the row above.
+            let mut prev_link: Option<&str> = None;
             let limit = out_cols.min(grid.width);
             let mut c = 0usize;
             while c < limit {
@@ -227,6 +253,16 @@ impl Renderer {
                 if prev_sgr != Some(sgr) {
                     line.push_str(if sgr.is_empty() { "\x1b[0m" } else { sgr });
                     prev_sgr = Some(sgr);
+                }
+                let link = cell.and_then(|c| c.link.as_deref());
+                if prev_link != link {
+                    match link {
+                        Some(uri) => {
+                            let _ = write!(line, "\x1b]8;;{uri}\x1b\\");
+                        }
+                        None => line.push_str("\x1b]8;;\x1b\\"),
+                    }
+                    prev_link = link;
                 }
                 let ch = cell.map(|c| c.ch).unwrap_or(' ');
                 let w = cw(ch);
@@ -240,6 +276,11 @@ impl Renderer {
                 // wide char occupies two columns: skip its spacer cell so the
                 // painted columns stay aligned with the grid (Hangul/CJK fix)
                 c += w;
+            }
+            // A link left open would swallow everything painted after this row,
+            // including the next row's CUP-anchored content and the status bar.
+            if prev_link.is_some() {
+                line.push_str("\x1b]8;;\x1b\\");
             }
             let is_status_row = r == out_rows - 1 && !self.status_text.is_empty();
             let painted = if is_status_row {
@@ -423,5 +464,55 @@ mod tests {
         // unchanged rows are not repainted
         let out3 = r.paint(&g, 5, 3);
         assert!(!out3.contains("last"));
+    }
+
+    const LINK: &str = "\x1b]8;;https://example.com/x\x1b\\";
+    const UNLINK: &str = "\x1b]8;;\x1b\\";
+
+    #[test]
+    fn osc8_is_captured_on_cells_and_repainted() {
+        let mut g = Grid::new();
+        g.resize(8, 2);
+        g.apply(&format!("\x1b[1;1H{LINK}PR\x1b[1;3H{UNLINK}ok"));
+        // the link rides the cells it covers, and only those
+        assert_eq!(g.rows[0][0].as_ref().unwrap().link.as_deref(), Some("https://example.com/x"));
+        assert_eq!(g.rows[0][1].as_ref().unwrap().link.as_deref(), Some("https://example.com/x"));
+        assert_eq!(g.rows[0][3].as_ref().unwrap().link, None);
+        // and survives the repaint, which is the whole point
+        let out = Renderer::new().paint(&g, 8, 2);
+        assert!(out.contains(LINK), "open sequence missing: {out:?}");
+        assert!(out.contains(UNLINK), "close sequence missing: {out:?}");
+    }
+
+    #[test]
+    fn osc8_params_are_ignored_and_bel_terminates() {
+        // the `id=` form with a BEL terminator is equally valid
+        let mut g = Grid::new();
+        g.resize(4, 1);
+        g.apply("\x1b[1;1H\x1b]8;id=7;https://example.com/y\x07hi");
+        assert_eq!(g.rows[0][0].as_ref().unwrap().link.as_deref(), Some("https://example.com/y"));
+    }
+
+    #[test]
+    fn non_hyperlink_osc_still_skipped() {
+        // OSC 0 (window title) must neither print nor be mistaken for a link
+        let mut g = Grid::new();
+        g.resize(4, 1);
+        g.apply("\x1b[1;1H\x1b]0;some title\x07hi");
+        assert_eq!(g.text_lines(), vec!["hi"]);
+        assert_eq!(g.rows[0][0].as_ref().unwrap().link, None);
+    }
+
+    #[test]
+    fn open_link_cannot_leak_past_the_row() {
+        // a link still open at the right edge would swallow the next row's
+        // content, which the terminal paints from a fresh CUP
+        let mut g = Grid::new();
+        g.resize(2, 2);
+        g.apply(&format!("\x1b[1;1H{LINK}ab\x1b[2;1H{UNLINK}cd"));
+        let out = Renderer::new().paint(&g, 2, 2);
+        let row2 = out.split("\x1b[2;1H").nth(1).expect("row 2 painted");
+        assert!(!row2.contains("\x1b]8;;https"), "link leaked into row 2: {out:?}");
+        assert_eq!(out.matches(UNLINK).count(), 1, "expected exactly one close: {out:?}");
     }
 }


### PR DESCRIPTION
Fixes the OSC 8 half of #43: hyperlinks are clickable in mirror panes again.

## The problem

A mirror pane could not carry a hyperlink at all. `Grid::apply` skipped every OSC, `Cell`
had no field to record one, and `Renderer::paint` emitted no OSC on any path — so a link
whose URI travels in `ESC ] 8 ; ; URI ST` arrived at the local terminal as inert label text.

The user-visible shape is confusing, because the *other* link mechanism kept working: plain
URLs stayed clickable via the terminal's own regex detection, while anything an app
linkified — agent CLIs render PR and issue numbers as OSC 8 — was dead on click.

## The frame stream is not the lossy part

Worth stating, since it decides where the fix belongs. Capturing `terminal.frame` off a live
`herdr terminal session observe` shows the sequence arriving intact:

```
\x1b[15;1H\x1b]8;;https://example.com/bbb\x1b\OSC8LABEL\x1b[16;1H\x1b]8;;\x1b\
```

herdr relays hyperlinks faithfully; they were being dropped on this side.

(Aside, in case it saves someone an hour: `herdr pane read --raw` is **not** a usable
observer here. It is itself lossy for OSC 8 — the label comes back bare even from a local
pane where the link works. I chased a false negative with it before capturing real frames.)

## The change

Track the active URI while parsing, hang it on each covered cell beside the SGR it already
carries, and re-emit it from `paint` on change. Non-hyperlink OSC keeps being skipped
byte-for-byte as before.

Two things follow from how the renderer works rather than from taste:

- **The URI lives on the cell**, not in renderer stream state, because rows are repainted
  individually from their own CUP and in arbitrary order — the same reason `sgr` is per-cell.
- **An open link is closed at the end of every row.** Left open it would swallow whatever is
  painted next, including the next row's content and the status bar.

A link spanning a wrap therefore opens once per row. Terminals handle that fine (both rows
resolve the right URI); it only forgoes the hover-grouping an `id=` parameter would give.

## Verification

End to end, on a real PTY, against the same live remote pane — the two binaries differ only
by this commit:

| binary | `ESC ] 8 ; ;` sequences emitted | `OSC8LABEL` text |
|---|---|---|
| stock 0.2.1 | **0** | present |
| this branch | **3 open + 3 close** | present |

Four unit tests cover capture-onto-cells, repaint, the `id=`/BEL form, non-hyperlink OSC
still being skipped, and the no-leak-past-row-end guard. `cargo test` 114 passed / 0 failed;
`cargo clippy --all-targets` clean.

Reproduced identically on three mirrored hosts before and after.

## Not covered here

- **Plain-text URLs that wrap** are still truncated — the other half of #43. `paint` writes an
  explicit CUP per row, clearing the deferred-wrap flag, and the frame format carries only
  absolute positions, so this side cannot tell a continuation row from a fresh one. That one
  needs wrap information in the frame, i.e. an upstream herdr change. Measured:
  `herdr pane read --source recent-unwrapped` returns a 229-char logical line in a local pane
  and 124 in a mirror pane. Note this fix does make wrapped *OSC 8* links work, since the URI
  is then carried explicitly rather than inferred from the text.
- **OSC 52** (#25) is untouched. It lands at the same drop site and could be relayed there,
  but it is a point event rather than cell state, so it wants its own change.

I did not reformat: `cargo fmt` wants 296 diffs repo-wide (including `grid.rs` above my
edits), so the tree clearly is not rustfmt-default on purpose. New code follows the
surrounding style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-session:b1827af0-e684-41c5-b98c-79467e190ce3 -->
🔖 **Claude agent:** missioncontrol-d7  
session id: `b1827af0-e684-41c5-b98c-79467e190ce3`