### PR TITLE
feat: support herdr named sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Then create the config at `~/.config/herdr-mirror/hosts.toml`:
 
 ```toml
 [hosts.work]
-target = "work"         # anything ssh accepts: alias, user@host, ssh://host:2222
-session = "project"     # optional: same target as `herdr --session project`
+target = "work"        # anything ssh accepts: alias, user@host, ssh://host:2222
 ```
 
 That's it — the daemon autostarts when you focus a workspace, so within a few
@@ -275,7 +274,6 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
 target = "work"
 # prefix = "work"                    # sidebar prefix (default: the host key)
 # remote_bin = "~/.local/bin/herdr"  # remote path if it's not on the remote PATH
-# session = "work"                    # Herdr session name on this host
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
 # enabled = true                     # false stops syncing this host without

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Then create the config at `~/.config/herdr-mirror/hosts.toml`:
 
 ```toml
 [hosts.work]
-target = "work"        # anything ssh accepts: alias, user@host, ssh://host:2222
+target = "work"         # anything ssh accepts: alias, user@host, ssh://host:2222
+session = "project"     # optional: same target as `herdr --session project`
 ```
 
 That's it — the daemon autostarts when you focus a workspace, so within a few
@@ -274,6 +275,7 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
 target = "work"
 # prefix = "work"                    # sidebar prefix (default: the host key)
 # remote_bin = "~/.local/bin/herdr"  # remote path if it's not on the remote PATH
+# session = "work"                    # Herdr session name on this host
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
 # enabled = true                     # false stops syncing this host without

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,13 +7,15 @@ use serde::Deserialize;
 
 use crate::util::{err, Result};
 
-/// Shell expression for `exec <expr> ...` on the remote.
+/// Shell expression for `exec <expr> <command> ...` on the remote.
 ///
 /// A configured path is used as-is (unquoted so remote-shell `~` expands).
 /// When unset, `herdr` is resolved via PATH, falling back to
