### PR TITLE
feat: per-host `max_cols`/`max_rows` cap on the size control asks the remote for

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,6 @@ set `always_control = false` (globally or per host). Its mirrors become
 read-only: a live view with zero effect on the remote that escalates to control
 when you type and auto-releases after 1h idle (`ctrl+\` releases immediately).
 
-Control is authoritative on the remote — the server resizes the remote pty to
-whatever the controlling client asks for — so on such a host a wide local window
-reflows a screen someone over there is reading, every time control escalates.
-Add `max_cols` / `max_rows` (globally or per host) to cap what control asks for:
-the remote keeps its own geometry and the unused part of your local pane simply
-stays blank. Uncapped by default, so headless remotes still fill the pane.
-
 **Close / restore** — by default, closing a mirror (`prefix+x`) also closes the
 pane/workspace on the remote (`close_remote_on_local_close`; set it false to
 only stop mirroring and leave the remote — and its agent — running). When the
@@ -294,11 +287,6 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
                          # idle release, and sized to your local pane so the
                          # remote fills it (ideal for headless remotes). Set
                          # false for read-only mirrors that escalate on type.
-# max_cols / max_rows    # unset by default = control fills your local pane.
-                         # Set to cap the size control asks the remote for, so a
-                         # remote with its own display keeps its own geometry
-                         # instead of reflowing to your window. Observe is never
-                         # capped (it doesn't resize anything).
 
 [hosts.work]
 target = "work"
@@ -306,9 +294,6 @@ target = "work"
 # remote_bin = "~/.local/bin/herdr"  # remote path if it's not on the remote PATH
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
-# max_cols = 212                     # per-host cap on the size control asks
-# max_rows = 58                      # for; pairs with always_control = false
-                                     # (that laptop's own terminal is 212x58)
 # enabled = true                     # false stops syncing this host without
                                      # deleting its config; mirrors stay put
 # api_transport = "auto"             # how to reach the remote API socket:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ set `always_control = false` (globally or per host). Its mirrors become
 read-only: a live view with zero effect on the remote that escalates to control
 when you type and auto-releases after 1h idle (`ctrl+\` releases immediately).
 
+Control is authoritative on the remote — the server resizes the remote pty to
+whatever the controlling client asks for — so on such a host a wide local window
+reflows a screen someone over there is reading, every time control escalates.
+Add `max_cols` / `max_rows` (globally or per host) to cap what control asks for:
+the remote keeps its own geometry and the unused part of your local pane simply
+stays blank. Uncapped by default, so headless remotes still fill the pane.
+
 **Close / restore** — by default, closing a mirror (`prefix+x`) also closes the
 pane/workspace on the remote (`close_remote_on_local_close`; set it false to
 only stop mirroring and leave the remote — and its agent — running). When the
@@ -269,6 +276,11 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
                          # idle release, and sized to your local pane so the
                          # remote fills it (ideal for headless remotes). Set
                          # false for read-only mirrors that escalate on type.
+# max_cols / max_rows    # unset by default = control fills your local pane.
+                         # Set to cap the size control asks the remote for, so a
+                         # remote with its own display keeps its own geometry
+                         # instead of reflowing to your window. Observe is never
+                         # capped (it doesn't resize anything).
 
 [hosts.work]
 target = "work"
@@ -276,6 +288,9 @@ target = "work"
 # remote_bin = "~/.local/bin/herdr"  # remote path if it's not on the remote PATH
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
+# max_cols = 212                     # per-host cap on the size control asks
+# max_rows = 58                      # for; pairs with always_control = false
+                                     # (that laptop's own terminal is 212x58)
 # enabled = true                     # false stops syncing this host without
                                      # deleting its config; mirrors stay put
 # api_transport = "auto"             # how to reach the remote API socket:

--- a/src/config.rs
+++ b/src/config.rs
@@ -263,16 +263,30 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     let global_always_control = raw.always_control.unwrap_or(true);
     // 0 is treated as unset rather than "clamp to nothing", same as an empty
     // remote_bin: a cap that would starve the remote of every column is a typo,
-    // not an instruction.
+    // not an instruction. Warn rather than dropping it silently — and say that
+    // it falls through, since 0 is NOT a way to un-cap one host under a global.
+    let mut warnings: Vec<String> = Vec::new();
     let size_cap = |v: Option<usize>| v.filter(|&n| n > 0);
+    for (key, v) in [("max_cols", raw.max_cols), ("max_rows", raw.max_rows)] {
+        if v == Some(0) {
+            warnings.push(format!("{key} = 0 ignored: 0 means unset, not \"cap to nothing\""));
+        }
+    }
     let global_max_cols = size_cap(raw.max_cols);
     let global_max_rows = size_cap(raw.max_rows);
     let mut hosts: Vec<HostConfig> = Vec::new();
-    let mut warnings: Vec<String> = Vec::new();
     for (name, value) in raw.hosts {
         let h: RawHost = value.try_into().map_err(|e| err(format!("[hosts.{name}]: {e}")))?;
         if h.enabled == Some(false) {
             continue;
+        }
+        for (key, v) in [("max_cols", h.max_cols), ("max_rows", h.max_rows)] {
+            if v == Some(0) {
+                warnings.push(format!(
+                    "[hosts.{name}]: {key} = 0 ignored; it falls through to any global cap \
+                     rather than clearing it"
+                ));
+            }
         }
         // Skip-with-warning, not abort. Aborting would let one typo'd entry
         // stop the daemon entirely and take every *other* host's mirrors down
@@ -635,5 +649,23 @@ mod tests {
         let e = load_config(&[a.clone(), b.clone()]).unwrap_err().to_string();
         assert!(e.contains(&a.join("hosts.toml").display().to_string()), "{e}");
         assert!(e.contains(&b.join("hosts.toml").display().to_string()), "{e}");
+    }
+
+    #[test]
+    fn a_zero_cap_warns_instead_of_vanishing() {
+        // silently dropping a typo'd cap leaves the user believing it applied
+        let c = parse_config("max_cols = 0\n[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert_eq!(c.hosts[0].max_cols, None);
+        assert!(c.warnings.iter().any(|w| w.contains("max_cols = 0 ignored")), "{:?}", c.warnings);
+
+        // and 0 per host is not a way to opt out of a global cap
+        let c =
+            parse_config("max_cols = 200\n[hosts.a]\ntarget = \"a\"\nmax_cols = 0\n").unwrap();
+        assert_eq!(c.hosts[0].max_cols, Some(200), "0 falls through to the global");
+        assert!(
+            c.warnings.iter().any(|w| w.contains("falls through to any global cap")),
+            "{:?}",
+            c.warnings
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,14 @@ pub struct HostConfig {
     /// the local pane so it fills). Default on; ideal for headless remotes. Turn
     /// off per host for a remote a human is actively using directly.
     pub always_control: bool,
+    /// Cap the size control asks the remote for. `None` = uncapped: fill the
+    /// local pane, which is right for a headless remote nobody looks at.
+    /// Control is authoritative on the remote, so on a host with its own
+    /// display an uncapped wide local window reflows a screen someone is
+    /// reading; capping renders the remote at its own width and leaves the rest
+    /// of the local pane blank instead. Observe is unaffected either way.
+    pub max_cols: Option<usize>,
+    pub max_rows: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -138,6 +146,8 @@ struct RawConfig {
     default_host: Option<String>,
     close_remote_on_local_close: Option<bool>,
     always_control: Option<bool>,
+    max_cols: Option<usize>,
+    max_rows: Option<usize>,
     // toml::Table (preserve_order) keeps declaration order — the first host
     // is the remote-create fallback, so order is user-visible
     #[serde(default)]
@@ -156,6 +166,8 @@ struct RawHost {
     remote_bin: Option<String>,
     enabled: Option<bool>,
     always_control: Option<bool>,
+    max_cols: Option<usize>,
+    max_rows: Option<usize>,
     api_transport: Option<String>,
 }
 
@@ -236,6 +248,12 @@ pub fn load_config(candidates: &[PathBuf]) -> Result<MirrorConfig> {
 pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     let raw: RawConfig = toml::from_str(text)?;
     let global_always_control = raw.always_control.unwrap_or(true);
+    // 0 is treated as unset rather than "clamp to nothing", same as an empty
+    // remote_bin: a cap that would starve the remote of every column is a typo,
+    // not an instruction.
+    let size_cap = |v: Option<usize>| v.filter(|&n| n > 0);
+    let global_max_cols = size_cap(raw.max_cols);
+    let global_max_rows = size_cap(raw.max_rows);
     let mut hosts: Vec<HostConfig> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
     for (name, value) in raw.hosts {
@@ -272,6 +290,8 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             // empty string is treated as unset (auto PATH → ~/.local/bin/herdr)
             remote_bin: h.remote_bin.filter(|s| !s.is_empty()),
             always_control: h.always_control.unwrap_or(global_always_control),
+            max_cols: size_cap(h.max_cols).or(global_max_cols),
+            max_rows: size_cap(h.max_rows).or(global_max_rows),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
             api_transport,
             kind,
@@ -339,6 +359,41 @@ mod tests {
         let b = c.hosts.iter().find(|h| h.name == "b").unwrap();
         assert!(!a.always_control); // inherits global off
         assert!(b.always_control); // per-host override on
+    }
+
+    #[test]
+    fn size_caps_default_off_and_override_per_host() {
+        // nothing set anywhere: uncapped, i.e. today's fill-the-pane behaviour
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert_eq!(c.hosts[0].max_cols, None);
+        assert_eq!(c.hosts[0].max_rows, None);
+
+        // global cap, one host narrowing it further
+        let c = parse_config(
+            "max_cols = 200\n\
+             [hosts.a]\ntarget = \"a\"\n\
+             [hosts.b]\ntarget = \"b\"\nmax_cols = 120\nmax_rows = 40\n",
+        )
+        .unwrap();
+        let a = c.hosts.iter().find(|h| h.name == "a").unwrap();
+        let b = c.hosts.iter().find(|h| h.name == "b").unwrap();
+        assert_eq!(a.max_cols, Some(200)); // inherits the global cap
+        assert_eq!(a.max_rows, None); // rows were never capped
+        assert_eq!(b.max_cols, Some(120)); // per-host override
+        assert_eq!(b.max_rows, Some(40));
+    }
+
+    /// A cap of 0 would starve the remote of every column. Treat it as unset,
+    /// the same way an empty remote_bin means "auto" rather than "no binary".
+    #[test]
+    fn a_zero_cap_is_unset_not_a_clamp_to_nothing() {
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\nmax_cols = 0\nmax_rows = 0\n").unwrap();
+        assert_eq!(c.hosts[0].max_cols, None);
+        assert_eq!(c.hosts[0].max_rows, None);
+
+        // and a zeroed per-host value falls back to the global, not to the zero
+        let c = parse_config("max_cols = 200\n[hosts.a]\ntarget = \"a\"\nmax_cols = 0\n").unwrap();
+        assert_eq!(c.hosts[0].max_cols, Some(200));
     }
 
     #[test]

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -355,6 +355,8 @@ pub(crate) fn cmd_for_pane(
     let target = host.target.clone();
     let remote_bin = host.remote_bin.clone();
     let always_control = host.always_control;
+    let max_cols = host.max_cols;
+    let max_rows = host.max_rows;
     let kind = host.kind.clone();
     let docker_bin = host.docker_bin.clone();
     // daemon's ControlMaster socket for this host (see remote.rs); the streamer
@@ -375,6 +377,13 @@ pub(crate) fn cmd_for_pane(
         }
         if always_control {
             argv.push("--always-control".into());
+        }
+        // absent when uncapped, so the argv of an unconfigured host is unchanged
+        if let Some(c) = max_cols {
+            argv.extend(["--max-cols".into(), c.to_string()]);
+        }
+        if let Some(r) = max_rows {
+            argv.extend(["--max-rows".into(), r.to_string()]);
         }
         // ssh only: the pane reuses the daemon's ControlMaster for cheap
         // foreground polls. Docker has no ControlMaster, and healing no longer
@@ -1510,6 +1519,8 @@ mod tests {
             prefix: "vps".into(),
             remote_bin: None,
             always_control: true,
+            max_cols: None,
+            max_rows: None,
             api_transport: crate::config::ApiTransport::Auto,
         }
     }
@@ -1699,6 +1710,26 @@ mod tests {
             argv[1..],
             ["pane", "vps", "w1:p1", "--ctl-path", "/state/vps.ctl"]
         );
+    }
+
+    /// An uncapped host's argv must not grow, and a capped one must round-trip
+    /// through the same parser the daemon's child uses.
+    #[test]
+    fn size_caps_reach_the_streamer_argv() {
+        let mut host = ssh_host();
+        host.always_control = false;
+        let uncapped = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        assert!(!uncapped.iter().any(|a| a == "--max-cols" || a == "--max-rows"));
+
+        host.max_cols = Some(212);
+        host.max_rows = Some(58);
+        let argv = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
+        assert_eq!(parsed.max_cols, Some(212));
+        assert_eq!(parsed.max_rows, Some(58));
+        // the caps are a ceiling on control only — the observe request size is
+        // still whatever --cols/--rows said (here: unset, so the default)
+        assert!(!parsed.size_fixed);
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -125,13 +125,17 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                     next("--control-idle")?.parse().map_err(|_| err("--control-idle must be a number"))?
             }
             "--always-control" => args.always_control = true,
+            // 0 is unset here for the same reason config treats it that way:
+            // a zero cap would ask the remote for a zero-column terminal, which
+            // herdr rejects outright, killing the session twice over and
+            // stranding the pane in "control unavailable" over a typo.
             "--max-cols" => {
-                args.max_cols =
-                    Some(next("--max-cols")?.parse().map_err(|_| err("--max-cols must be a number"))?)
+                args.max_cols = Some(next("--max-cols")?.parse().map_err(|_| err("--max-cols must be a number"))?)
+                    .filter(|&n| n > 0)
             }
             "--max-rows" => {
-                args.max_rows =
-                    Some(next("--max-rows")?.parse().map_err(|_| err("--max-rows must be a number"))?)
+                args.max_rows = Some(next("--max-rows")?.parse().map_err(|_| err("--max-rows must be a number"))?)
+                    .filter(|&n| n > 0)
             }
             "--ctl-path" => args.ctl_path = Some(next("--ctl-path")?),
             "--container" => container_name = Some(next("--container")?),
@@ -1540,6 +1544,23 @@ mod tests {
         assert_eq!(observe_size_for(&a, (40, 20)), (70, 31));
         // --dump has no tty: exactly what was asked for
         assert_eq!(observe_size_for(&a, (0, 0)), (70, 31));
+    }
+
+    #[test]
+    fn a_zero_cap_on_the_cli_is_unset_not_a_zero_request() {
+        // herdr rejects a 0-column terminal, so a typo would kill the session
+        // twice and strand the pane in "control unavailable"
+        let argv: Vec<String> = ["h", "w1:p1", "--max-cols", "0", "--max-rows", "0"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let a = parse_args(&argv).unwrap();
+        assert_eq!(a.max_cols, None);
+        assert_eq!(a.max_rows, None);
+
+        let argv: Vec<String> =
+            ["h", "w1:p1", "--max-cols", "212"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(parse_args(&argv).unwrap().max_cols, Some(212));
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -15,6 +15,10 @@
 //   --control-idle N    auto-release control after N seconds idle (default 3600)
 //   --always-control    start and stay in control: writable, no idle release,
 //                       and sized to the local pane so it fills
+//   --max-cols N        cap the size control asks the remote for (default:
+//   --max-rows N        uncapped — control fills the local pane). Set for a
+//                       remote with its own display: the remote keeps its own
+//                       geometry and the rest of the local pane stays blank.
 //
 // Every stream gets its own direct ssh connection (no shared ControlMaster):
 // isolated, and nothing persists to go stale on a flaky network.
@@ -62,6 +66,11 @@ pub struct Args {
     /// start and stay in control: writable, no idle release, and sized to the
     /// local pane so it fills. Set by the daemon from per-host config.
     pub always_control: bool,
+    /// upper bound on the size control asks the remote for. `None` = uncapped
+    /// (fill the local pane). Set by the daemon from per-host config; observe
+    /// is never capped, since it doesn't resize anything.
+    pub max_cols: Option<usize>,
+    pub max_rows: Option<usize>,
     /// daemon's ssh ControlMaster socket for this host; foreground polls reuse it
     /// (`ssh -S <path>`) to skip a handshake. None → polls connect directly.
     ///
@@ -91,6 +100,8 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
         control_idle_secs: 3600,
         size_fixed: false,
         always_control: false,
+        max_cols: None,
+        max_rows: None,
         ctl_path: None,
         container: None,
     };
@@ -119,6 +130,14 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                     next("--control-idle")?.parse().map_err(|_| err("--control-idle must be a number"))?
             }
             "--always-control" => args.always_control = true,
+            "--max-cols" => {
+                args.max_cols =
+                    Some(next("--max-cols")?.parse().map_err(|_| err("--max-cols must be a number"))?)
+            }
+            "--max-rows" => {
+                args.max_rows =
+                    Some(next("--max-rows")?.parse().map_err(|_| err("--max-rows must be a number"))?)
+            }
             "--ctl-path" => args.ctl_path = Some(next("--ctl-path")?),
             "--container" => container_name = Some(next("--container")?),
             "--container-folder" => container_folder = Some(next("--container-folder")?),
@@ -130,7 +149,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
     }
     if positional.len() != 2 {
         return Err(err(
-            "usage: herdr-mirror pane <ssh-target> <pane-target> [--remote-bin PATH] [--cols N --rows N] [--dump]",
+            "usage: herdr-mirror pane <ssh-target> <pane-target> [--remote-bin PATH] [--cols N --rows N] [--max-cols N --max-rows N] [--dump]",
         ));
     }
     args.container = match (container_name, container_folder) {
@@ -322,6 +341,19 @@ const HERDR_NO_CLIENT_LAYOUT: (usize, usize) = (80, 24);
 /// resize. It self-heals the moment a client attaches.
 fn size_is_trusted((cols, rows): (usize, usize)) -> bool {
     cols > HERDR_NO_CLIENT_LAYOUT.0 || rows > HERDR_NO_CLIENT_LAYOUT.1
+}
+
+/// Clamp a local terminal size to the per-host control caps. Split out from
+/// `control_size` so the arithmetic is testable without an `App`.
+fn cap_size(
+    (cols, rows): (usize, usize),
+    max_cols: Option<usize>,
+    max_rows: Option<usize>,
+) -> (usize, usize) {
+    (
+        max_cols.map_or(cols, |cap| cols.min(cap)),
+        max_rows.map_or(rows, |cap| rows.min(cap)),
+    )
 }
 
 /// Mode to open with. Split out from `run` so the composition is testable.
@@ -626,6 +658,16 @@ impl App {
         (self.args.cols.max(c), self.args.rows.max(r))
     }
 
+    /// Size to enter (and stay in) control at. Control is authoritative on the
+    /// remote — the server resizes the remote pty to whatever we ask for — so a
+    /// host whose remote has its own display caps this and renders the remote at
+    /// its own geometry, leaving the rest of the local pane blank rather than
+    /// reflowing a screen someone over there is reading. Uncapped by default,
+    /// which is the pre-existing fill-the-pane behaviour.
+    fn control_size(&self) -> (usize, usize) {
+        cap_size(term_size(), self.args.max_cols, self.args.max_rows)
+    }
+
     /// Stop the child (clean release first for control) — never leave an
     /// orphan holding the remote attach lock.
     fn stop_session(&mut self) {
@@ -646,7 +688,7 @@ impl App {
         self.predict = Predictor::new();
         let (cols, rows) = match m {
             Mode::Observe => self.observe_size(),
-            Mode::Control => term_size(),
+            Mode::Control => self.control_size(),
         };
         if let Some(s) = self.session.take() {
             unsafe { libc::kill(s.pid, libc::SIGTERM) };
@@ -1028,7 +1070,9 @@ pub async fn run(args: Args) -> Result<()> {
                     app.switch_mode(Mode::Control);
                 }
                 if app.mode == Mode::Control {
-                    let (cols, rows) = term_size();
+                    // capped like the initial connect: a local window drag must
+                    // not push a capped host past its ceiling either
+                    let (cols, rows) = app.control_size();
                     app.send(json!({ "type": "terminal.resize", "cols": cols, "rows": rows })).await;
                 }
                 app.paint();
@@ -1094,6 +1138,27 @@ pub async fn run(args: Args) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Uncapped must stay byte-identical to the old `term_size()` call, or
+    /// every existing headless-remote config silently changes behaviour.
+    #[test]
+    fn uncapped_control_size_is_the_local_size() {
+        assert_eq!(cap_size((253, 50), None, None), (253, 50));
+    }
+
+    #[test]
+    fn caps_only_bite_when_the_local_pane_is_bigger() {
+        // the real case: local 253 cols vs a laptop that renders at 212
+        assert_eq!(cap_size((253, 50), Some(212), Some(58)), (212, 50));
+        // a local pane smaller than the cap is left alone — a cap is a ceiling,
+        // never a demand for a size the local window can't show
+        assert_eq!(cap_size((120, 30), Some(212), Some(58)), (120, 30));
+        // one axis capped, the other free
+        assert_eq!(cap_size((253, 50), Some(212), None), (212, 50));
+        assert_eq!(cap_size((253, 90), None, Some(58)), (253, 58));
+        // equal is not clamped away
+        assert_eq!(cap_size((212, 58), Some(212), Some(58)), (212, 58));
+    }
 
     #[test]
     fn wheel_always_semantic_scroll_even_on_tui_foreground() {


### PR DESCRIPTION
Closes #47.

### Problem

Control is authoritative on the remote — `pane.rs` says so explicitly at the top of `run()`: *"the server resizes the remote pty to whatever we ask for, beating even a larger live client over there."* But both places that send a control size asked for `term_size()` unconditionally:

- `connect()` — `Mode::Control => term_size()`
- the `sigwinch` arm — `let (cols, rows) = term_size();`

So on a host with `always_control = false` — a laptop with its own display and a human sitting at it — every control escalation drags that machine's pane to my local geometry (measured here: **58×212 → 50×253**), rewrapping every long line on a screen someone is reading. An hour later control auto-releases and it reflows back.

`Observe` already has an escape hatch for exactly this shape of problem (`size_fixed` / `observe_size()`). `Control` had no equivalent, and `HostConfig` carried nothing about size at all, so the only workaround was to physically resize my local terminal until `stty size` reported 212 columns — which reverts the next time that window is maximised.

### Change

Optional `max_cols` / `max_rows`, global with a per-host override, in the same shape as `always_control`:

```toml
[hosts.macbook]
target = "macbook"
always_control = false
max_cols = 212
max_rows = 58
```

- **Ceilings, not demands.** A local pane smaller than the cap is left alone.
- **Unset by default.** An uncapped host's streamer argv and requested size are byte-identical to before — headless remotes keep filling the pane, and there's a test asserting exactly that.
- **`0` is treated as unset**, not as a clamp to nothing, matching how an empty `remote_bin` means "auto" rather than "no binary".
- **Control only.** Observe never resizes anything, so it is never capped.
- The clamp lives in a free `cap_size()` so the arithmetic is testable without an `App`, and it is applied in *both* send sites — the initial connect and the window-resize path — so dragging the local window can't push a capped host past its ceiling either.

### Tests

5 new, all green (`cargo test`: 115 passed, 0 failed; `cargo clippy --all-targets` clean):

| test | asserts |
|---|---|
| `pane::uncapped_control_size_is_the_local_size` | uncapped is identical to the old `term_size()` behaviour |
| `pane::caps_only_bite_when_the_local_pane_is_bigger` | ceiling semantics, one-axis caps, equality not clamped |
| `config::size_caps_default_off_and_override_per_host` | global default + per-host narrowing |
| `config::a_zero_cap_is_unset_not_a_clamp_to_nothing` | `0` falls through to the global / to unset |
| `mirror::size_caps_reach_the_streamer_argv` | uncapped argv doesn't grow; capped round-trips through `parse_args` |

I deliberately did **not** run `cargo fmt` — the tree isn't default-rustfmt clean (every file reports diffs), so formatting it would have buried this change. The new code follows the surrounding hand style.

### Notes

Related in spirit to #23, though the failure direction is the opposite one: there, control was entered at a size too small to vouch for; here it's entered at one that's legitimate locally but too large for the remote's own human.

Tested on herdr 0.8.0, one ssh host (`always_control = false`), local herdr in Windows Terminal on WSL at 50×253 against a macOS remote at 58×212.

One thing I want to be explicit about since I mentioned it in the issue: I originally suspected this reflow was breaking Moshi's remote-approval screen verification, and my own data refuted that — an approval verified fine across a 41-column mismatch. This is an ergonomics change, not a correctness fix, and I didn't want to sell it to you as more than it is.
