### PR TITLE
feat: upload dropped files and paste their remote paths

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -181,6 +181,7 @@ enum Msg {
     /// Some(false)=TUI, None=poll failed (keep last value)
     Foreground(Option<bool>),
     Paste(crate::paste::Outcome),
+    Drop(crate::paste::DropResult),
 }
 
 struct Session {
@@ -462,6 +463,85 @@ fn contains_wheel_press(bytes: &[u8]) -> bool {
     false
 }
 
+/// Cap on a partially-received bracketed paste. Past this we stop waiting for
+/// a terminator and flush what we have: a huge paste is still forwarded, it
+/// just loses the drop treatment rather than buffering without bound.
+const MAX_PASTE_BYTES: usize = 1024 * 1024;
+
+const PASTE_START: &[u8] = b"\x1b[200~";
+const PASTE_END: &[u8] = b"\x1b[201~";
+
+/// Input held back while an upload is in flight (see `route_input`).
+enum Queued {
+    Raw(Vec<u8>),
+    Body(Vec<u8>),
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum PasteSplit {
+    /// a paste has begun but not finished; nothing to do yet
+    Pending,
+    /// no paste involved: forward as-is
+    Passthrough(Vec<u8>),
+    Complete { before: Vec<u8>, body: Vec<u8>, after: Vec<u8> },
+}
+
+fn find_seq(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Longest suffix of `hay` that is a *proper* prefix of `needle`, so a marker
+/// straddling two reads is held rather than forwarded in pieces.
+fn trailing_partial(hay: &[u8], needle: &[u8]) -> usize {
+    (1..needle.len().min(hay.len()) + 1)
+        .rev()
+        .find(|&n| n < needle.len() && hay[hay.len() - n..] == needle[..n])
+        .unwrap_or(0)
+}
+
+/// Pull the next complete bracketed paste out of `buf` + `chunk`.
+///
+/// Pure so the framing can be table-tested without a pane: every interesting
+/// case (split reads, a START with no END, bytes either side, several pastes
+/// in one read, the oversize flush) lives here rather than in the event loop.
+pub(crate) fn split_paste(buf: &mut Vec<u8>, chunk: Vec<u8>) -> PasteSplit {
+    // fast path for ordinary typing: nothing buffered and no marker starting
+    if buf.is_empty()
+        && find_seq(&chunk, PASTE_START).is_none()
+        && trailing_partial(&chunk, PASTE_START) == 0
+    {
+        return PasteSplit::Passthrough(chunk);
+    }
+    buf.extend_from_slice(&chunk);
+
+    // a paste that never terminates must not buffer without bound
+    if buf.len() > MAX_PASTE_BYTES {
+        return PasteSplit::Passthrough(std::mem::take(buf));
+    }
+
+    let Some(start) = find_seq(buf, PASTE_START) else {
+        // hold only a possible partial marker; release everything before it
+        let keep = trailing_partial(buf, PASTE_START);
+        let cut = buf.len() - keep;
+        if cut == 0 {
+            return PasteSplit::Pending;
+        }
+        let tail = buf.split_off(cut);
+        let head = std::mem::replace(buf, tail);
+        return PasteSplit::Passthrough(head);
+    };
+    let Some(end) = find_seq(&buf[start..], PASTE_END).map(|i| start + i) else {
+        return PasteSplit::Pending;
+    };
+
+    let all = std::mem::take(buf);
+    PasteSplit::Complete {
+        before: all[..start].to_vec(),
+        body: all[start + PASTE_START.len()..end].to_vec(),
+        after: all[end + PASTE_END.len()..].to_vec(),
+    }
+}
+
 fn has_mouse_seq(bytes: &[u8]) -> bool {
     bytes.windows(3).any(|w| w == [0x1b, b'[', b'<'])
 }
@@ -515,6 +595,13 @@ struct App {
     /// to match the remote's so forwarded arrows arrive in the form it expects
     app_cursor_keys: bool,
     paste_inflight: bool,
+    /// partially-received bracketed paste (see `intercept_paste`)
+    paste_buf: Vec<u8>,
+    /// input held back while an upload is in flight, flushed in order after
+    paste_queue: Vec<Queued>,
+    /// the payload that started the in-flight upload, so it can be forwarded
+    /// unchanged when every path turns out to exist on the remote already
+    paste_original: Option<Vec<u8>>,
 }
 
 /// minimum spacing between foreground polls — each is an ssh handshake, so we
@@ -553,6 +640,15 @@ impl App {
         self.renderer.status(text);
         self.paint();
         self.hint_clear_at = Some(Instant::now() + Duration::from_millis(1500));
+    }
+
+    /// A hint with no expiry, for work whose duration we don't know: an upload
+    /// can outlast the usual 1.5s and the pane would otherwise look idle while
+    /// it is busy. Whoever set it replaces it when the work resolves.
+    fn hint_sticky(&mut self, text: &str) {
+        self.renderer.status(text);
+        self.paint();
+        self.hint_clear_at = None;
     }
 
     /// Kick a background poll of the remote pane's foreground process, throttled
@@ -784,7 +880,110 @@ impl App {
         }
     }
 
-    async fn handle_stdin(&mut self, buf: Vec<u8>) {
+    /// Drain every complete paste in this chunk, in order.
+    ///
+    /// Deliberately a loop, not a one-shot: two drops land in a single read
+    /// with nothing between them (a drop carries no terminator at all — which
+    /// is precisely why `run` asks for DECSET 2004), so handling only the
+    /// first would silently swallow the second, and leave its markers in the
+    /// tail to be forwarded raw at the remote.
+    async fn handle_stdin(&mut self, chunk: Vec<u8>) {
+        let mut chunk = chunk;
+        loop {
+            match split_paste(&mut self.paste_buf, chunk) {
+                PasteSplit::Pending => return,
+                PasteSplit::Passthrough(bytes) => return self.route_input(bytes).await,
+                PasteSplit::Complete { before, body, after } => {
+                    self.route_input(before).await;
+                    self.route_paste_body(body).await;
+                    if after.is_empty() {
+                        return;
+                    }
+                    chunk = after;
+                }
+            }
+        }
+    }
+
+    /// Ordinary input, held back while an upload is in flight so the pasted
+    /// remote paths cannot be overtaken by whatever was typed after them.
+    async fn route_input(&mut self, bytes: Vec<u8>) {
+        if bytes.is_empty() {
+            return;
+        }
+        if self.paste_inflight {
+            self.paste_queue.push(Queued::Raw(bytes));
+            return;
+        }
+        self.handle_stdin_inner(bytes).await;
+    }
+
+    /// A complete paste body, markers already stripped. A file drop is
+    /// uploaded; anything else is forwarded verbatim as if it had been typed.
+    async fn route_paste_body(&mut self, body: Vec<u8>) {
+        if self.paste_inflight {
+            self.paste_queue.push(Queued::Body(body));
+            return;
+        }
+        // lossy only for the probe; the forward path keeps the original bytes
+        let Some(paths) = crate::paste::dropped_paths(&String::from_utf8_lossy(&body)) else {
+            self.handle_stdin_inner(body).await;
+            return;
+        };
+
+        self.paste_inflight = true;
+        self.paste_original = Some(body);
+        self.hint_sticky(&format!("uploading {} file(s)…", paths.len()));
+        let tx = self.tx.clone();
+        let ssh = self.args.ssh_target.clone();
+        let ctl = self.args.ctl_path.clone();
+        let container = self.args.container.clone();
+        tokio::spawn(async move {
+            let result =
+                crate::paste::files_to_remote(&paths, &ssh, ctl.as_deref(), container.as_ref())
+                    .await;
+            let _ = tx.send(Msg::Drop(result)).await;
+        });
+    }
+
+    async fn handle_drop(&mut self, result: crate::paste::DropResult) {
+        self.paste_inflight = false;
+        let original = self.paste_original.take();
+        if let Some(text) = &result.text {
+            self.deliver_input(crate::paste::bracketed(text)).await;
+            self.hint(&format!("→ {text}"));
+        } else if result.unchanged {
+            // every path already exists over there, so the user meant those
+            // files: forward what they actually dropped
+            if let Some(body) = original {
+                self.handle_stdin_inner(body).await;
+            }
+        }
+        if let Some(e) = result.error {
+            self.hint(&format!("drop failed: {e}"));
+        }
+        self.drain_paste_queue().await;
+    }
+
+    /// Flush input held during an upload. Stops if a queued drop starts a new
+    /// upload, leaving the remainder queued behind it so order is preserved.
+    async fn drain_paste_queue(&mut self) {
+        let mut items = std::mem::take(&mut self.paste_queue).into_iter();
+        while let Some(item) = items.next() {
+            match item {
+                Queued::Raw(b) => self.handle_stdin_inner(b).await,
+                Queued::Body(b) => {
+                    self.route_paste_body(b).await;
+                    if self.paste_inflight {
+                        self.paste_queue.extend(items);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_stdin_inner(&mut self, buf: Vec<u8>) {
         if buf.len() == 1 && buf[0] == 0x16 && !self.paste_inflight {
             self.paste_inflight = true;
             let tx = self.tx.clone();
@@ -915,7 +1114,7 @@ impl App {
             crate::paste::Outcome::NoImage => self.deliver_input(vec![0x16]).await,
             crate::paste::Outcome::Pasted(path) => {
                 self.deliver_input(crate::paste::bracketed(&path)).await;
-                self.hint(&format!("image → {path}"));
+                self.hint(&format!("→ {path}"));
             }
             crate::paste::Outcome::Failed(e) => {
                 self.hint(&format!("image paste failed: {e}"));
@@ -956,7 +1155,11 @@ pub async fn run(args: Args) -> Result<()> {
     let raw = if tty {
         // 1002/1006: button-event mouse tracking with SGR encoding, so wheel and
         // clicks reach us instead of scrolling the hosting pane's scrollback
-        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?1002h\x1b[?1006h");
+        // 2004 (bracketed paste) is asked for purely to get framing: herdr
+        // only wraps a paste when the pane's app has enabled it, and a file
+        // drop otherwise arrives as bare text with no terminator at all. See
+        // `intercept_paste`; the markers never reach the remote.
+        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?1002h\x1b[?1006h\x1b[?2004h");
         RawMode::enable()
     } else {
         None
@@ -1010,6 +1213,9 @@ pub async fn run(args: Args) -> Result<()> {
         // moves it if the remote turns out to be a TUI
         app_cursor_keys: false,
         paste_inflight: false,
+        paste_buf: Vec::new(),
+        paste_queue: Vec::new(),
+        paste_original: None,
     };
     // Control is authoritative on the remote: the server resizes the remote pty
     // to whatever we ask for, beating even a larger live client over there. So
@@ -1069,6 +1275,7 @@ pub async fn run(args: Args) -> Result<()> {
                         app.sync_cursor_key_mode();
                     },
                     Some(Msg::Paste(outcome)) => app.handle_paste(outcome).await,
+                    Some(Msg::Drop(result)) => app.handle_drop(result).await,
                 }
             }
             _ = sigwinch.recv() => {
@@ -1137,7 +1344,7 @@ pub async fn run(args: Args) -> Result<()> {
     if tty {
         // ?1l with the rest: leaving the hosting pane in application cursor mode
         // would misencode arrows for whatever runs there next
-        write_stdout("\x1b[?1002l\x1b[?1006l\x1b[?1l\x1b[?25h\x1b[?1049l");
+        write_stdout("\x1b[?2004l\x1b[?1002l\x1b[?1006l\x1b[?1l\x1b[?25h\x1b[?1049l");
     }
     if let Some(raw) = raw {
         raw.restore();
@@ -1265,5 +1472,116 @@ mod tests {
         // allowed to impose a size we cannot vouch for.
         assert!(!size_is_trusted((44, 16)));
         assert!(!size_is_trusted((49, 23)));
+    }
+
+    // --- paste framing -----------------------------------------------------
+    // The bugs these pin were all real: a one-shot version dropped the second
+    // drop in a read, leaked markers from the tail, and corrupted non-UTF-8.
+
+    const S: &[u8] = b"\x1b[200~";
+    const E: &[u8] = b"\x1b[201~";
+
+    fn split(buf: &mut Vec<u8>, chunk: &[u8]) -> PasteSplit {
+        split_paste(buf, chunk.to_vec())
+    }
+
+    fn seq(parts: &[&[u8]]) -> Vec<u8> {
+        parts.concat()
+    }
+
+    #[test]
+    fn ordinary_typing_passes_straight_through() {
+        let mut buf = Vec::new();
+        assert_eq!(split(&mut buf, b"a"), PasteSplit::Passthrough(b"a".to_vec()));
+        assert_eq!(split(&mut buf, b"\x1b[A"), PasteSplit::Passthrough(b"\x1b[A".to_vec()));
+        assert!(buf.is_empty(), "typing must not buffer");
+    }
+
+    #[test]
+    fn paste_split_across_reads_reassembles() {
+        let mut buf = Vec::new();
+        assert_eq!(split(&mut buf, &seq(&[S, b"he"])), PasteSplit::Pending);
+        assert_eq!(split(&mut buf, b"llo"), PasteSplit::Pending);
+        assert_eq!(
+            split(&mut buf, E),
+            PasteSplit::Complete { before: vec![], body: b"hello".to_vec(), after: vec![] }
+        );
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn start_marker_split_across_reads_is_not_leaked() {
+        // the 6-byte introducer straddling a read boundary must be held, not
+        // forwarded in pieces (which would print ESC[20 at the remote)
+        let mut buf = Vec::new();
+        assert_eq!(split(&mut buf, b"\x1b[20"), PasteSplit::Pending);
+        assert_eq!(
+            split(&mut buf, &seq(&[b"0~/tmp/a.png", E])),
+            PasteSplit::Complete { before: vec![], body: b"/tmp/a.png".to_vec(), after: vec![] }
+        );
+    }
+
+    #[test]
+    fn bytes_around_the_markers_are_preserved() {
+        let mut buf = Vec::new();
+        assert_eq!(
+            split(&mut buf, &seq(&[b"pre", S, b"mid", E, b"post"])),
+            PasteSplit::Complete {
+                before: b"pre".to_vec(),
+                body: b"mid".to_vec(),
+                after: b"post".to_vec(),
+            }
+        );
+    }
+
+    #[test]
+    fn two_pastes_in_one_read_are_drained_in_order() {
+        // the regression: only the first was handled and the rest discarded,
+        // so a second drop vanished and its markers reached the remote raw
+        let mut buf = Vec::new();
+        let PasteSplit::Complete { body, after, .. } =
+            split(&mut buf, &seq(&[S, b"one", E, S, b"two", E]))
+        else {
+            panic!("expected first paste")
+        };
+        assert_eq!(body, b"one");
+        assert_eq!(
+            split(&mut buf, &after),
+            PasteSplit::Complete { before: vec![], body: b"two".to_vec(), after: vec![] },
+            "feeding the tail back must yield the second paste"
+        );
+    }
+
+    #[test]
+    fn keystroke_after_a_paste_survives() {
+        let mut buf = Vec::new();
+        let PasteSplit::Complete { after, .. } = split(&mut buf, &seq(&[S, b"/tmp/a", E, b"\r"]))
+        else {
+            panic!("expected paste")
+        };
+        assert_eq!(after, b"\r", "the trailing keystroke must not be eaten");
+    }
+
+    #[test]
+    fn unterminated_paste_flushes_at_the_cap_without_duplicating() {
+        let mut buf = Vec::new();
+        assert_eq!(split(&mut buf, S), PasteSplit::Pending);
+        let big = vec![b'x'; MAX_PASTE_BYTES + 1];
+        let PasteSplit::Passthrough(out) = split(&mut buf, &big) else {
+            panic!("expected a flush")
+        };
+        assert_eq!(out.len(), S.len() + big.len(), "every byte exactly once");
+        assert!(buf.is_empty(), "buffer must not keep a copy");
+    }
+
+    #[test]
+    fn non_utf8_paste_body_is_forwarded_byte_exact() {
+        // the body is only lossily decoded to probe for paths; what gets
+        // forwarded must be the original bytes
+        let mut buf = Vec::new();
+        let PasteSplit::Complete { body, .. } = split(&mut buf, &seq(&[S, b"caf\xe9", E])) else {
+            panic!("expected paste")
+        };
+        assert_eq!(body, b"caf\xe9", "0xE9 must not become U+FFFD");
     }
 }

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -83,32 +83,39 @@ async fn upload(
     ctl_path: Option<&str>,
     container: Option<&ContainerArg>,
 ) -> Result<String> {
+    upload_named(png, Some("png"), ssh_target, ctl_path, container).await
+}
+
+/// The name is generated, never taken from the source: a dropped file's own
+/// name could carry anything, and this string is interpolated into a remote
+/// shell command. The extension is the one thing we keep, sanitised to
+/// alphanumerics so it cannot smuggle a quote or a path separator.
+async fn upload_named(
+    png: &[u8],
+    ext: Option<&str>,
+    ssh_target: &str,
+    ctl_path: Option<&str>,
+    container: Option<&ContainerArg>,
+) -> Result<String> {
+    let ext = ext
+        .map(|e| e.chars().filter(|c| c.is_ascii_alphanumeric()).take(16).collect::<String>())
+        .filter(|e| !e.is_empty())
+        .unwrap_or_else(|| "bin".into());
+    // The counter, not just the clock: a multi-file drop can finish two
+    // uploads inside one millisecond, and a collision would silently overwrite
+    // the first file and paste two identical paths.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let name = format!(
-        "paste-{}-{}.png",
+        "paste-{}-{}-{}.{ext}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis(),
-        std::process::id()
+        std::process::id(),
+        SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     );
     let cmd = format!("mkdir -p ~/{REMOTE_DIR} && cat > ~/{REMOTE_DIR}/{name} && echo \"$HOME\"");
-    let mut c = match container {
-        Some(ct) => {
-            let ids = crate::docker::resolve(&ct.docker_bin, &ct.kind).await?;
-            let id = ids.into_iter().next().ok_or_else(|| err("container not found"))?;
-            let mut c = Command::new(&ct.docker_bin);
-            c.args(["exec", "-i", &id, "sh", "-c", &cmd]);
-            c
-        }
-        None => {
-            let mut c = Command::new("ssh");
-            if let Some(path) = ctl_path {
-                c.arg("-S").arg(path);
-            }
-            c.args(SSH_COMMON_OPTS).arg(ssh_target).arg(&cmd);
-            c
-        }
-    };
+    let mut c = remote_command(&cmd, ssh_target, ctl_path, container).await?;
     let mut child = c
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -132,11 +139,225 @@ async fn upload(
     Ok(format!("{home}/{REMOTE_DIR}/{name}"))
 }
 
+/// One `sh -c` on the far end, over whichever transport this pane uses.
+async fn remote_command(
+    cmd: &str,
+    ssh_target: &str,
+    ctl_path: Option<&str>,
+    container: Option<&ContainerArg>,
+) -> Result<Command> {
+    Ok(match container {
+        Some(ct) => {
+            let ids = crate::docker::resolve(&ct.docker_bin, &ct.kind).await?;
+            let id = ids.into_iter().next().ok_or_else(|| err("container not found"))?;
+            let mut c = Command::new(&ct.docker_bin);
+            c.args(["exec", "-i", &id, "sh", "-c", cmd]);
+            c
+        }
+        None => {
+            let mut c = Command::new("ssh");
+            if let Some(path) = ctl_path {
+                c.arg("-S").arg(path);
+            }
+            c.args(SSH_COMMON_OPTS).arg(ssh_target).arg(cmd);
+            c
+        }
+    })
+}
+
 pub fn bracketed(path: &str) -> Vec<u8> {
     let mut b: Vec<u8> = b"\x1b[200~".to_vec();
     b.extend_from_slice(path.as_bytes());
     b.extend_from_slice(b"\x1b[201~");
     b
+}
+
+/// Cap per dropped file. Enforced on the READ, not just the stat, so a file
+/// that grows underneath us — or a pseudo-file reporting zero length and
+/// streaming forever — cannot get past it. Generous enough for screenshots,
+/// logs and PDFs; small enough that a stray video drop fails in a sentence.
+pub const MAX_DROP_BYTES: u64 = 32 * 1024 * 1024;
+
+/// What to do with a payload that looked like a file drop.
+pub struct DropResult {
+    /// text to paste in place of the payload; None pastes nothing
+    pub text: Option<String>,
+    /// forward the original payload untouched (every path already exists on
+    /// the remote, so the user meant those files, not copies of ours)
+    pub unchanged: bool,
+    /// message for the pane hint
+    pub error: Option<String>,
+}
+
+/// Split a dropped-file payload into paths.
+///
+/// Captured from a real terminal: absolute paths, single-space separated,
+/// spaces inside a name backslash-escaped, and no trailing newline. Some
+/// terminals quote instead of escaping, which herdr also handles upstream
+/// (`strip_matching_path_quotes`), so both forms are accepted here.
+///
+/// Returns None unless every token is an absolute path to an existing regular
+/// file. Requiring *all* of them is what keeps an ordinary paste that merely
+/// mentions a path from being treated as a drop.
+pub fn dropped_paths(text: &str) -> Option<Vec<std::path::PathBuf>> {
+    let text = text.trim_matches(|c: char| c == '\r' || c == '\n');
+    if text.is_empty() {
+        return None;
+    }
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            // the escape is the terminal's, not the shell's: the next char is
+            // literal whatever it is. A trailing lone backslash is kept rather
+            // than rejecting the payload, matching herdr's unescape.
+            '\\' => match chars.next() {
+                Some(next) => current.push(next),
+                None => current.push('\\'),
+            },
+            '\'' | '"' if quote.is_none() => quote = Some(ch),
+            _ if Some(ch) == quote => quote = None,
+            ' ' if quote.is_none() => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+
+    let paths: Vec<std::path::PathBuf> =
+        tokens.into_iter().map(std::path::PathBuf::from).collect();
+    let all_files = paths
+        .iter()
+        .all(|p| p.is_absolute() && std::fs::metadata(p).map(|m| m.is_file()).unwrap_or(false));
+    (!paths.is_empty() && all_files).then_some(paths)
+}
+
+/// Which of `paths` already exist at the same absolute path on the remote.
+///
+/// This is what separates a drop from an ordinary paste of a path. `/etc/hosts`
+/// exists on both machines, so the user meant the remote's copy and we must not
+/// substitute ours; a screenshot from ~/Desktop does not exist there, so it has
+/// to be uploaded to mean anything. One round trip answers it for the whole
+/// payload.
+async fn remote_has_all(
+    paths: &[std::path::PathBuf],
+    ssh_target: &str,
+    ctl_path: Option<&str>,
+    container: Option<&ContainerArg>,
+) -> Result<bool> {
+    let quoted: Vec<String> = paths
+        .iter()
+        .map(|p| crate::pane::sh_quote(&p.display().to_string()))
+        .collect();
+    let cmd = format!(
+        "for p in {}; do [ -e \"$p\" ] && echo 1 || echo 0; done",
+        quoted.join(" ")
+    );
+    let mut c = remote_command(&cmd, ssh_target, ctl_path, container).await?;
+    let out = timeout(CLIPBOARD_TIMEOUT, c.stdin(Stdio::null()).output())
+        .await
+        .map_err(|_| err("remote existence check timed out"))??;
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let lines: Vec<&str> = stdout.lines().map(str::trim).filter(|l| !l.is_empty()).collect();
+    // a short or garbled answer means "don't know", which must not read as
+    // "all present" — that would skip the upload and paste useless local paths
+    Ok(lines.len() == paths.len() && lines.iter().all(|l| *l == "1"))
+}
+
+/// Upload each dropped file and hand back the remote paths.
+///
+/// All-or-nothing on the *decision* (if any path is missing remotely, every
+/// file is uploaded) so the pasted list is uniform and needs no re-escaping:
+/// generated names contain nothing a shell would split on.
+pub async fn files_to_remote(
+    paths: &[std::path::PathBuf],
+    ssh_target: &str,
+    ctl_path: Option<&str>,
+    container: Option<&ContainerArg>,
+) -> DropResult {
+    // size-check everything before uploading anything, so a too-large file at
+    // the end cannot leave earlier ones orphaned on the remote
+    for path in paths {
+        match tokio::fs::metadata(path).await {
+            Ok(m) if m.len() > MAX_DROP_BYTES => {
+                return DropResult {
+                    text: None,
+                    unchanged: false,
+                    error: Some(format!(
+                        "{} is {} MB; limit is {} MB",
+                        path.display(),
+                        m.len() / (1024 * 1024),
+                        MAX_DROP_BYTES / (1024 * 1024)
+                    )),
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                return DropResult {
+                    text: None,
+                    unchanged: false,
+                    error: Some(format!("{}: {e}", path.display())),
+                }
+            }
+        }
+    }
+
+    match remote_has_all(paths, ssh_target, ctl_path, container).await {
+        Ok(true) => {
+            return DropResult { text: None, unchanged: true, error: None };
+        }
+        Ok(false) => {}
+        // a failed probe must not block the drop: uploading is the safe guess
+        Err(_) => {}
+    }
+
+    let mut remote = Vec::new();
+    let mut failed = Vec::new();
+    for path in paths {
+        let bytes = match read_capped(path).await {
+            Ok(b) => b,
+            Err(e) => {
+                failed.push(format!("{}: {e}", path.display()));
+                continue;
+            }
+        };
+        // keep the extension: an agent on the other end usually decides how to
+        // read a file from it
+        let ext = path.extension().and_then(|e| e.to_str());
+        match upload_named(&bytes, ext, ssh_target, ctl_path, container).await {
+            Ok(p) => remote.push(p),
+            Err(e) => failed.push(format!("{}: {e}", path.display())),
+        }
+    }
+
+    // partial success still pastes what made it, rather than throwing away
+    // files already sitting on the remote
+    DropResult {
+        text: (!remote.is_empty()).then(|| remote.join(" ")),
+        unchanged: false,
+        error: (!failed.is_empty()).then(|| failed.join("; ")),
+    }
+}
+
+/// Read at most `MAX_DROP_BYTES`, off the reactor thread and without trusting
+/// the stat: `take` bounds what a growing or endless file can hand back.
+async fn read_capped(path: &std::path::Path) -> Result<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+
+    let file = tokio::fs::File::open(path).await?;
+    let mut buf = Vec::new();
+    let read = file.take(MAX_DROP_BYTES + 1).read_to_end(&mut buf).await?;
+    if read as u64 > MAX_DROP_BYTES {
+        return Err(err(format!("larger than {} MB", MAX_DROP_BYTES / (1024 * 1024))));
+    }
+    Ok(buf)
 }
 
 #[cfg(test)]
@@ -165,5 +386,91 @@ mod tests {
         assert!(b.starts_with(b"\x1b[200~"));
         assert!(b.ends_with(b"\x1b[201~"));
         assert_eq!(&b[6..b.len() - 6], b"/home/u/.cache/herdr-mirror/pastes/p.png");
+    }
+
+    /// Real terminal output, captured by dragging onto a pane: absolute paths,
+    /// single-space separated, spaces inside a name backslash-escaped, and
+    /// notably NO trailing newline.
+    #[test]
+    fn drop_payload_splits_on_unescaped_spaces_only() {
+        let dir = std::env::temp_dir().join(format!("drop-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let spaced = dir.join("drop test A.png");
+        let plain = dir.join("d2.html");
+        std::fs::write(&spaced, b"x").unwrap();
+        std::fs::write(&plain, b"y").unwrap();
+
+        // one file whose name contains spaces: escaped, must stay one path
+        let one = format!("{}", spaced.display()).replace(' ', "\\ ");
+        assert_eq!(dropped_paths(&one), Some(vec![spaced.clone()]));
+
+        // two files: the separating space is NOT escaped
+        let two = format!("{one} {}", plain.display());
+        assert_eq!(dropped_paths(&two), Some(vec![spaced.clone(), plain.clone()]));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ordinary_paste_is_never_treated_as_a_drop() {
+        // text that isn't paths at all
+        assert_eq!(dropped_paths("git status && cargo test"), None);
+        assert_eq!(dropped_paths(""), None);
+        // a path-shaped string that does not exist
+        assert_eq!(dropped_paths("/tmp/definitely-not-here-9182.png"), None);
+        // relative paths are not drops (a drop is always absolute)
+        assert_eq!(dropped_paths("src/paste.rs"), None);
+        // a directory is not a file
+        assert_eq!(dropped_paths(&std::env::temp_dir().display().to_string()), None);
+    }
+
+    #[test]
+    fn one_missing_file_disqualifies_the_whole_paste() {
+        // partial matches must not upload: forwarding the text unchanged is
+        // the safe outcome, since this is probably prose that mentions a path
+        let real = std::env::temp_dir().join(format!("drop-solo-{}.txt", std::process::id()));
+        std::fs::write(&real, b"z").unwrap();
+        let mixed = format!("{} /tmp/nope-not-real-4471.png", real.display());
+        assert_eq!(dropped_paths(&mixed), None);
+        std::fs::remove_file(&real).ok();
+    }
+
+    #[test]
+    fn upload_extension_cannot_escape_the_remote_command() {
+        // the filename is interpolated into a remote `sh -c`; only the
+        // extension comes from user data, so it must survive nothing but
+        // alphanumerics
+        let san = |e: Option<&str>| {
+            e.map(|e| e.chars().filter(|c| c.is_ascii_alphanumeric()).take(16).collect::<String>())
+                .filter(|e| !e.is_empty())
+                .unwrap_or_else(|| "bin".into())
+        };
+        assert_eq!(san(Some("png")), "png");
+        assert_eq!(san(Some("tar.gz")), "targz");
+        assert_eq!(san(Some("a/b")), "ab");
+        assert_eq!(san(Some("'; rm -rf / #")), "rmrf");
+        assert_eq!(san(Some("..")), "bin");
+        assert_eq!(san(None), "bin");
+        assert_eq!(san(Some(&"z".repeat(40))).len(), 16);
+    }
+
+    #[test]
+    fn quoted_and_backslashed_drops_both_parse() {
+        let dir = std::env::temp_dir().join(format!("drop-q-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let spaced = dir.join("a b.png");
+        std::fs::write(&spaced, b"x").unwrap();
+
+        let esc = spaced.display().to_string().replace(' ', "\\ ");
+        assert_eq!(dropped_paths(&esc), Some(vec![spaced.clone()]));
+        // some terminals quote instead of escaping
+        assert_eq!(dropped_paths(&format!("'{}'", spaced.display())), Some(vec![spaced.clone()]));
+        assert_eq!(dropped_paths(&format!("\"{}\"", spaced.display())), Some(vec![spaced.clone()]));
+
+        // a trailing lone backslash is kept, not a reason to reject
+        let plain = dir.join("c.png");
+        std::fs::write(&plain, b"y").unwrap();
+        assert_eq!(dropped_paths(&format!("{}\\", plain.display())), None, "no such file with a trailing backslash");
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Extends the ctrl+v image paste from #39 to drag-and-drop of any file.

Dragging a file onto a mirror pane inserts a *local* path, which means nothing on the remote. This uploads the file over the pane's existing transport and pastes the remote path instead.

The streamer now enables DECSET 2004. That's load-bearing rather than cosmetic: a drop carries no trailing newline and no terminator of any kind, so without paste markers there's no way to tell a finished drop from a half-received one, or two quick drops from one. herdr only wraps pastes when the pane's app asks for 2004. The markers are a local signal and are stripped before anything reaches the remote, whose app may not have bracketed paste on.

A paste that is entirely existing absolute paths is checked against the remote first: if those paths already exist over there (`/etc/hosts` is the obvious case), the payload is forwarded untouched, because the user meant the remote's files. Otherwise the files are uploaded.

Also fixes the in-flight double ctrl+v from #39: input arriving during an upload is now queued and replayed in order rather than forwarded raw.

Details: any file type, not just images, with the extension preserved but sanitised (the name is interpolated into a remote `sh -c`); 32MB per file enforced on the read rather than the stat; sizes checked before any upload so a late oversized file can't orphan earlier ones; partial failures paste what succeeded and name what didn't; quoted payloads accepted alongside backslash-escaped.

## Testing

140 tests, clippy clean. Seven table tests over the pure `split_paste` cover split reads, a marker straddling a read boundary, bytes either side, two pastes in one read, a keystroke after a paste, the oversize flush, and a non-UTF-8 body.

Verified live against an ssh host: single and multi-file drops upload byte-identically and paste in order; two drops in one read both land; `/etc/hosts` uploads nothing and pastes unchanged; ordinary pastes and plain typing are unaffected.

Reviewed by a subagent, which found the framing bugs this now fixes.