-/// `~/.local/bin/herdr` if `command -v` finds nothing.
-pub fn remote_bin_expr(remote_bin: Option<&str>) -> String {
-    match remote_bin {
+/// `~/.local/bin/herdr` if `command -v` finds nothing. A configured session is
+/// added as Herdr's global `--session` option so every remote command selects
+/// the same server.
+pub fn remote_herdr_expr(remote_bin: Option<&str>, session: Option<&str>) -> String {
+    let bin = match remote_bin {
         Some(b) if !b.is_empty() => b.to_string(),
         // The `$(...)` substitution must run under a POSIX sh, never the remote
         // login shell: `ssh host cmd` hands the string to that shell, and fish
@@ -24,7 +26,15 @@ pub fn remote_bin_expr(remote_bin: Option<&str>) -> String {
         // substitution prevent word-splitting if the resolved path contains
         // spaces; ~ still expands inside the unquoted `echo` arg.
         _ => "sh -c 'exec \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\" \"$@\"' herdr".into(),
+    };
+    match session {
+        Some(session) => format!("{bin} --session {}", shell_quote(session)),
+        None => bin,
     }
+}
+
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 /// How to reach a host. `Ssh` is the default and the only kind that existed
@@ -87,8 +97,10 @@ pub struct HostConfig {
     pub docker_bin: String,
     pub prefix: String,
     /// Remote herdr binary. `None` = auto-resolve on the remote: PATH first
-    /// (`command -v herdr`), then `~/.local/bin/herdr`. See `remote_bin_expr`.
+    /// (`command -v herdr`), then `~/.local/bin/herdr`. See `remote_herdr_expr`.
     pub remote_bin: Option<String>,
+    /// Herdr session name on the remote. `None` selects the default session.
+    pub session: Option<String>,
     /// ssh hosts only; see `ApiTransport`. Default `Auto`.
     pub api_transport: ApiTransport,
     /// keep each mirror pane in control (writable, no idle release, and sized to
@@ -154,6 +166,7 @@ struct RawHost {
     docker_bin: Option<String>,
     prefix: Option<String>,
     remote_bin: Option<String>,
+    session: Option<String>,
     enabled: Option<bool>,
     always_control: Option<bool>,
     api_transport: Option<String>,
@@ -271,6 +284,7 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             prefix: h.prefix.unwrap_or_else(|| name.clone()),
             // empty string is treated as unset (auto PATH → ~/.local/bin/herdr)
             remote_bin: h.remote_bin.filter(|s| !s.is_empty()),
+            session: h.session.filter(|s| !s.is_empty()),
             always_control: h.always_control.unwrap_or(global_always_control),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
             api_transport,
@@ -323,6 +337,7 @@ mod tests {
         assert_eq!(h.name, "work");
         assert_eq!(h.prefix, "work");
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
+        assert_eq!(h.session, None); // default remote session
         assert!(h.always_control); // default on
     }
 
@@ -347,6 +362,7 @@ mod tests {
             "autostart = false\npoll_seconds = 30\ndefault_host = \"vps\"\n\
              [hosts.vps]\ntarget = \"ssh://niko@203.0.113.7:2222\"\nprefix = \"v\"\n\
              remote_bin = \"/opt/herdr\"\n\
+             session = \"work\"\n\
              [hosts.off]\ntarget = \"x\"\nenabled = false\n",
         )
         .unwrap();
@@ -355,6 +371,7 @@ mod tests {
         assert_eq!(c.hosts.len(), 1);
         assert_eq!(c.hosts[0].prefix, "v");
         assert_eq!(c.hosts[0].remote_bin.as_deref(), Some("/opt/herdr"));
+        assert_eq!(c.hosts[0].session.as_deref(), Some("work"));
         assert_eq!(c.default_host().unwrap().name, "vps");
     }
 
@@ -387,15 +404,23 @@ mod tests {
         assert_eq!(c.hosts[0].kind, HostKind::Ssh);
         assert_eq!(c.hosts[0].target, "work");
         assert_eq!(c.hosts[0].remote_bin, None);
+        assert_eq!(c.hosts[0].session, None);
     }
 
     #[test]
-    fn remote_bin_expr_configured_vs_auto() {
-        assert_eq!(remote_bin_expr(Some("/opt/herdr")), "/opt/herdr");
-        assert_eq!(remote_bin_expr(Some("~/.local/bin/herdr")), "~/.local/bin/herdr");
+    fn remote_herdr_expr_configured_vs_auto_and_session() {
+        assert_eq!(remote_herdr_expr(Some("/opt/herdr"), None), "/opt/herdr");
+        assert_eq!(
+            remote_herdr_expr(Some("~/.local/bin/herdr"), Some("work")),
+            "~/.local/bin/herdr --session 'work'"
+        );
         let auto = "sh -c 'exec \"$(command -v herdr 2>/dev/null || echo ~/.local/bin/herdr)\" \"$@\"' herdr";
-        assert_eq!(remote_bin_expr(None), auto);
-        assert_eq!(remote_bin_expr(Some("")), auto);
+        assert_eq!(remote_herdr_expr(None, None), auto);
+        assert_eq!(remote_herdr_expr(Some(""), None), auto);
+        assert_eq!(
+            remote_herdr_expr(None, Some("team's")),
+            format!("{auto} --session 'team'\\''s'")
+        );
     }
 
     #[test]

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -180,7 +180,7 @@ impl Container {
     /// never sources `/etc/profile*`. Matching that matters because the output
     /// is parsed as JSON — an image whose profile prints a welcome banner would
     /// otherwise make every connect fail with "expected value at line 1
-    /// column 1". Tilde expansion and `command -v` in `remote_bin_expr` work
+    /// column 1". Tilde expansion and `command -v` in `remote_herdr_expr` work
     /// either way.
     pub async fn exec(&self, command: &str, timeout_ms: u64) -> Result<String> {
         let fut = Command::new(&self.docker_bin)

--- a/src/foreground.rs
+++ b/src/foreground.rs
@@ -47,12 +47,13 @@ pub fn classify(json: &str) -> Option<bool> {
 pub async fn poll(
     ssh_target: &str,
     remote_bin: Option<&str>,
+    session: Option<&str>,
     pane: &str,
     ctl_path: Option<&str>,
     container: Option<&crate::pane::ContainerArg>,
 ) -> Option<bool> {
     // same expression as the observe session (configured path or PATH auto)
-    let bin = crate::config::remote_bin_expr(remote_bin);
+    let bin = crate::config::remote_herdr_expr(remote_bin, session);
     let cmd = format!("exec {} pane process-info --pane {}", bin, sh_quote(pane));
     let mut sc = match container {
         Some(ct) => {

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -354,6 +354,7 @@ pub(crate) fn cmd_for_pane(
         .unwrap_or_else(|_| "herdr-mirror".into());
     let target = host.target.clone();
     let remote_bin = host.remote_bin.clone();
+    let session = host.session.clone();
     let always_control = host.always_control;
     let kind = host.kind.clone();
     let docker_bin = host.docker_bin.clone();
@@ -372,6 +373,9 @@ pub(crate) fn cmd_for_pane(
         // defaults to the same resolution so the argv stays short
         if let Some(bin) = &remote_bin {
             argv.extend(["--remote-bin".into(), bin.clone()]);
+        }
+        if let Some(session) = &session {
+            argv.extend(["--session".into(), session.clone()]);
         }
         if always_control {
             argv.push("--always-control".into());
@@ -1509,6 +1513,7 @@ mod tests {
             docker_bin: "docker".into(),
             prefix: "vps".into(),
             remote_bin: None,
+            session: None,
             always_control: true,
             api_transport: crate::config::ApiTransport::Auto,
         }
@@ -1636,6 +1641,29 @@ mod tests {
                 "/state/vps.ctl",
             ]
         );
+    }
+
+    #[test]
+    fn ssh_pane_argv_carries_remote_session() {
+        let mut host = ssh_host();
+        host.session = Some("work".into());
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let argv = cmd("w1:p1");
+        assert_eq!(
+            argv[1..],
+            [
+                "pane",
+                "vps",
+                "w1:p1",
+                "--session",
+                "work",
+                "--always-control",
+                "--ctl-path",
+                "/state/vps.ctl",
+            ]
+        );
+        let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
+        assert_eq!(parsed.session.as_deref(), Some("work"));
     }
 
     /// Docker hosts append their flags *after* the ssh-shaped prefix, so the

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -125,7 +125,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
     }
     if positional.len() != 2 {
         return Err(err(
-            "usage: herdr-mirror pane <ssh-target> <pane-target> [--remote-bin PATH] [--cols N --rows N] [--dump]",
+            "usage: herdr-mirror pane <ssh-target> <pane-target> [--remote-bin PATH] [--session NAME] [--cols N --rows N] [--dump]",
         ));
     }
     args.container = match (container_name, container_folder) {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -49,7 +49,7 @@ pub struct Args {
     pub ssh_target: String,
     pub pane_target: String,
     /// Configured remote herdr path. `None` = auto-resolve on the remote
-    /// (PATH, then `~/.local/bin/herdr`). See `config::remote_bin_expr`.
+    /// (PATH, then `~/.local/bin/herdr`). See `config::remote_herdr_expr`.
     pub remote_bin: Option<String>,
     pub cols: usize,
     pub rows: usize,
@@ -200,19 +200,16 @@ pub(crate) fn sh_quote(s: &str) -> String {
 }
 
 fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx: mpsc::Sender<Msg>) -> Result<Session> {
-    let session_flag = args
-        .session
-        .as_ref()
-        .map(|s| format!(" --session {}", sh_quote(s)))
-        .unwrap_or_default();
     // Configured paths stay unquoted so remote-shell ~ expands; auto mode is an
     // `sh -c` resolver that takes the trailing words as "$@" (see
-    // config::remote_bin_expr).
-    let bin = crate::config::remote_bin_expr(args.remote_bin.as_deref());
+    // config::remote_herdr_expr).
+    let bin = crate::config::remote_herdr_expr(
+        args.remote_bin.as_deref(),
+        args.session.as_deref(),
+    );
     let cmd = format!(
-        "exec {}{} terminal session {} {} --cols {} --rows {}",
+        "exec {} terminal session {} {} --cols {} --rows {}",
         bin,
-        session_flag,
         mode.as_str(),
         sh_quote(&args.pane_target),
         cols,
@@ -557,6 +554,7 @@ impl App {
         let tx = self.tx.clone();
         let ssh = self.args.ssh_target.clone();
         let bin = self.args.remote_bin.clone();
+        let session = self.args.session.clone();
         let pane = self.args.pane_target.clone();
         let ctl = self.args.ctl_path.clone();
         let container = self.args.container.clone();
@@ -564,6 +562,7 @@ impl App {
             let v = crate::foreground::poll(
                 &ssh,
                 bin.as_deref(),
+                session.as_deref(),
                 &pane,
                 ctl.as_deref(),
                 container.as_ref(),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -358,7 +358,14 @@ impl RemoteHost {
         let socket = parsed.server.and_then(|s| s.socket).unwrap_or_default();
         let mut status = RemoteStatus { socket, supported: false, reason: None };
         if !running {
-            status.reason = Some("remote herdr server is not running".into());
+            // Name the session, or this reads as "that machine's herdr is
+            // down" while the default session is running perfectly and only
+            // the configured one is stopped — which is the common way to get
+            // here once `session` is in play (a typo, or `herdr session stop`).
+            status.reason = Some(match &self.cfg.session {
+                Some(name) => format!("remote herdr session {name:?} is not running"),
+                None => "remote herdr server is not running".into(),
+            });
             return Ok(status);
         }
         match version_supported(&version) {
@@ -602,6 +609,7 @@ mod tests {
             docker_bin: "docker".into(),
             prefix: name.into(),
             remote_bin: None,
+            session: None,
             api_transport: ApiTransport::Auto,
             always_control: true,
         }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -250,7 +250,10 @@ impl RemoteHost {
     }
 
     pub async fn status(&self) -> Result<RemoteStatus> {
-        let bin = crate::config::remote_bin_expr(self.cfg.remote_bin.as_deref());
+        let bin = crate::config::remote_herdr_expr(
+            self.cfg.remote_bin.as_deref(),
+            self.cfg.session.as_deref(),
+        );
         let out = self.exec(&format!("exec {} status --json", bin), 15000).await?;
         #[derive(Deserialize)]
         struct Client {


### PR DESCRIPTION
herdr [supports named sessions](https://herdr.dev/docs/cli-reference/#launch-and-status), either via the `--session` cli arg or with the `HERDR_SESSION` env var. herdr-mirror currently does not connect to named sessions correctly, it always uses the default herdr session. This PR adds support for named sessions.

This can be set on a per-host basis, e.g.

```
[hosts.work]
target = "work"
session = "agent-1"
```