### PR TITLE
fix: keep the mouse local for agent CLIs so selection works in their panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,20 @@ Mirror panes adapt to what's running on the remote pane:
 
 - at a **shell**, the mouse stays local — drag-select and copy work natively, and
   nothing leaks into the prompt;
-- in a **TUI** (vim, htop, lazygit, …), clicks and wheel forward to the app.
+- at an **agent CLI** (claude, codex, gemini, …), likewise: they're full-screen
+  but never turn mouse reporting on, so selection stays yours;
+- in a **mouse-aware TUI** (vim, htop, lazygit, …), clicks forward to the app.
+
+The wheel is always a semantic scroll of the remote pane, whichever of those it is.
 
 herdr's streamed frames don't carry the app's mouse mode, so the plugin infers it
-from the remote pane's foreground process — anything that isn't a known shell is
-treated as a mouse-aware TUI. Detection is polled, so after switching between a
-shell and a TUI there's a brief lag before the mouse mode catches up.
+from the remote pane's foreground process. Taking the mouse is what stops herdr
+doing native selection, so it is only taken for a process known to want it —
+while the answer is still unknown, selection wins. Detection is polled, so after
+quitting a TUI back to a shell there's a brief lag before the mouse catches up.
+
+If an agent CLI isn't recognised (they ship faster than the built-in list), name
+it in `mouse_local_apps` rather than living without selection in its panes.
 
 ## Configuration
 
@@ -288,6 +296,11 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
 # max_cols / max_rows    # cap the size control asks the remote for, so a
                          # machine with its own display keeps its geometry.
                          # A ceiling only, and never applies to watch-only.
+# mouse_local_apps = ["myagent"]
+                         # extra foreground process names that never enable
+                         # mouse reporting, on top of the built-in shell and
+                         # agent-CLI lists. Naming one here keeps herdr's native
+                         # drag-select working in that program's panes.
 
 [hosts.work]
 target = "work"
@@ -297,6 +310,7 @@ target = "work"
                                      # (`herdr --session project`)
 # max_cols = 212                     # per-host size cap; pairs with
 # max_rows = 58                      # always_control = false
+# mouse_local_apps = ["myagent"]     # added to the global list, not replacing it
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
 # enabled = true                     # false stops syncing this host without

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,11 @@ pub struct HostConfig {
     /// of the local pane blank instead. Observe is unaffected either way.
     pub max_cols: Option<usize>,
     pub max_rows: Option<usize>,
+    /// Extra foreground process names that never enable mouse reporting, added
+    /// to the built-in shell and agent-CLI lists. Agent CLIs ship faster than
+    /// the built-in list is updated, and an unlisted one costs you native
+    /// selection in every pane it runs in — this is the escape hatch.
+    pub mouse_local_apps: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -160,6 +165,7 @@ struct RawConfig {
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
+    mouse_local_apps: Option<Vec<String>>,
     // toml::Table (preserve_order) keeps declaration order — the first host
     // is the remote-create fallback, so order is user-visible
     #[serde(default)]
@@ -181,6 +187,7 @@ struct RawHost {
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
+    mouse_local_apps: Option<Vec<String>>,
     api_transport: Option<String>,
 }
 
@@ -274,6 +281,7 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     }
     let global_max_cols = size_cap(raw.max_cols);
     let global_max_rows = size_cap(raw.max_rows);
+    let global_mouse_local = raw.mouse_local_apps.unwrap_or_default();
     let mut hosts: Vec<HostConfig> = Vec::new();
     for (name, value) in raw.hosts {
         let h: RawHost = value.try_into().map_err(|e| err(format!("[hosts.{name}]: {e}")))?;
@@ -320,6 +328,14 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             always_control: h.always_control.unwrap_or(global_always_control),
             max_cols: size_cap(h.max_cols).or(global_max_cols),
             max_rows: size_cap(h.max_rows).or(global_max_rows),
+            // union, not override: the global list is "agents I run everywhere"
+            // and the per-host one is "and this box also runs these" — a host
+            // that names one extra agent should not lose the global set
+            mouse_local_apps: global_mouse_local
+                .iter()
+                .cloned()
+                .chain(h.mouse_local_apps.unwrap_or_default())
+                .collect(),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
             api_transport,
             kind,
@@ -410,6 +426,25 @@ mod tests {
         assert_eq!(a.max_rows, None); // rows were never capped
         assert_eq!(b.max_cols, Some(120)); // per-host override
         assert_eq!(b.max_rows, Some(40));
+    }
+
+    #[test]
+    fn mouse_local_apps_union_global_and_per_host() {
+        // unset anywhere: empty, so the built-in shell/agent lists are the whole policy
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert!(c.hosts[0].mouse_local_apps.is_empty());
+
+        let c = parse_config(
+            "mouse_local_apps = [\"everywhere\"]\n\
+             [hosts.a]\ntarget = \"a\"\n\
+             [hosts.b]\ntarget = \"b\"\nmouse_local_apps = [\"justhere\"]\n",
+        )
+        .unwrap();
+        let a = c.hosts.iter().find(|h| h.name == "a").unwrap();
+        let b = c.hosts.iter().find(|h| h.name == "b").unwrap();
+        assert_eq!(a.mouse_local_apps, vec!["everywhere"]);
+        // union, not override — naming one extra agent must not drop the global set
+        assert_eq!(b.mouse_local_apps, vec!["everywhere", "justhere"]);
     }
 
     /// A cap of 0 would starve the remote of every column. Treat it as unset,

--- a/src/foreground.rs
+++ b/src/foreground.rs
@@ -3,10 +3,17 @@
 // herdr strips the mouse-mode DECSET from the frames the plugin observes, so the
 // streamer can't tell whether the remote pane's app wants the mouse. As a proxy,
 // query the remote pane's foreground process (`herdr pane process-info`) and
-// classify it: a plain shell at a prompt never enables mouse reporting, so mouse
-// events should stay local (no garbage in the prompt); anything else is treated
-// as a possible mouse-aware TUI and clicks are forwarded. This is a heuristic
-// stand-in until herdr exposes the pane's mouse-reporting state through the API.
+// classify it. This is a heuristic stand-in until herdr exposes the pane's
+// mouse-reporting state through the API.
+//
+// "Is it a TUI?" turned out to be the wrong question. A plain shell at a prompt
+// never enables mouse reporting — but neither does an agent CLI, which is
+// full-screen and so answered "TUI" and got the mouse grabbed on its behalf.
+// Holding the grab is precisely what stops herdr doing native text selection, so
+// in a mirror of an agent host — where nearly every pane is an agent — selection
+// was dead everywhere and the forwarded clicks went to a program that had never
+// asked for them. The question that matters is "does this process want the
+// mouse?", which is answered `false` for two different reasons.
 
 use std::process::Stdio;
 
@@ -23,23 +30,58 @@ const SHELLS: &[&str] = &[
     "pwsh", "powershell", "cmd",
 ];
 
-/// Is `name` one of the known interactive shells? Normalizes a login-shell dash
-/// (`-bash`), a leading path, and a Windows `.exe` suffix before matching.
-pub fn is_shell(name: &str) -> bool {
+/// Agent CLIs: full-screen, but they do not turn mouse reporting on. Same
+/// conclusion as a shell — keep the mouse local — reached for a different reason,
+/// so it is a separate list. Kept lowercase and extension-free; `basename`
+/// normalizes the incoming name before matching.
+const MOUSE_BLIND_TUIS: &[&str] = &[
+    "claude", "codex", "gemini", "cursor-agent", "opencode", "aider", "goose",
+    "crush", "grok", "qwen", "kimi", "amp", "droid", "pi", "antigravity",
+    "hermes",
+];
+
+/// Strip a login-shell dash (`-bash`), any leading path, and a Windows `.exe`
+/// suffix, then lowercase — the form both lists are written in.
+fn basename(name: &str) -> String {
     let base = name.trim_start_matches('-').rsplit(['/', '\\']).next().unwrap_or(name);
-    let n = base.trim_end_matches(".exe").to_ascii_lowercase();
-    SHELLS.contains(&n.as_str())
+    base.trim_end_matches(".exe").to_ascii_lowercase()
 }
 
-/// Classify a `pane process-info` JSON response. `Some(true)` = foreground is a
-/// shell, `Some(false)` = something else, `None` = indeterminate (empty/unparseable).
-pub fn classify(json: &str) -> Option<bool> {
+/// Is `name` one of the known interactive shells?
+pub fn is_shell(name: &str) -> bool {
+    SHELLS.contains(&basename(name).as_str())
+}
+
+/// Does this foreground process enable mouse reporting? `extra` is the per-host
+/// `mouse_local_apps` escape hatch: new agent CLIs appear faster than this list
+/// is updated, and the cost of a miss is a pane you cannot select text in.
+pub fn wants_mouse(name: &str, extra: &[String]) -> bool {
+    let n = basename(name);
+    !SHELLS.contains(&n.as_str())
+        && !MOUSE_BLIND_TUIS.contains(&n.as_str())
+        && !extra.iter().any(|e| basename(e) == n)
+}
+
+/// What the remote foreground implies for local input handling. Two answers, not
+/// one, because they answer different questions: `is_shell` picks the cursor-key
+/// encoding, `wants_mouse` decides the mouse grab. An agent CLI is *not* a shell
+/// — it sets DECCKM, so arrows must stay in application mode — and still doesn't
+/// want the mouse. Collapsing them is the bug this type exists to prevent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Fg {
+    pub is_shell: bool,
+    pub wants_mouse: bool,
+}
+
+/// Classify a `pane process-info` JSON response. `None` = indeterminate
+/// (empty/unparseable), so the caller keeps its last known value.
+pub fn classify(json: &str, extra: &[String]) -> Option<Fg> {
     let v: serde_json::Value = serde_json::from_str(json).ok()?;
     let fg = v.get("result")?.get("process_info")?.get("foreground_processes")?.as_array()?;
     // the last foreground process is the actually-running leaf, so `sudo vim`
     // classifies on `vim`, not `sudo`
     let name = fg.last()?.get("name")?.as_str()?;
-    Some(is_shell(name))
+    Some(Fg { is_shell: is_shell(name), wants_mouse: wants_mouse(name, extra) })
 }
 
 /// Query the remote pane's foreground process over ssh and classify it. `None`
@@ -51,7 +93,8 @@ pub async fn poll(
     pane: &str,
     ctl_path: Option<&str>,
     container: Option<&crate::pane::ContainerArg>,
-) -> Option<bool> {
+    extra_mouse_local: &[String],
+) -> Option<Fg> {
     // same expression as the observe session (configured path or PATH auto)
     let bin = crate::config::remote_herdr_expr(remote_bin, session);
     let cmd = format!("exec {} pane process-info --pane {}", bin, sh_quote(pane));
@@ -93,7 +136,7 @@ pub async fn poll(
     if !out.status.success() {
         return None;
     }
-    classify(&String::from_utf8_lossy(&out.stdout))
+    classify(&String::from_utf8_lossy(&out.stdout), extra_mouse_local)
 }
 
 #[cfg(test)]
@@ -113,22 +156,51 @@ mod tests {
         assert!(!is_shell("lazygit"));
     }
 
+    fn fg(name: &str) -> String {
+        format!(r#"{{"result":{{"process_info":{{"foreground_processes":[{{"name":"{name}"}}]}}}}}}"#)
+    }
+
     #[test]
     fn classify_reads_leaf_foreground() {
-        let shell = r#"{"result":{"process_info":{"foreground_processes":[{"name":"zsh"}]}}}"#;
-        assert_eq!(classify(shell), Some(true));
-        let tui = r#"{"result":{"process_info":{"foreground_processes":[{"name":"vim"}]}}}"#;
-        assert_eq!(classify(tui), Some(false));
+        assert_eq!(classify(&fg("zsh"), &[]), Some(Fg { is_shell: true, wants_mouse: false }));
+        assert_eq!(classify(&fg("vim"), &[]), Some(Fg { is_shell: false, wants_mouse: true }));
         // sudo wrapper: the leaf is the real program
         let sudo =
             r#"{"result":{"process_info":{"foreground_processes":[{"name":"sudo"},{"name":"vim"}]}}}"#;
-        assert_eq!(classify(sudo), Some(false));
+        assert_eq!(classify(sudo, &[]), Some(Fg { is_shell: false, wants_mouse: true }));
     }
 
     #[test]
     fn classify_indeterminate_on_empty_or_garbage() {
-        assert_eq!(classify(r#"{"result":{"process_info":{"foreground_processes":[]}}}"#), None);
-        assert_eq!(classify("not json"), None);
-        assert_eq!(classify(r#"{"result":{}}"#), None);
+        assert_eq!(classify(r#"{"result":{"process_info":{"foreground_processes":[]}}}"#, &[]), None);
+        assert_eq!(classify("not json", &[]), None);
+        assert_eq!(classify(r#"{"result":{}}"#, &[]), None);
+    }
+
+    #[test]
+    fn an_agent_cli_is_not_a_shell_but_still_does_not_want_the_mouse() {
+        // the whole point: these two answers must be allowed to disagree, or
+        // application cursor keys break when the mouse is fixed (and vice versa)
+        for name in ["claude", "codex", "gemini", "opencode", "cursor-agent"] {
+            let c = classify(&fg(name), &[]).unwrap();
+            assert!(!c.is_shell, "{name} must keep application cursor keys");
+            assert!(!c.wants_mouse, "{name} must leave the mouse to herdr");
+        }
+    }
+
+    #[test]
+    fn a_real_mouse_aware_tui_still_gets_the_mouse() {
+        for name in ["vim", "nvim", "htop", "lazygit", "emacs"] {
+            assert!(wants_mouse(name, &[]), "{name} must still receive clicks");
+        }
+    }
+
+    #[test]
+    fn the_escape_hatch_normalizes_like_the_builtin_lists() {
+        let extra = vec!["MyAgent.exe".to_string(), "/opt/bin/tool".to_string()];
+        assert!(!wants_mouse("myagent", &extra));
+        assert!(!wants_mouse("/usr/local/bin/MyAgent", &extra));
+        assert!(!wants_mouse("tool", &extra));
+        assert!(wants_mouse("unrelated", &extra));
     }
 }

--- a/src/foreground.rs
+++ b/src/foreground.rs
@@ -78,8 +78,23 @@ pub struct Fg {
 pub fn classify(json: &str, extra: &[String]) -> Option<Fg> {
     let v: serde_json::Value = serde_json::from_str(json).ok()?;
     let fg = v.get("result")?.get("process_info")?.get("foreground_processes")?.as_array()?;
-    // the last foreground process is the actually-running leaf, so `sudo vim`
-    // classifies on `vim`, not `sudo`
+    // An agent CLI anywhere in the chain wins over the leaf. A working
+    // agent's leaf is whatever tool it just spawned (`node`, `python3`,
+    // `rg`, a shell — changing every few seconds), but those children are
+    // batch commands, not TUIs, and the AGENT keeps reading the pty the
+    // whole time. Classifying the leaf made the pane flip to "mouse-wanting
+    // TUI" exactly while the agent worked, so the grab was held and the
+    // wheel forwarded — straight into the fullscreen agent's conversation
+    // view (and native selection died for the duration of every tool call).
+    let agent = fg.iter().filter_map(|p| p.get("name").and_then(|n| n.as_str())).any(|name| {
+        let n = basename(name);
+        MOUSE_BLIND_TUIS.contains(&n.as_str()) || extra.iter().any(|e| basename(e) == n)
+    });
+    if agent {
+        return Some(Fg { is_shell: false, wants_mouse: false });
+    }
+    // otherwise the last foreground process is the actually-running leaf, so
+    // `sudo vim` classifies on `vim`, not `sudo`
     let name = fg.last()?.get("name")?.as_str()?;
     Some(Fg { is_shell: is_shell(name), wants_mouse: wants_mouse(name, extra) })
 }
@@ -168,6 +183,26 @@ mod tests {
         let sudo =
             r#"{"result":{"process_info":{"foreground_processes":[{"name":"sudo"},{"name":"vim"}]}}}"#;
         assert_eq!(classify(sudo, &[]), Some(Fg { is_shell: false, wants_mouse: true }));
+    }
+
+    #[test]
+    fn a_working_agent_still_classifies_as_the_agent_not_its_tool() {
+        // claude mid-tool-call: the leaf is the spawned command, but claude
+        // keeps reading the pty — the pane must NOT flip to mouse-wanting
+        for leaf in ["node", "python3", "rg", "zsh"] {
+            let chain = format!(
+                r#"{{"result":{{"process_info":{{"foreground_processes":[{{"name":"claude"}},{{"name":"sh"}},{{"name":"{leaf}"}}]}}}}}}"#
+            );
+            assert_eq!(
+                classify(&chain, &[]),
+                Some(Fg { is_shell: false, wants_mouse: false }),
+                "claude running {leaf} must stay classified as the agent"
+            );
+        }
+        // the escape-hatch list joins the chain scan too
+        let chain = r#"{"result":{"process_info":{"foreground_processes":[{"name":"myagent"},{"name":"node"}]}}}"#;
+        let extra = vec!["myagent".to_string()];
+        assert_eq!(classify(chain, &extra), Some(Fg { is_shell: false, wants_mouse: false }));
     }
 
     #[test]

--- a/src/hist.rs
+++ b/src/hist.rs
@@ -1,0 +1,164 @@
+// Local history view for a mirror pane.
+//
+// A mirror pane paints into the alternate screen, so it has no local
+// scrollback of its own, and the remote side offers nothing to scroll either:
+// the session API's `terminal.scroll` is deliver-to-the-app semantics (for a
+// no-mouse pane it types history-cycling arrow keys — measured), and a
+// classic/inline agent renderer swallows re-materialized SGR wheels without
+// moving anything. The pane's real history lives server-side, and `pane read
+// --source recent` can hand it to us — herdr even collects the conversation
+// text of idle alternate-screen agents into it — so a wheel-up fetches that
+// over the existing ssh ControlMaster and renders it LOCALLY. Read-only, no
+// control session, no agent lock: a glance-scroll never touches the remote.
+
+use std::process::Stdio;
+
+use tokio::process::Command;
+
+use crate::pane::sh_quote;
+use crate::remote::SSH_COMMON_OPTS;
+
+/// How many history lines one fetch asks for. Enough that hitting the top
+/// means the pane really is near its beginning, small enough that the ansi
+/// payload stays a sub-second read over an existing ControlMaster.
+pub const FETCH_LINES: usize = 2000;
+
+/// A fetched snapshot being viewed, plus how far up into it we are.
+pub struct HistView {
+    /// ansi-styled lines, oldest first, trailing blanks trimmed
+    pub lines: Vec<String>,
+    /// lines scrolled up from the bottom; clamped at render time
+    pub offset: usize,
+}
+
+/// Fetch the remote pane's recent history as ansi lines. `None` on any
+/// failure — the caller shows "history unavailable" and stays live.
+pub async fn fetch(
+    ssh_target: &str,
+    remote_bin: Option<&str>,
+    session: Option<&str>,
+    pane: &str,
+    ctl_path: Option<&str>,
+    container: Option<&crate::pane::ContainerArg>,
+) -> Option<Vec<String>> {
+    let bin = crate::config::remote_herdr_expr(remote_bin, session);
+    let cmd = format!(
+        "exec {} pane read {} --source recent --format ansi --lines {}",
+        bin,
+        sh_quote(pane),
+        FETCH_LINES
+    );
+    let mut sc = match container {
+        Some(ct) => {
+            let ids = crate::docker::resolve(&ct.docker_bin, &ct.kind).await.ok()?;
+            let id = ids.into_iter().next()?;
+            let mut c = Command::new(&ct.docker_bin);
+            c.args(["exec", &id, "sh", "-c", &cmd]);
+            c
+        }
+        None => {
+            let mut c = Command::new("ssh");
+            if let Some(path) = ctl_path {
+                c.arg("-S").arg(path);
+            }
+            c.args(SSH_COMMON_OPTS).arg(ssh_target).arg(cmd);
+            c
+        }
+    };
+    let out =
+        sc.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::null()).output().await.ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let mut lines: Vec<String> =
+        String::from_utf8_lossy(&out.stdout).lines().map(str::to_string).collect();
+    while lines.last().is_some_and(|l| l.trim().is_empty()) {
+        lines.pop();
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    Some(lines)
+}
+
+/// Which slice of the buffer a viewport shows at a given offset. Pure so the
+/// clamping logic is testable: `rows_avail` is the viewport minus the status
+/// bar, the returned offset is the clamped one to store back.
+pub fn window(total: usize, rows_avail: usize, offset: usize) -> (usize, usize, usize) {
+    let max_off = total.saturating_sub(rows_avail);
+    let off = offset.min(max_off);
+    let end = total - off;
+    let start = end.saturating_sub(rows_avail);
+    (start, end, off)
+}
+
+/// Paint the view: absolute cursor addressing per row so a repaint needs no
+/// scroll region, autowrap off (the caller restores `?7h` on exit) so a line
+/// wider than the local pane truncates instead of pushing rows out of place,
+/// all inside a synchronized-update block. Returns the clamped offset.
+pub fn render(view: &HistView, _cols: usize, rows: usize) -> (String, usize) {
+    let rows_avail = rows.saturating_sub(1).max(1);
+    let (start, end, off) = window(view.lines.len(), rows_avail, view.offset);
+    let mut out = String::with_capacity(4096);
+    out.push_str("\x1b[?2026h\x1b[?7l\x1b[?25l");
+    for row in 0..rows_avail {
+        out.push_str(&format!("\x1b[{};1H\x1b[2K", row + 1));
+        if let Some(line) = view.lines.get(start + row).filter(|_| start + row < end) {
+            out.push_str(line);
+            out.push_str("\x1b[0m");
+        }
+    }
+    let above = off;
+    let top = if start == 0 { " · top" } else { "" };
+    out.push_str(&format!(
+        "\x1b[{};1H\x1b[2K\x1b[7m history · {above} below live{top} · wheel down / any key to return \x1b[0m",
+        rows.max(1)
+    ));
+    out.push_str("\x1b[?2026l");
+    (out, off)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_clamps_offset_to_what_exists() {
+        // 100 lines, 20 usable rows: deepest offset shows lines 0..20
+        assert_eq!(window(100, 20, 0), (80, 100, 0));
+        assert_eq!(window(100, 20, 30), (50, 70, 30));
+        assert_eq!(window(100, 20, 80), (0, 20, 80));
+        assert_eq!(window(100, 20, 5000), (0, 20, 80));
+    }
+
+    #[test]
+    fn window_with_fewer_lines_than_viewport_pins_to_top() {
+        assert_eq!(window(5, 20, 0), (0, 5, 0));
+        assert_eq!(window(5, 20, 3), (0, 5, 0));
+        assert_eq!(window(0, 20, 3), (0, 0, 0));
+    }
+
+    #[test]
+    fn render_reports_clamped_offset_and_marks_top() {
+        let view = HistView { lines: (0..10).map(|i| format!("l{i}")).collect(), offset: 999 };
+        let (out, off) = render(&view, 80, 6);
+        // 5 usable rows over 10 lines: max offset is 5
+        assert_eq!(off, 5);
+        assert!(out.contains(" · top"));
+        assert!(out.contains("l0"));
+        assert!(!out.contains("l9"));
+        // autowrap off and synchronized update are part of the contract
+        assert!(out.contains("\x1b[?7l"));
+        assert!(out.starts_with("\x1b[?2026h"));
+        assert!(out.ends_with("\x1b[?2026l"));
+    }
+
+    #[test]
+    fn render_at_bottom_shows_last_lines_without_top_marker() {
+        let view = HistView { lines: (0..10).map(|i| format!("l{i}")).collect(), offset: 0 };
+        let (out, off) = render(&view, 80, 6);
+        assert_eq!(off, 0);
+        assert!(out.contains("l9"));
+        assert!(!out.contains(" · top"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod daemon;
 mod docker;
 mod foreground;
 mod grid;
+mod hist;
 mod layout_sync;
 mod mirror;
 mod pane;

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -358,6 +358,7 @@ pub(crate) fn cmd_for_pane(
     let always_control = host.always_control;
     let max_cols = host.max_cols;
     let max_rows = host.max_rows;
+    let mouse_local = host.mouse_local_apps.clone();
     let kind = host.kind.clone();
     let docker_bin = host.docker_bin.clone();
     // daemon's ControlMaster socket for this host (see remote.rs); the streamer
@@ -390,6 +391,11 @@ pub(crate) fn cmd_for_pane(
         }
         if let Some(r) = max_rows {
             argv.extend(["--max-rows".into(), r.to_string()]);
+        }
+        // one comma-joined flag rather than one per name, so a host with a long
+        // list doesn't blow up the argv the daemon has to match on when healing
+        if !mouse_local.is_empty() {
+            argv.extend(["--mouse-local".into(), mouse_local.join(",")]);
         }
         // ssh only: the pane reuses the daemon's ControlMaster for cheap
         // foreground polls. Docker has no ControlMaster, and healing no longer
@@ -1528,6 +1534,7 @@ mod tests {
             always_control: true,
             max_cols: None,
             max_rows: None,
+            mouse_local_apps: Vec::new(),
             api_transport: crate::config::ApiTransport::Auto,
         }
     }
@@ -1761,6 +1768,19 @@ mod tests {
         // still whatever --cols/--rows said (here: unset, so the defaults,
         // which #42 made a floor rather than an exact size)
         assert_eq!((parsed.cols, parsed.rows), (240, 72));
+    }
+
+    #[test]
+    fn mouse_local_apps_reach_the_streamer_argv() {
+        let mut host = ssh_host();
+        let bare = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        // an unconfigured host's argv is unchanged, so the built-in lists stand alone
+        assert!(!bare.iter().any(|a| a == "--mouse-local"));
+
+        host.mouse_local_apps = vec!["myagent".into(), "other".into()];
+        let argv = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
+        assert_eq!(parsed.mouse_local, vec!["myagent", "other"]);
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -535,7 +535,7 @@ fn whole_chunk_arrow_burst(bytes: &[u8]) -> Option<(bool, usize)> {
             .then(|| b[i + 2] == b'A')
     }
     let up = arrow_at(bytes, 0)?;
-    if bytes.len() % 3 != 0 {
+    if !bytes.len().is_multiple_of(3) {
         return None;
     }
     let n = bytes.len() / 3;

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -735,6 +735,8 @@ struct App {
     control_failures: u32,
     control_sticky: bool,
     pending_input: Vec<Vec<u8>>,
+    /// wheel notches that arrived before control was up; scrolled on connect
+    pending_wheel: Vec<(bool, usize)>,
     last_input: Instant,
     hint_clear_at: Option<Instant>,
     /// predictive local echo — draws keystrokes optimistically, frame-verified
@@ -953,8 +955,24 @@ impl App {
                     }
                 } else {
                     self.pending_input.clear();
+                    self.pending_wheel.clear();
                 }
                 self.session = Some(s);
+                // wheel notches that escalated us here scroll now, coalesced
+                // by direction so a fast flick is one message, not ten
+                if m == Mode::Control && !self.pending_wheel.is_empty() {
+                    let notches = std::mem::take(&mut self.pending_wheel);
+                    let mut merged: Vec<(bool, usize)> = Vec::new();
+                    for (up, n) in notches {
+                        match merged.last_mut() {
+                            Some((u, c)) if *u == up => *c += n,
+                            _ => merged.push((up, n)),
+                        }
+                    }
+                    for (up, n) in merged {
+                        self.emit_wheel(up, n).await;
+                    }
+                }
                 // warm the foreground classification before the user mouses
                 self.spawn_foreground_poll(false);
                 // always-control has no release, so no "ctrl+\ to release" hint
@@ -1248,11 +1266,16 @@ impl App {
                     if self.in_full_control() {
                         self.last_input = Instant::now();
                         self.emit_wheel(h.up, h.count).await;
-                    } else if self.control_sticky {
+                    } else {
+                        // scrolling IS the intent: take control like a
+                        // keystroke would and scroll once the session is up
                         self.control_sticky = false;
-                        self.switch_mode(Mode::Control);
-                    } else if self.mode == Mode::Observe {
-                        self.hint("read-only — type to take control");
+                        if self.pending_wheel.len() < 32 {
+                            self.pending_wheel.push((h.up, h.count));
+                        }
+                        if self.mode == Mode::Observe {
+                            self.switch_mode(Mode::Control);
+                        }
                     }
                 }
                 return;
@@ -1263,15 +1286,13 @@ impl App {
         if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
             // no quit key: the wrapper's lifecycle belongs to the hosting pane
             if has_mouse_seq(&buf) {
-                // wheel escalates only after a soft release; a stray wheel
-                // while glancing shouldn't grab the remote's lock
+                // scrolling is intent enough: a wheel takes control like a
+                // keystroke and the events deliver once the session is up.
+                // Clicks and drags while merely glancing stay dropped.
                 if contains_wheel_press(&buf) {
-                    if self.control_sticky {
-                        self.control_sticky = false;
-                        self.switch_mode(Mode::Control);
-                    } else {
-                        self.hint("read-only — type to take control");
-                    }
+                    self.control_sticky = false;
+                    self.pending_input.push(buf);
+                    self.switch_mode(Mode::Control);
                 }
                 return;
             }
@@ -1523,6 +1544,7 @@ pub async fn run(args: Args) -> Result<()> {
         control_failures: 0,
         control_sticky: false,
         pending_input: Vec::new(),
+        pending_wheel: Vec::new(),
         last_input: Instant::now(),
         hint_clear_at: None,
         predict: Predictor::new(),

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -516,17 +516,18 @@ fn mouse_action(
     }
 }
 
-/// herdr's alternate-scroll emulation, recognized after the fact. With the
-/// mouse grab released (the price of native selection), the local herdr owns
-/// the wheel again — and for an alternate-screen pane it synthesizes
-/// `mouse_scroll_lines` identical arrow keys per notch, written as ONE chunk.
-/// Typed into an agent CLI those arrows cycle its composer history: a wheel
-/// flick rewrites what the user was about to send. A chunk that is NOTHING
-/// BUT >=3 identical arrows is that emulation — a human keypress arrives one
-/// arrow per chunk, autorepeat one per event, and a bracketed paste carries
-/// its `ESC[200~` prefix — so it is safe to take the burst back and route it
-/// as the wheel it really was. Returns (up, arrow_count).
-fn whole_chunk_arrow_burst(bytes: &[u8]) -> Option<(bool, usize)> {
+/// A chunk that is NOTHING BUT identical arrow-key sequences — the raw
+/// material of herdr's alternate-scroll emulation. With the mouse grab
+/// released (the price of native selection), the local herdr owns the wheel
+/// again, and for an alternate-screen pane it synthesizes
+/// `mouse_scroll_lines` identical arrows per notch. Typed into an agent CLI
+/// those arrows cycle its composer history: a wheel flick rewrites what the
+/// user was about to send. The emulation's writes may reach us as one chunk
+/// or one arrow at a time, so recognition is an ACCUMULATOR (`ArrowHold` on
+/// App): this function only reports "this chunk is purely N identical
+/// arrows". A bracketed paste never matches — its `ESC[200~` prefix is not
+/// an arrow. Returns (up, arrow_count, the 3-byte sequence).
+fn whole_chunk_arrows(bytes: &[u8]) -> Option<(bool, usize, [u8; 3])> {
     fn arrow_at(b: &[u8], i: usize) -> Option<bool> {
         (b.len() >= i + 3
             && b[i] == 0x1b
@@ -535,7 +536,7 @@ fn whole_chunk_arrow_burst(bytes: &[u8]) -> Option<(bool, usize)> {
             .then(|| b[i + 2] == b'A')
     }
     let up = arrow_at(bytes, 0)?;
-    if !bytes.len().is_multiple_of(3) {
+    if bytes.len() < 3 || !bytes.len().is_multiple_of(3) {
         return None;
     }
     let n = bytes.len() / 3;
@@ -544,8 +545,23 @@ fn whole_chunk_arrow_burst(bytes: &[u8]) -> Option<(bool, usize)> {
             return None;
         }
     }
-    (n >= 3).then_some((up, n))
+    Some((up, n, [bytes[0], bytes[1], bytes[2]]))
 }
+
+/// Arrows held back while we decide whether they are a wheel notch. Reaching
+/// [`WHEEL_ARROWS`] inside the hold window is the emulation — no human
+/// presses the same arrow three times in 35ms, and autorepeat delivers one
+/// event at a time, far slower. Anything less flushes to the remote as the
+/// keystrokes they were, delayed imperceptibly.
+struct ArrowHold {
+    up: bool,
+    seq: [u8; 3],
+    count: usize,
+    flush_at: Instant,
+}
+
+const ARROW_HOLD_WINDOW: Duration = Duration::from_millis(35);
+const WHEEL_ARROWS: usize = 3; // herdr's mouse_scroll_lines default
 
 fn contains_wheel_press(bytes: &[u8]) -> bool {
     let mut i = 0;
@@ -732,6 +748,9 @@ struct App {
     /// (treated as "leave it to herdr", so selection works before the first poll
     /// lands rather than after the user has typed something).
     remote_wants_mouse: Option<bool>,
+    /// arrows held while deciding whether they are a wheel notch (alternate-
+    /// scroll emulation) or real keystrokes; flushed on window expiry
+    arrow_hold: Option<ArrowHold>,
     /// frame-driven classification attempts spent so far (see `handle_frame`)
     frame_fg_polls: u8,
     /// last time a foreground poll was kicked off (throttles the ssh handshakes)
@@ -1252,36 +1271,34 @@ impl App {
         // and re-check shortly after input settles, to catch a change the input
         // just caused (e.g. `:q` quitting vim — the poll above still sees vim)
         self.settle_at = Some(Instant::now() + SETTLE_DELAY);
-        // A pure burst of identical arrows is the local herdr's wheel
-        // emulation (see whole_chunk_arrow_burst) — take it back and scroll:
-        // a shell's scrollback moves semantically; a mouse-blind TUI (agent
-        // CLI) gets the wheel re-materialized as SGR, which it consumes as
-        // chat-view scrolling instead of having its composer history cycled.
-        // Unknown or mouse-wanting foregrounds pass through untouched.
-        if let Some((up, arrows)) = whole_chunk_arrow_burst(&buf) {
-            match (self.remote_is_shell, self.remote_wants_mouse) {
-                (Some(true), _) => {
-                    self.send(json!({
-                        "type": "terminal.scroll",
-                        "direction": if up { "up" } else { "down" },
-                        "lines": arrows,
-                        "source": "wheel",
-                        "column": 0,
-                        "row": 0,
-                        "modifiers": 0,
-                    }))
-                    .await;
-                    return;
+        // Arrow chunks feed the wheel accumulator (see ArrowHold): herdr's
+        // alternate-scroll emulation may arrive one arrow per chunk, so a
+        // lone arrow is held ~35ms; three identical ones inside the window
+        // are a wheel notch. Only when the grab is released (that is the only
+        // time herdr synthesizes arrows) and never mid-decision for a
+        // mouse-wanting foreground.
+        if self.remote_wants_mouse != Some(true) {
+            if let Some((up, n, seq)) = whole_chunk_arrows(&buf) {
+                match &mut self.arrow_hold {
+                    Some(h) if h.up == up => h.count += n,
+                    _ => {
+                        self.flush_arrow_hold().await;
+                        self.arrow_hold = Some(ArrowHold {
+                            up,
+                            seq,
+                            count: n,
+                            flush_at: Instant::now() + ARROW_HOLD_WINDOW,
+                        });
+                    }
                 }
-                (Some(false), Some(false)) => {
-                    let sgr: &[u8] = if up { b"\x1b[<64;1;1M" } else { b"\x1b[<65;1;1M" };
-                    let bytes: Vec<u8> = sgr.repeat(arrows.div_ceil(3));
-                    self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) }))
-                        .await;
-                    return;
+                if self.arrow_hold.as_ref().is_some_and(|h| h.count >= WHEEL_ARROWS) {
+                    let h = self.arrow_hold.take().unwrap();
+                    self.emit_wheel(h.up, h.count).await;
                 }
-                _ => {}
+                return;
             }
+            // anything else flushes held arrows first, keeping input order
+            self.flush_arrow_hold().await;
         }
         // wheel becomes a semantic scroll (server decides app vs scrollback);
         // clicks/drags forward to the remote pty only when the foreground is a
@@ -1322,6 +1339,43 @@ impl App {
             if self.predict.on_input(&rest, &self.grid) {
                 self.paint();
             }
+        }
+    }
+
+    /// Held arrows turned out to be keystrokes — forward them unchanged.
+    async fn flush_arrow_hold(&mut self) {
+        if let Some(h) = self.arrow_hold.take() {
+            let bytes: Vec<u8> = h.seq.repeat(h.count);
+            self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) })).await;
+        }
+    }
+
+    /// A recognized wheel notch, routed by foreground: a shell's remote
+    /// scrollback scrolls semantically; a mouse-blind TUI (agent CLI) gets
+    /// the wheel re-materialized as SGR, which it consumes as chat-view
+    /// scrolling instead of having its composer history cycled; an unknown
+    /// foreground drops it — the uncertain case should cost the scroll, not
+    /// type junk into whatever is there.
+    async fn emit_wheel(&mut self, up: bool, arrows: usize) {
+        match self.remote_is_shell {
+            Some(true) => {
+                self.send(json!({
+                    "type": "terminal.scroll",
+                    "direction": if up { "up" } else { "down" },
+                    "lines": arrows,
+                    "source": "wheel",
+                    "column": 0,
+                    "row": 0,
+                    "modifiers": 0,
+                }))
+                .await;
+            }
+            Some(false) => {
+                let sgr: &[u8] = if up { b"\x1b[<64;1;1M" } else { b"\x1b[<65;1;1M" };
+                let bytes: Vec<u8> = sgr.repeat(arrows.div_ceil(WHEEL_ARROWS));
+                self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) })).await;
+            }
+            None => {}
         }
     }
 
@@ -1448,6 +1502,7 @@ pub async fn run(args: Args) -> Result<()> {
         predict: Predictor::new(),
         remote_is_shell: None,
         remote_wants_mouse: None,
+        arrow_hold: None,
         frame_fg_polls: 0,
         fg_poll_at: None,
         settle_at: None,
@@ -1502,6 +1557,7 @@ pub async fn run(args: Args) -> Result<()> {
             idle_at,
             app.predict.deadline(),
             app.settle_at,
+            app.arrow_hold.as_ref().map(|h| h.flush_at),
         ]);
 
         tokio::select! {
@@ -1570,6 +1626,10 @@ pub async fn run(args: Args) -> Result<()> {
                 if app.settle_at.is_some_and(|t| t <= now) {
                     app.settle_at = None;
                     app.spawn_foreground_poll(true); // forced: bypass the throttle
+                }
+                if app.arrow_hold.as_ref().is_some_and(|h| h.flush_at <= now) {
+                    // window expired below the wheel threshold: keystrokes
+                    app.flush_arrow_hold().await;
                 }
                 if app.predict.deadline().is_some_and(|t| t <= now) {
                     app.predict.on_tick(); // wipe timed-out ghosts (no-echo prompts)
@@ -1656,22 +1716,24 @@ mod tests {
     }
 
     #[test]
-    fn arrow_bursts_are_recognized_and_human_input_is_not() {
-        // herdr's wheel emulation: 3 identical arrows in one chunk
-        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A\x1b[A"), Some((true, 3)));
-        assert_eq!(whole_chunk_arrow_burst(b"\x1b[B\x1b[B\x1b[B"), Some((false, 3)));
+    fn arrow_chunks_are_recognized_and_anything_else_is_not() {
+        // pure arrow chunks report their count — one per chunk (how the
+        // emulation often arrives) up to whole coalesced notches
+        assert_eq!(whole_chunk_arrows(b"\x1b[A"), Some((true, 1, *b"\x1b[A")));
+        assert_eq!(whole_chunk_arrows(b"\x1b[A\x1b[A\x1b[A"), Some((true, 3, *b"\x1b[A")));
+        assert_eq!(whole_chunk_arrows(b"\x1b[B\x1b[B\x1b[B"), Some((false, 3, *b"\x1b[B")));
         // application cursor keys mode
-        assert_eq!(whole_chunk_arrow_burst(b"\x1bOA\x1bOA\x1bOA"), Some((true, 3)));
+        assert_eq!(whole_chunk_arrows(b"\x1bOA\x1bOA\x1bOA"), Some((true, 3, *b"\x1bOA")));
         // two coalesced notches
-        assert_eq!(whole_chunk_arrow_burst(&b"\x1b[A".repeat(6)), Some((true, 6)));
-        // a single keypress is never a burst
-        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A"), None);
-        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A"), None);
+        assert_eq!(whole_chunk_arrows(&b"\x1b[A".repeat(6)), Some((true, 6, *b"\x1b[A")));
         // mixed directions or trailing bytes: not the emulation's shape
-        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A\x1b[B"), None);
-        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A\x1b[Ax"), None);
+        assert_eq!(whole_chunk_arrows(b"\x1b[A\x1b[A\x1b[B"), None);
+        assert_eq!(whole_chunk_arrows(b"\x1b[A\x1b[A\x1b[Ax"), None);
         // a bracketed paste of arrows keeps its prefix, so it never matches
-        assert_eq!(whole_chunk_arrow_burst(b"\x1b[200~\x1b[A\x1b[A\x1b[A\x1b[201~"), None);
+        assert_eq!(whole_chunk_arrows(b"\x1b[200~\x1b[A\x1b[A\x1b[A\x1b[201~"), None);
+        // plain typing is untouched
+        assert_eq!(whole_chunk_arrows(b"hello"), None);
+        assert_eq!(whole_chunk_arrows(b"\x1b[C"), None); // right arrow: not a scroll
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -217,6 +217,8 @@ enum Msg {
     /// result of a background foreground-process poll: Some(true)=shell,
     /// Some(false)=TUI, None=poll failed (keep last value)
     Foreground(Option<crate::foreground::Fg>),
+    /// result of a background history fetch for the local history view
+    Hist(Option<Vec<String>>),
     Paste(crate::paste::Outcome),
     Drop(crate::paste::DropResult),
 }
@@ -473,40 +475,35 @@ fn parse_mouse(bytes: &[u8], at: usize) -> Option<(u32, u32, u32, bool, usize)> 
 /// How a parsed mouse event should be routed while in control mode.
 #[derive(Debug, PartialEq, Eq)]
 enum MouseAction {
-    /// wheel/click/drag on a remote TUI or agent: forward the raw SGR sequence
+    /// click/drag on a mouse-aware remote TUI: forward the raw SGR sequence
     ForwardRaw,
+    /// wheel over anything that can't consume it: drive the local history view
+    Notch { up: bool },
     /// event at a process where forwarding could corrupt input: drop, keep it local
     Drop,
 }
 
-/// A wheel forwards its raw SGR to any non-shell foreground and is dropped
-/// otherwise — the same policy as [`emit_wheel`] on the arrow-emulation path.
-/// A mouse-aware TUI asked for exactly this encoding; an agent CLI's
-/// fullscreen renderer consumes it as chat-view scrolling, and the
-/// classic/inline renderers' parsers swallow unrequested SGR without echo
-/// (probed against Claude Code and codex). A SHELL drops it — there is no
-/// safe delivery: the session API's `terminal.scroll` turned out to type
-/// history-cycling ARROW KEYS at any pane whose app never enabled the mouse
-/// (measured), and raw SGR at a prompt is garbage on the command line. No
-/// scroll beats corrupted input. The unknown foreground drops for the same
-/// reason clicks do below.
+/// A wheel forwards its raw SGR only to a foreground that verifiably wants
+/// the mouse — it asked for exactly this encoding. Everything else gets the
+/// LOCAL history view instead (see hist.rs): nothing can be scrolled remotely
+/// — the session API's `terminal.scroll` turned out to type history-cycling
+/// ARROW KEYS at any pane whose app never enabled the mouse (measured), and a
+/// classic/inline agent renderer swallows re-materialized SGR without moving
+/// anything (probed against Claude Code and codex) — while the pane's real
+/// history is always readable server-side. The view is read-only and local,
+/// so even the unknown foreground gets it: a glance-scroll costs nothing.
 ///
 /// Clicks and drags forward only when the foreground is *known* to want the
 /// mouse. Unknown drops: sending SGR bytes to a program that never enabled
 /// reporting types garbage into it, and the grab that makes forwarding possible
 /// is the same grab that takes native selection away from herdr — so the
 /// uncertain case should cost the click, not the selection.
-fn mouse_action(
-    remote_is_shell: Option<bool>,
-    remote_wants_mouse: Option<bool>,
-    btn: u32,
-    press: bool,
-) -> MouseAction {
+fn mouse_action(remote_wants_mouse: Option<bool>, btn: u32, press: bool) -> MouseAction {
     if press && (btn == 64 || btn == 65) {
-        if remote_is_shell == Some(false) {
+        if remote_wants_mouse == Some(true) {
             MouseAction::ForwardRaw
         } else {
-            MouseAction::Drop
+            MouseAction::Notch { up: btn == 64 }
         }
     } else if btn == 66 || btn == 67 {
         MouseAction::Drop
@@ -564,19 +561,22 @@ struct ArrowHold {
 const ARROW_HOLD_WINDOW: Duration = Duration::from_millis(35);
 const WHEEL_ARROWS: usize = 3; // herdr's mouse_scroll_lines default
 
-fn contains_wheel_press(bytes: &[u8]) -> bool {
+/// Every wheel press in the chunk, in order: `true` = up. Empty for clicks,
+/// drags, releases and plain text.
+fn wheel_presses(bytes: &[u8]) -> Vec<bool> {
+    let mut presses = Vec::new();
     let mut i = 0;
     while i < bytes.len() {
         if let Some((btn, _, _, press, len)) = parse_mouse(bytes, i) {
             if press && (btn == 64 || btn == 65) {
-                return true;
+                presses.push(btn == 64);
             }
             i += len;
         } else {
             i += 1;
         }
     }
-    false
+    presses
 }
 
 /// Cap on a partially-received bracketed paste. Past this we stop waiting for
@@ -736,8 +736,12 @@ struct App {
     control_failures: u32,
     control_sticky: bool,
     pending_input: Vec<Vec<u8>>,
-    /// wheel notches that arrived before control was up; scrolled on connect
-    pending_wheel: Vec<(bool, usize)>,
+    /// local history view (wheel-up over the pane); None = live mirror
+    hist: Option<crate::hist::HistView>,
+    /// a history fetch is in flight
+    hist_fetching: bool,
+    /// wheel-up lines accumulated while the fetch is in flight
+    hist_pending: usize,
     last_input: Instant,
     hint_clear_at: Option<Instant>,
     /// predictive local echo — draws keystrokes optimistically, frame-verified
@@ -956,24 +960,8 @@ impl App {
                     }
                 } else {
                     self.pending_input.clear();
-                    self.pending_wheel.clear();
                 }
                 self.session = Some(s);
-                // wheel notches that escalated us here scroll now, coalesced
-                // by direction so a fast flick is one message, not ten
-                if m == Mode::Control && !self.pending_wheel.is_empty() {
-                    let notches = std::mem::take(&mut self.pending_wheel);
-                    let mut merged: Vec<(bool, usize)> = Vec::new();
-                    for (up, n) in notches {
-                        match merged.last_mut() {
-                            Some((u, c)) if *u == up => *c += n,
-                            _ => merged.push((up, n)),
-                        }
-                    }
-                    for (up, n) in merged {
-                        self.emit_wheel(up, n).await;
-                    }
-                }
                 // warm the foreground classification before the user mouses
                 self.spawn_foreground_poll(false);
                 // always-control has no release, so no "ctrl+\ to release" hint
@@ -1042,7 +1030,9 @@ impl App {
         if frame.kind == "terminal.closed" {
             let suffix = frame.reason.as_deref().map(|r| format!(": {r}")).unwrap_or_default();
             self.renderer.status(&format!("remote terminal closed{suffix}"));
-            self.paint();
+            if self.hist.is_none() {
+                self.paint();
+            }
             return;
         }
         if frame.kind != "terminal.frame" {
@@ -1087,7 +1077,9 @@ impl App {
                 frame.height.unwrap_or(0),
                 lines.join("\n")
             );
-        } else {
+        } else if self.hist.is_none() {
+            // the grid stays current underneath the history view; the paint
+            // waits until the view exits
             self.paint();
         }
     }
@@ -1244,10 +1236,9 @@ impl App {
         // emulation (the grab is released, so a wheel arrives as synthesized
         // arrows) hits the observe branch below as "any keystroke", where it
         // would escalate to control and cycle an agent CLI's prompt history.
-        // Hold pure-arrow chunks; a notch inside the window is a wheel and is
-        // routed (full control) or treated like the stray SGR wheel below
-        // (observe: never grab the remote's lock for a glance-scroll);
-        // anything less flushes as the keystrokes it was.
+        // Hold pure-arrow chunks; a notch inside the window is a wheel and
+        // drives the LOCAL history view; anything less flushes as the
+        // keystrokes it was.
         if self.remote_wants_mouse != Some(true) {
             if let Some((up, n, seq)) = whole_chunk_arrows(&buf) {
                 match &mut self.arrow_hold {
@@ -1264,36 +1255,27 @@ impl App {
                 }
                 if self.arrow_hold.as_ref().is_some_and(|h| h.count >= WHEEL_ARROWS) {
                     let h = self.arrow_hold.take().unwrap();
-                    if self.in_full_control() {
-                        self.last_input = Instant::now();
-                        self.emit_wheel(h.up, h.count).await;
-                    } else {
-                        // scrolling IS the intent: take control like a
-                        // keystroke would and scroll once the session is up
-                        self.control_sticky = false;
-                        if self.pending_wheel.len() < 32 {
-                            self.pending_wheel.push((h.up, h.count));
-                        }
-                        if self.mode == Mode::Observe {
-                            self.switch_mode(Mode::Control);
-                        }
-                    }
+                    self.wheel_notch(h.up, h.count);
                 }
                 return;
             }
             // any other input first flushes held arrows, keeping their order
             self.flush_arrow_hold().await;
         }
+        // any real (non-mouse) input returns the pane from the history view
+        // to live, then behaves exactly as it would have; mouse events fall
+        // through so the wheel keeps driving the view
+        if self.hist.is_some() && !has_mouse_seq(&buf) {
+            self.exit_hist();
+        }
         if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
             // no quit key: the wrapper's lifecycle belongs to the hosting pane
             if has_mouse_seq(&buf) {
-                // scrolling is intent enough: a wheel takes control like a
-                // keystroke and the events deliver once the session is up.
-                // Clicks and drags while merely glancing stay dropped.
-                if contains_wheel_press(&buf) {
-                    self.control_sticky = false;
-                    self.pending_input.push(buf);
-                    self.switch_mode(Mode::Control);
+                // a wheel opens the local history view — read-only, never
+                // grab the remote's agent lock for a glance-scroll. Clicks
+                // and drags while merely glancing stay dropped.
+                for up in wheel_presses(&buf) {
+                    self.wheel_notch(up, WHEEL_ARROWS);
                 }
                 return;
             }
@@ -1336,11 +1318,13 @@ impl App {
         // clicks/drags forward to the remote pty only when the foreground is a
         // TUI — at a shell they're dropped so they don't garbage the prompt
         let mut rest: Vec<u8> = Vec::with_capacity(buf.len());
+        let mut notches: Vec<bool> = Vec::new();
         let mut i = 0usize;
         while i < buf.len() {
             if let Some((btn, _x, _y, press, len)) = parse_mouse(&buf, i) {
-                match mouse_action(self.remote_is_shell, self.remote_wants_mouse, btn, press) {
+                match mouse_action(self.remote_wants_mouse, btn, press) {
                     MouseAction::ForwardRaw => rest.extend_from_slice(&buf[i..i + len]),
+                    MouseAction::Notch { up } => notches.push(up),
                     MouseAction::Drop => {}
                 }
                 i += len;
@@ -1348,6 +1332,9 @@ impl App {
                 rest.push(buf[i]);
                 i += 1;
             }
+        }
+        for up in notches {
+            self.wheel_notch(up, WHEEL_ARROWS);
         }
         if !rest.is_empty() {
             let msg = json!({ "type": "terminal.input", "bytes": B64.encode(&rest) });
@@ -1367,8 +1354,13 @@ impl App {
 
     /// Held arrows turned out to be keystrokes — deliver them the way the
     /// mode they arrived in would have: sent directly under full control,
-    /// queued (and escalating, exactly like any typed key) otherwise.
+    /// queued (and escalating, exactly like any typed key) otherwise. A real
+    /// keystroke also returns the pane from the history view first, so the
+    /// arrow acts on the live remote the user now sees.
     async fn flush_arrow_hold(&mut self) {
+        if self.arrow_hold.is_some() && self.hist.is_some() {
+            self.exit_hist();
+        }
         if let Some(h) = self.arrow_hold.take() {
             let bytes: Vec<u8> = h.seq.repeat(h.count);
             if self.in_full_control() {
@@ -1383,29 +1375,106 @@ impl App {
         }
     }
 
-    /// A recognized wheel notch, re-materialized as an SGR wheel event for
-    /// any non-shell foreground and DROPPED for a shell or an unknown one.
-    ///
-    /// Why not the session API's `terminal.scroll`: it turned out to have
-    /// deliver-to-the-app semantics, not viewport semantics. It cannot reach
-    /// the server-side scrollback, and for a pane whose app never enabled the
-    /// mouse it falls back to typing ARROW KEYS at it (measured: three `^[[A`
-    /// echoed at the prompt, scrollback offset untouched) — at a shell prompt
-    /// those cycle command history, and at an agent composer they cycle
-    /// prompt history. The SGR event is safe across the board instead: a
-    /// mouse-aware TUI asked for exactly this encoding, a fullscreen agent
-    /// renderer consumes it as chat-view scrolling, and the classic/inline
-    /// agent renderers' input parsers swallow unrequested SGR without echo
-    /// (probed against both Claude Code and codex) — so the worst case is a
-    /// dead wheel, never junk in the composer. No scroll beats corrupted
-    /// input, which is also why a shell and the unknown foreground drop.
-    async fn emit_wheel(&mut self, up: bool, arrows: usize) {
-        if self.remote_is_shell != Some(false) {
+    /// A wheel notch over the pane. Up opens or deepens the LOCAL history
+    /// view — the remote pane's server-side history fetched over the existing
+    /// ssh path and rendered here, read-only, no control session and no agent
+    /// lock (see hist.rs for why nothing can be scrolled remotely) — and down
+    /// shallows it until the pane lands back on the live mirror.
+    fn wheel_notch(&mut self, up: bool, lines: usize) {
+        if up {
+            if self.hist.is_some() {
+                if let Some(h) = &mut self.hist {
+                    h.offset += lines;
+                }
+                self.paint_hist();
+            } else if self.hist_fetching {
+                self.hist_pending += lines;
+            } else {
+                self.hist_fetching = true;
+                self.hist_pending = lines;
+                self.hint_sticky("history…");
+                self.spawn_hist_fetch();
+            }
+        } else if self.hist_fetching {
+            // scrolled back down before the fetch landed; reaching zero
+            // cancels the view (handle_hist discards the result)
+            self.hist_pending = self.hist_pending.saturating_sub(lines);
+        } else if let Some(off) = self.hist.as_ref().map(|h| h.offset) {
+            if off <= lines {
+                self.exit_hist();
+            } else {
+                if let Some(h) = &mut self.hist {
+                    h.offset = off - lines;
+                }
+                self.paint_hist();
+            }
+        }
+    }
+
+    /// Kick the background history fetch; the result arrives as Msg::Hist.
+    fn spawn_hist_fetch(&mut self) {
+        let tx = self.tx.clone();
+        let ssh = self.args.ssh_target.clone();
+        let bin = self.args.remote_bin.clone();
+        let session = self.args.session.clone();
+        let pane = self.args.pane_target.clone();
+        let ctl = self.args.ctl_path.clone();
+        let container = self.args.container.clone();
+        tokio::spawn(async move {
+            let v = crate::hist::fetch(
+                &ssh,
+                bin.as_deref(),
+                session.as_deref(),
+                &pane,
+                ctl.as_deref(),
+                container.as_ref(),
+            )
+            .await;
+            let _ = tx.send(Msg::Hist(v)).await;
+        });
+    }
+
+    fn handle_hist(&mut self, lines: Option<Vec<String>>) {
+        self.hist_fetching = false;
+        let pending = std::mem::take(&mut self.hist_pending);
+        match lines {
+            None => self.hint("history unavailable"),
+            Some(_) if pending == 0 => {
+                // the user scrolled back down while the fetch was in flight
+                self.renderer.status("");
+                self.paint();
+            }
+            Some(lines) => {
+                self.hist = Some(crate::hist::HistView { lines, offset: pending });
+                self.paint_hist();
+            }
+        }
+    }
+
+    fn paint_hist(&mut self) {
+        if !self.tty {
             return;
         }
-        let sgr: &[u8] = if up { b"\x1b[<64;1;1M" } else { b"\x1b[<65;1;1M" };
-        let bytes: Vec<u8> = sgr.repeat(arrows.div_ceil(WHEEL_ARROWS));
-        self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) })).await;
+        let (cols, rows) = term_size();
+        let Some(view) = self.hist.as_ref() else { return };
+        let (out, off) = crate::hist::render(view, cols, rows);
+        if let Some(h) = self.hist.as_mut() {
+            h.offset = off;
+        }
+        write_stdout(&out);
+    }
+
+    /// Leave the history view: restore autowrap and the cursor, then repaint
+    /// the live grid from scratch.
+    fn exit_hist(&mut self) {
+        self.hist = None;
+        self.hist_pending = 0;
+        if self.tty {
+            write_stdout("\x1b[?7h\x1b[?25h");
+        }
+        self.renderer.status("");
+        self.renderer.invalidate();
+        self.paint();
     }
 
     async fn deliver_input(&mut self, buf: Vec<u8>) {
@@ -1526,7 +1595,9 @@ pub async fn run(args: Args) -> Result<()> {
         control_failures: 0,
         control_sticky: false,
         pending_input: Vec::new(),
-        pending_wheel: Vec::new(),
+        hist: None,
+        hist_fetching: false,
+        hist_pending: 0,
         last_input: Instant::now(),
         hint_clear_at: None,
         predict: Predictor::new(),
@@ -1604,11 +1675,16 @@ pub async fn run(args: Args) -> Result<()> {
                         app.sync_mouse_grab();
                         app.sync_cursor_key_mode();
                     },
+                    Some(Msg::Hist(v)) => app.handle_hist(v),
                     Some(Msg::Paste(outcome)) => app.handle_paste(outcome).await,
                     Some(Msg::Drop(result)) => app.handle_drop(result).await,
                 }
             }
             _ = sigwinch.recv() => {
+                // a resize invalidates the view's row addressing — go live
+                if app.hist.is_some() {
+                    app.exit_hist();
+                }
                 app.renderer.invalidate();
                 // a resize means a client is laying this pane out, so the size is
                 // now a real viewport: take control if that is what we're for.
@@ -1714,30 +1790,27 @@ mod tests {
     }
 
     #[test]
-    fn wheel_forwards_to_any_non_shell_and_never_touches_shells() {
+    fn wheel_forwards_to_mouse_tuis_and_drives_the_view_everywhere_else() {
         // a mouse-aware TUI asked for SGR wheel events — forward with coords
-        assert_eq!(mouse_action(Some(false), Some(true), 65, true), MouseAction::ForwardRaw);
-        // an agent CLI too: fullscreen renderers scroll their chat view with
-        // it, classic/inline parsers swallow it silently
-        assert_eq!(mouse_action(Some(false), Some(false), 64, true), MouseAction::ForwardRaw);
-        // a shell gets NOTHING: terminal.scroll would type history-cycling
-        // arrows and raw SGR is garbage on the command line
-        assert_eq!(mouse_action(Some(true), Some(false), 64, true), MouseAction::Drop);
-        // unknown foreground: drop, same reasoning as clicks
-        assert_eq!(mouse_action(None, None, 64, true), MouseAction::Drop);
+        assert_eq!(mouse_action(Some(true), 65, true), MouseAction::ForwardRaw);
+        // everything else — shell, agent CLI, unknown — gets the local
+        // history view: nothing can be scrolled remotely, and the view is
+        // read-only so even the uncertain case costs nothing
+        assert_eq!(mouse_action(Some(false), 64, true), MouseAction::Notch { up: true });
+        assert_eq!(mouse_action(Some(false), 65, true), MouseAction::Notch { up: false });
+        assert_eq!(mouse_action(None, 64, true), MouseAction::Notch { up: true });
     }
 
     #[test]
     fn clicks_forward_only_to_a_foreground_that_asked_for_them() {
         // a real mouse-aware TUI (vim, htop) gets the click
-        assert_eq!(mouse_action(Some(false), Some(true), 0, true), MouseAction::ForwardRaw);
+        assert_eq!(mouse_action(Some(true), 0, true), MouseAction::ForwardRaw);
         // a shell or an agent CLI does not: forwarding types SGR garbage into a
         // program that never enabled reporting, and holding the grab needed to
         // forward is what costs herdr its native selection
-        assert_eq!(mouse_action(Some(false), Some(false), 0, true), MouseAction::Drop);
-        assert_eq!(mouse_action(Some(true), Some(false), 0, true), MouseAction::Drop);
+        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::Drop);
         // and while we still don't know, the click is the cheaper thing to lose
-        assert_eq!(mouse_action(None, None, 0, true), MouseAction::Drop);
+        assert_eq!(mouse_action(None, 0, true), MouseAction::Drop);
     }
 
     #[test]
@@ -1766,9 +1839,10 @@ mod tests {
         let seq = b"\x1b[<64;10;5M";
         let (btn, x, y, press, len) = parse_mouse(seq, 0).unwrap();
         assert_eq!((btn, x, y, press, len), (64, 10, 5, true, seq.len()));
-        assert!(contains_wheel_press(seq));
-        assert!(!contains_wheel_press(b"\x1b[<0;3;4M")); // click, not wheel
-        assert!(!contains_wheel_press(b"\x1b[<64;10;5m")); // release, not press
+        assert_eq!(wheel_presses(seq), vec![true]);
+        assert_eq!(wheel_presses(b"\x1b[<65;1;1M\x1b[<64;1;1M"), vec![false, true]);
+        assert!(wheel_presses(b"\x1b[<0;3;4M").is_empty()); // click, not wheel
+        assert!(wheel_presses(b"\x1b[<64;10;5m").is_empty()); // release, not press
         assert!(has_mouse_seq(b"xx\x1b[<0;1;1Myy"));
         assert!(!has_mouse_seq(b"plain text"));
     }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -75,6 +75,10 @@ pub struct Args {
     pub ctl_path: Option<String>,
     /// container to exec into instead of ssh. `None` = ssh host.
     pub container: Option<ContainerArg>,
+    /// extra foreground process names to treat as not wanting the mouse, on top
+    /// of the built-in shell and agent-CLI lists. Set by the daemon from
+    /// per-host config; see `foreground::wants_mouse`.
+    pub mouse_local: Vec<String>,
 }
 
 /// How the pane process should reach its container. The daemon passes a *ref*,
@@ -101,6 +105,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
         max_rows: None,
         ctl_path: None,
         container: None,
+        mouse_local: Vec::new(),
     };
     let mut container_name: Option<String> = None;
     let mut container_folder: Option<String> = None;
@@ -137,6 +142,15 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                 args.max_rows = Some(next("--max-rows")?.parse().map_err(|_| err("--max-rows must be a number"))?)
                     .filter(|&n| n > 0)
             }
+            // repeatable and comma-separated both work, so a host with one extra
+            // agent doesn't need different syntax from a host with six
+            "--mouse-local" => args.mouse_local.extend(
+                next("--mouse-local")?
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string),
+            ),
             "--ctl-path" => args.ctl_path = Some(next("--ctl-path")?),
             "--container" => container_name = Some(next("--container")?),
             "--container-folder" => container_folder = Some(next("--container-folder")?),
@@ -202,7 +216,7 @@ enum Msg {
     Stdin(Vec<u8>),
     /// result of a background foreground-process poll: Some(true)=shell,
     /// Some(false)=TUI, None=poll failed (keep last value)
-    Foreground(Option<bool>),
+    Foreground(Option<crate::foreground::Fg>),
     Paste(crate::paste::Outcome),
     Drop(crate::paste::DropResult),
 }
@@ -463,21 +477,26 @@ enum MouseAction {
     Scroll { up: bool },
     /// click/drag on a remote TUI: forward the raw SGR sequence
     ForwardRaw,
-    /// click/drag at a shell (or unclassified): drop, keep mouse local
+    /// click/drag at a process that never asked for the mouse: drop, keep it local
     Drop,
 }
 
 /// Wheel always scrolls semantically, regardless of the foreground
 /// classification — the remote herdr server knows the real app's mouse mode
 /// and is a better judge than this side's process-name heuristic (e.g. a TUI
-/// that doesn't consume wheel events, like an agent CLI). Non-wheel
-/// clicks/drags keep the existing foreground-based routing.
-fn mouse_action(remote_is_shell: Option<bool>, btn: u32, press: bool) -> MouseAction {
+/// that doesn't consume wheel events, like an agent CLI).
+///
+/// Clicks and drags forward only when the foreground is *known* to want the
+/// mouse. Unknown drops: sending SGR bytes to a program that never enabled
+/// reporting types garbage into it, and the grab that makes forwarding possible
+/// is the same grab that takes native selection away from herdr — so the
+/// uncertain case should cost the click, not the selection.
+fn mouse_action(remote_wants_mouse: Option<bool>, btn: u32, press: bool) -> MouseAction {
     if press && (btn == 64 || btn == 65) {
         MouseAction::Scroll { up: btn == 64 }
     } else if btn == 66 || btn == 67 {
         MouseAction::Drop
-    } else if remote_is_shell == Some(false) {
+    } else if remote_wants_mouse == Some(true) {
         MouseAction::ForwardRaw
     } else {
         MouseAction::Drop
@@ -660,10 +679,17 @@ struct App {
     hint_clear_at: Option<Instant>,
     /// predictive local echo — draws keystrokes optimistically, frame-verified
     predict: Predictor,
-    /// remote pane foreground: Some(true)=shell (keep mouse local, no garbage),
-    /// Some(false)=TUI (forward clicks), None=unknown (fail safe to local).
-    /// Refreshed lazily on mouse activity via `herdr pane process-info`.
+    /// remote pane foreground is a plain shell. Drives the cursor-key encoding
+    /// only — an agent CLI is not a shell but still wants application mode.
+    /// Refreshed lazily on input via `herdr pane process-info`.
     remote_is_shell: Option<bool>,
+    /// remote pane foreground has mouse reporting on: `Some(true)` = forward
+    /// clicks, `Some(false)` = leave the mouse to herdr, `None` = not yet known
+    /// (treated as "leave it to herdr", so selection works before the first poll
+    /// lands rather than after the user has typed something).
+    remote_wants_mouse: Option<bool>,
+    /// frame-driven classification attempts spent so far (see `handle_frame`)
+    frame_fg_polls: u8,
     /// last time a foreground poll was kicked off (throttles the ssh handshakes)
     fg_poll_at: Option<Instant>,
     /// scheduled delayed re-poll to catch a foreground change the last input just
@@ -693,6 +719,11 @@ const FG_POLL_INTERVAL: Duration = Duration::from_millis(1500);
 /// after input settles, re-poll once this much later to catch a foreground
 /// change the input caused (e.g. a TUI just exited); bypasses FG_POLL_INTERVAL
 const SETTLE_DELAY: Duration = Duration::from_millis(350);
+
+/// how many frame-driven classification attempts a pane gets before it falls
+/// back to polling only on input. Enough to ride out a slow first connect,
+/// small enough that a pane which can never be classified stops paying for it.
+const MAX_FRAME_FG_POLLS: u8 = 3;
 
 impl App {
     fn paint(&mut self) {
@@ -749,6 +780,7 @@ impl App {
         let pane = self.args.pane_target.clone();
         let ctl = self.args.ctl_path.clone();
         let container = self.args.container.clone();
+        let mouse_local = self.args.mouse_local.clone();
         tokio::spawn(async move {
             let v = crate::foreground::poll(
                 &ssh,
@@ -757,21 +789,22 @@ impl App {
                 &pane,
                 ctl.as_deref(),
                 container.as_ref(),
+                &mouse_local,
             )
             .await;
             let _ = tx.send(Msg::Foreground(v)).await;
         });
     }
 
-    /// Match the local mouse grab to the classification: release it at a shell so
-    /// herdr does native selection/scroll, keep it grabbed for a TUI (or while
-    /// unknown) so clicks can be forwarded. Only writes on a change.
+    /// Match the local mouse grab to the classification: hold it only for a
+    /// foreground known to want the mouse, so herdr keeps native selection
+    /// everywhere else. Only writes on a change.
     fn sync_mouse_grab(&mut self) {
         if !self.tty {
             return;
         }
-        // grab unless we've confirmed the foreground is a shell
-        let want = self.remote_is_shell != Some(true);
+        // grab only once we've confirmed the foreground wants the mouse
+        let want = self.remote_wants_mouse == Some(true);
         if want == self.mouse_grabbed {
             return;
         }
@@ -936,6 +969,22 @@ impl App {
         let Some(bytes) = &frame.bytes else { return };
         self.backoff_idx = 0;
         self.renderer.status("");
+        // First frame proves the remote pane is live, which is the earliest we
+        // can usefully ask what is running in it. Polling here rather than
+        // waiting for input is what makes the mouse correct in a pane you only
+        // ever look at — a mirror is full of those, and the old lazy poll left
+        // them unclassified until something was typed.
+        //
+        // Bounded, because `poll` returns None on any failure and a failure
+        // leaves us unclassified: an unbounded "retry while unknown" would spawn
+        // an ssh handshake every FG_POLL_INTERVAL forever in a pane whose
+        // process-info never resolves, times every pane on the host. After the
+        // budget it falls back to the old input-driven path, which costs nothing
+        // in a pane nobody touches.
+        if self.remote_wants_mouse.is_none() && self.frame_fg_polls < MAX_FRAME_FG_POLLS {
+            self.frame_fg_polls += 1;
+            self.spawn_foreground_poll(false);
+        }
         self.grid
             .resize(frame.width.unwrap_or(self.grid.width), frame.height.unwrap_or(self.grid.height));
         if frame.full == Some(true) {
@@ -1167,7 +1216,7 @@ impl App {
         let mut scrolls: Vec<serde_json::Value> = Vec::new();
         while i < buf.len() {
             if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
-                match mouse_action(self.remote_is_shell, btn, press) {
+                match mouse_action(self.remote_wants_mouse, btn, press) {
                     MouseAction::Scroll { up } => {
                         scrolls.push(json!({
                             "type": "terminal.scroll",
@@ -1264,13 +1313,19 @@ pub async fn run(args: Args) -> Result<()> {
 
     let tty = !args.dump && unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1;
     let raw = if tty {
-        // 1002/1006: button-event mouse tracking with SGR encoding, so wheel and
-        // clicks reach us instead of scrolling the hosting pane's scrollback
+        // No mouse grab here, deliberately. Grabbing (1002/1006) is what lets us
+        // turn the wheel into a semantic scroll and forward clicks — but it is
+        // the same act that takes native selection away from herdr, and until
+        // the first foreground poll lands we do not know which the remote needs.
+        // Starting ungrabbed makes the ordinary case — select some text in a
+        // pane you just opened — work straight away; `sync_mouse_grab` takes the
+        // mouse the moment a genuinely mouse-aware TUI is identified.
+        //
         // 2004 (bracketed paste) is asked for purely to get framing: herdr
         // only wraps a paste when the pane's app has enabled it, and a file
         // drop otherwise arrives as bare text with no terminator at all. See
         // `intercept_paste`; the markers never reach the remote.
-        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?1002h\x1b[?1006h\x1b[?2004h");
+        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?2004h");
         RawMode::enable()
     } else {
         None
@@ -1317,9 +1372,11 @@ pub async fn run(args: Args) -> Result<()> {
         hint_clear_at: None,
         predict: Predictor::new(),
         remote_is_shell: None,
+        remote_wants_mouse: None,
+        frame_fg_polls: 0,
         fg_poll_at: None,
         settle_at: None,
-        mouse_grabbed: tty, // startup wrote ?1002h when we're a tty
+        mouse_grabbed: false, // startup no longer grabs; see the ?1049h write
         // startup leaves the pane in normal cursor mode; the first classification
         // moves it if the remote turns out to be a TUI
         app_cursor_keys: false,
@@ -1380,8 +1437,9 @@ pub async fn run(args: Args) -> Result<()> {
                     Some(Msg::SessionExit { gen, mode, reason, uptime }) => app.handle_exit(gen, mode, reason, uptime),
                     Some(Msg::Stdin(buf)) => app.handle_stdin(buf).await,
                     // keep the last good classification if a poll failed (None)
-                    Some(Msg::Foreground(v)) => if v.is_some() {
-                        app.remote_is_shell = v;
+                    Some(Msg::Foreground(v)) => if let Some(fg) = v {
+                        app.remote_is_shell = Some(fg.is_shell);
+                        app.remote_wants_mouse = Some(fg.wants_mouse);
                         app.sync_mouse_grab();
                         app.sync_cursor_key_mode();
                     },
@@ -1491,19 +1549,25 @@ mod tests {
     }
 
     #[test]
-    fn wheel_always_semantic_scroll_even_on_tui_foreground() {
-        // remote foreground classified as a TUI (e.g. `claude`) — wheel must
-        // still produce a semantic scroll, not a raw forward, or it silently
-        // does nothing when the TUI doesn't consume mouse wheel input
-        assert_eq!(mouse_action(Some(false), 64, true), MouseAction::Scroll { up: true });
-        assert_eq!(mouse_action(Some(false), 65, true), MouseAction::Scroll { up: false });
-        // unclassified/shell foreground: wheel still scrolls
-        assert_eq!(mouse_action(None, 64, true), MouseAction::Scroll { up: true });
-        assert_eq!(mouse_action(Some(true), 65, true), MouseAction::Scroll { up: false });
-        // non-wheel clicks/drags keep the existing foreground-based routing
-        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::ForwardRaw); // TUI click
-        assert_eq!(mouse_action(Some(true), 0, true), MouseAction::Drop); // shell click
-        assert_eq!(mouse_action(None, 0, true), MouseAction::Drop); // unclassified click
+    fn wheel_is_always_a_semantic_scroll_whatever_the_foreground() {
+        // wheel must produce a semantic scroll rather than a raw forward, or it
+        // silently does nothing when the app doesn't consume wheel input
+        for who in [Some(true), Some(false), None] {
+            assert_eq!(mouse_action(who, 64, true), MouseAction::Scroll { up: true });
+            assert_eq!(mouse_action(who, 65, true), MouseAction::Scroll { up: false });
+        }
+    }
+
+    #[test]
+    fn clicks_forward_only_to_a_foreground_that_asked_for_them() {
+        // a real mouse-aware TUI (vim, htop) gets the click
+        assert_eq!(mouse_action(Some(true), 0, true), MouseAction::ForwardRaw);
+        // a shell or an agent CLI does not: forwarding types SGR garbage into a
+        // program that never enabled reporting, and holding the grab needed to
+        // forward is what costs herdr its native selection
+        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::Drop);
+        // and while we still don't know, the click is the cheaper thing to lose
+        assert_eq!(mouse_action(None, 0, true), MouseAction::Drop);
     }
 
     #[test]
@@ -1561,6 +1625,24 @@ mod tests {
         let argv: Vec<String> =
             ["h", "w1:p1", "--max-cols", "212"].iter().map(|s| s.to_string()).collect();
         assert_eq!(parse_args(&argv).unwrap().max_cols, Some(212));
+    }
+
+    #[test]
+    fn mouse_local_accepts_commas_and_repeats() {
+        // a host with one extra agent shouldn't need different syntax from a
+        // host with six, so both spellings work and accumulate
+        let argv: Vec<String> = [
+            "h", "w1:p1", "--mouse-local", "myagent, other ", "--mouse-local", "third",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let a = parse_args(&argv).unwrap();
+        assert_eq!(a.mouse_local, vec!["myagent", "other", "third"]);
+
+        // unset stays empty, so the built-in lists are the whole policy
+        let argv: Vec<String> = ["h", "w1:p1"].iter().map(|s| s.to_string()).collect();
+        assert!(parse_args(&argv).unwrap().mouse_local.is_empty());
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1221,6 +1221,45 @@ impl App {
             });
             return;
         }
+        // The arrow accumulator guards BOTH modes: herdr's alternate-scroll
+        // emulation (the grab is released, so a wheel arrives as synthesized
+        // arrows) hits the observe branch below as "any keystroke", where it
+        // would escalate to control and cycle an agent CLI's prompt history.
+        // Hold pure-arrow chunks; a notch inside the window is a wheel and is
+        // routed (full control) or treated like the stray SGR wheel below
+        // (observe: never grab the remote's lock for a glance-scroll);
+        // anything less flushes as the keystrokes it was.
+        if self.remote_wants_mouse != Some(true) {
+            if let Some((up, n, seq)) = whole_chunk_arrows(&buf) {
+                match &mut self.arrow_hold {
+                    Some(h) if h.up == up => h.count += n,
+                    _ => {
+                        self.flush_arrow_hold().await;
+                        self.arrow_hold = Some(ArrowHold {
+                            up,
+                            seq,
+                            count: n,
+                            flush_at: Instant::now() + ARROW_HOLD_WINDOW,
+                        });
+                    }
+                }
+                if self.arrow_hold.as_ref().is_some_and(|h| h.count >= WHEEL_ARROWS) {
+                    let h = self.arrow_hold.take().unwrap();
+                    if self.in_full_control() {
+                        self.last_input = Instant::now();
+                        self.emit_wheel(h.up, h.count).await;
+                    } else if self.control_sticky {
+                        self.control_sticky = false;
+                        self.switch_mode(Mode::Control);
+                    } else if self.mode == Mode::Observe {
+                        self.hint("read-only — type to take control");
+                    }
+                }
+                return;
+            }
+            // any other input first flushes held arrows, keeping their order
+            self.flush_arrow_hold().await;
+        }
         if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
             // no quit key: the wrapper's lifecycle belongs to the hosting pane
             if has_mouse_seq(&buf) {
@@ -1271,35 +1310,6 @@ impl App {
         // and re-check shortly after input settles, to catch a change the input
         // just caused (e.g. `:q` quitting vim — the poll above still sees vim)
         self.settle_at = Some(Instant::now() + SETTLE_DELAY);
-        // Arrow chunks feed the wheel accumulator (see ArrowHold): herdr's
-        // alternate-scroll emulation may arrive one arrow per chunk, so a
-        // lone arrow is held ~35ms; three identical ones inside the window
-        // are a wheel notch. Only when the grab is released (that is the only
-        // time herdr synthesizes arrows) and never mid-decision for a
-        // mouse-wanting foreground.
-        if self.remote_wants_mouse != Some(true) {
-            if let Some((up, n, seq)) = whole_chunk_arrows(&buf) {
-                match &mut self.arrow_hold {
-                    Some(h) if h.up == up => h.count += n,
-                    _ => {
-                        self.flush_arrow_hold().await;
-                        self.arrow_hold = Some(ArrowHold {
-                            up,
-                            seq,
-                            count: n,
-                            flush_at: Instant::now() + ARROW_HOLD_WINDOW,
-                        });
-                    }
-                }
-                if self.arrow_hold.as_ref().is_some_and(|h| h.count >= WHEEL_ARROWS) {
-                    let h = self.arrow_hold.take().unwrap();
-                    self.emit_wheel(h.up, h.count).await;
-                }
-                return;
-            }
-            // anything else flushes held arrows first, keeping input order
-            self.flush_arrow_hold().await;
-        }
         // wheel becomes a semantic scroll (server decides app vs scrollback);
         // clicks/drags forward to the remote pty only when the foreground is a
         // TUI — at a shell they're dropped so they don't garbage the prompt
@@ -1342,11 +1352,27 @@ impl App {
         }
     }
 
-    /// Held arrows turned out to be keystrokes — forward them unchanged.
+    /// In control with a live session — the only state where input can be
+    /// sent directly rather than queued.
+    fn in_full_control(&self) -> bool {
+        self.mode == Mode::Control && self.switching_to.is_none() && self.session.is_some()
+    }
+
+    /// Held arrows turned out to be keystrokes — deliver them the way the
+    /// mode they arrived in would have: sent directly under full control,
+    /// queued (and escalating, exactly like any typed key) otherwise.
     async fn flush_arrow_hold(&mut self) {
         if let Some(h) = self.arrow_hold.take() {
             let bytes: Vec<u8> = h.seq.repeat(h.count);
-            self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) })).await;
+            if self.in_full_control() {
+                self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) })).await;
+            } else {
+                self.control_sticky = false;
+                self.pending_input.push(bytes);
+                if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
+                    self.switch_mode(Mode::Control);
+                }
+            }
         }
     }
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1255,7 +1255,7 @@ impl App {
                 }
                 if self.arrow_hold.as_ref().is_some_and(|h| h.count >= WHEEL_ARROWS) {
                     let h = self.arrow_hold.take().unwrap();
-                    self.wheel_notch(h.up, h.count);
+                    self.wheel_notch(h.up, h.count).await;
                 }
                 return;
             }
@@ -1275,7 +1275,7 @@ impl App {
                 // grab the remote's agent lock for a glance-scroll. Clicks
                 // and drags while merely glancing stay dropped.
                 for up in wheel_presses(&buf) {
-                    self.wheel_notch(up, WHEEL_ARROWS);
+                    self.wheel_notch(up, WHEEL_ARROWS).await;
                 }
                 return;
             }
@@ -1334,7 +1334,7 @@ impl App {
             }
         }
         for up in notches {
-            self.wheel_notch(up, WHEEL_ARROWS);
+            self.wheel_notch(up, WHEEL_ARROWS).await;
         }
         if !rest.is_empty() {
             let msg = json!({ "type": "terminal.input", "bytes": B64.encode(&rest) });
@@ -1375,12 +1375,16 @@ impl App {
         }
     }
 
-    /// A wheel notch over the pane. Up opens or deepens the LOCAL history
-    /// view — the remote pane's server-side history fetched over the existing
-    /// ssh path and rendered here, read-only, no control session and no agent
-    /// lock (see hist.rs for why nothing can be scrolled remotely) — and down
-    /// shallows it until the pane lands back on the live mirror.
-    fn wheel_notch(&mut self, up: bool, lines: usize) {
+    /// A wheel notch opens or deepens the LOCAL history view: the remote
+    /// pane's server-side history is fetched over the existing ssh path and
+    /// rendered here, read-only. This applies in control mode too. Inline and
+    /// classic agent renderers (including Codex) swallow synthetic SGR wheel
+    /// events, so sending them directly makes the wheel appear dead. A
+    /// mouse-aware TUI still receives raw SGR events from mouse_action; only
+    /// events that cannot be delivered safely reach this function.
+    ///
+    /// Down shallows the view until the pane lands back on the live mirror.
+    async fn wheel_notch(&mut self, up: bool, lines: usize) {
         if up {
             if self.hist.is_some() {
                 if let Some(h) = &mut self.hist {
@@ -1552,7 +1556,10 @@ pub async fn run(args: Args) -> Result<()> {
         // only wraps a paste when the pane's app has enabled it, and a file
         // drop otherwise arrives as bare text with no terminator at all. See
         // `intercept_paste`; the markers never reach the remote.
-        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?2004h");
+        // 1007 is alternate-scroll mode: Herdr can turn wheel motion into
+        // Up/Down input on the alternate screen without enabling button or
+        // motion reporting, so native click-and-drag selection stays intact.
+        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?2004h\x1b[?1007h");
         RawMode::enable()
     } else {
         None
@@ -1756,7 +1763,7 @@ pub async fn run(args: Args) -> Result<()> {
     if tty {
         // ?1l with the rest: leaving the hosting pane in application cursor mode
         // would misencode arrows for whatever runs there next
-        write_stdout("\x1b[?2004l\x1b[?1002l\x1b[?1006l\x1b[?1l\x1b[?25h\x1b[?1049l");
+        write_stdout("\x1b[?2004l\x1b[?1007l\x1b[?1002l\x1b[?1006l\x1b[?1l\x1b[?25h\x1b[?1049l");
     }
     if let Some(raw) = raw {
         raw.restore();

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -481,19 +481,32 @@ enum MouseAction {
     Drop,
 }
 
-/// Wheel always scrolls semantically, regardless of the foreground
-/// classification — the remote herdr server knows the real app's mouse mode
-/// and is a better judge than this side's process-name heuristic (e.g. a TUI
-/// that doesn't consume wheel events, like an agent CLI).
+/// Wheel scrolls semantically for a shell (real scrollback to move) and for a
+/// mouse-aware TUI (the server synthesizes wheel events at the app) — but is
+/// DROPPED for a mouse-blind TUI. Those are alt-screen apps with no
+/// scrollback, so the server's alternate-scroll emulation turns the scroll
+/// into ARROW KEYS typed at the app; in an agent CLI that cycles the
+/// composer's prompt history, so an idle flick of the wheel rewrites what the
+/// user is about to send. No scroll beats corrupted input. The unknown
+/// foreground drops for the same reason clicks do below.
 ///
 /// Clicks and drags forward only when the foreground is *known* to want the
 /// mouse. Unknown drops: sending SGR bytes to a program that never enabled
 /// reporting types garbage into it, and the grab that makes forwarding possible
 /// is the same grab that takes native selection away from herdr — so the
 /// uncertain case should cost the click, not the selection.
-fn mouse_action(remote_wants_mouse: Option<bool>, btn: u32, press: bool) -> MouseAction {
+fn mouse_action(
+    remote_is_shell: Option<bool>,
+    remote_wants_mouse: Option<bool>,
+    btn: u32,
+    press: bool,
+) -> MouseAction {
     if press && (btn == 64 || btn == 65) {
-        MouseAction::Scroll { up: btn == 64 }
+        if remote_is_shell == Some(true) || remote_wants_mouse == Some(true) {
+            MouseAction::Scroll { up: btn == 64 }
+        } else {
+            MouseAction::Drop
+        }
     } else if btn == 66 || btn == 67 {
         MouseAction::Drop
     } else if remote_wants_mouse == Some(true) {
@@ -501,6 +514,37 @@ fn mouse_action(remote_wants_mouse: Option<bool>, btn: u32, press: bool) -> Mous
     } else {
         MouseAction::Drop
     }
+}
+
+/// herdr's alternate-scroll emulation, recognized after the fact. With the
+/// mouse grab released (the price of native selection), the local herdr owns
+/// the wheel again — and for an alternate-screen pane it synthesizes
+/// `mouse_scroll_lines` identical arrow keys per notch, written as ONE chunk.
+/// Typed into an agent CLI those arrows cycle its composer history: a wheel
+/// flick rewrites what the user was about to send. A chunk that is NOTHING
+/// BUT >=3 identical arrows is that emulation — a human keypress arrives one
+/// arrow per chunk, autorepeat one per event, and a bracketed paste carries
+/// its `ESC[200~` prefix — so it is safe to take the burst back and route it
+/// as the wheel it really was. Returns (up, arrow_count).
+fn whole_chunk_arrow_burst(bytes: &[u8]) -> Option<(bool, usize)> {
+    fn arrow_at(b: &[u8], i: usize) -> Option<bool> {
+        (b.len() >= i + 3
+            && b[i] == 0x1b
+            && (b[i + 1] == b'[' || b[i + 1] == b'O')
+            && (b[i + 2] == b'A' || b[i + 2] == b'B'))
+            .then(|| b[i + 2] == b'A')
+    }
+    let up = arrow_at(bytes, 0)?;
+    if bytes.len() % 3 != 0 {
+        return None;
+    }
+    let n = bytes.len() / 3;
+    for k in 1..n {
+        if arrow_at(bytes, k * 3) != Some(up) {
+            return None;
+        }
+    }
+    (n >= 3).then_some((up, n))
 }
 
 fn contains_wheel_press(bytes: &[u8]) -> bool {
@@ -1208,6 +1252,37 @@ impl App {
         // and re-check shortly after input settles, to catch a change the input
         // just caused (e.g. `:q` quitting vim — the poll above still sees vim)
         self.settle_at = Some(Instant::now() + SETTLE_DELAY);
+        // A pure burst of identical arrows is the local herdr's wheel
+        // emulation (see whole_chunk_arrow_burst) — take it back and scroll:
+        // a shell's scrollback moves semantically; a mouse-blind TUI (agent
+        // CLI) gets the wheel re-materialized as SGR, which it consumes as
+        // chat-view scrolling instead of having its composer history cycled.
+        // Unknown or mouse-wanting foregrounds pass through untouched.
+        if let Some((up, arrows)) = whole_chunk_arrow_burst(&buf) {
+            match (self.remote_is_shell, self.remote_wants_mouse) {
+                (Some(true), _) => {
+                    self.send(json!({
+                        "type": "terminal.scroll",
+                        "direction": if up { "up" } else { "down" },
+                        "lines": arrows,
+                        "source": "wheel",
+                        "column": 0,
+                        "row": 0,
+                        "modifiers": 0,
+                    }))
+                    .await;
+                    return;
+                }
+                (Some(false), Some(false)) => {
+                    let sgr: &[u8] = if up { b"\x1b[<64;1;1M" } else { b"\x1b[<65;1;1M" };
+                    let bytes: Vec<u8> = sgr.repeat(arrows.div_ceil(3));
+                    self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) }))
+                        .await;
+                    return;
+                }
+                _ => {}
+            }
+        }
         // wheel becomes a semantic scroll (server decides app vs scrollback);
         // clicks/drags forward to the remote pty only when the foreground is a
         // TUI — at a shell they're dropped so they don't garbage the prompt
@@ -1216,7 +1291,7 @@ impl App {
         let mut scrolls: Vec<serde_json::Value> = Vec::new();
         while i < buf.len() {
             if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
-                match mouse_action(self.remote_wants_mouse, btn, press) {
+                match mouse_action(self.remote_is_shell, self.remote_wants_mouse, btn, press) {
                     MouseAction::Scroll { up } => {
                         scrolls.push(json!({
                             "type": "terminal.scroll",
@@ -1549,25 +1624,54 @@ mod tests {
     }
 
     #[test]
-    fn wheel_is_always_a_semantic_scroll_whatever_the_foreground() {
-        // wheel must produce a semantic scroll rather than a raw forward, or it
-        // silently does nothing when the app doesn't consume wheel input
-        for who in [Some(true), Some(false), None] {
-            assert_eq!(mouse_action(who, 64, true), MouseAction::Scroll { up: true });
-            assert_eq!(mouse_action(who, 65, true), MouseAction::Scroll { up: false });
-        }
+    fn wheel_scrolls_shells_and_mouse_tuis_but_never_blind_tuis() {
+        // a shell has scrollback: semantic scroll moves it
+        assert_eq!(
+            mouse_action(Some(true), Some(false), 64, true),
+            MouseAction::Scroll { up: true }
+        );
+        // a mouse-aware TUI gets the wheel via the server's app synthesis
+        assert_eq!(
+            mouse_action(Some(false), Some(true), 65, true),
+            MouseAction::Scroll { up: false }
+        );
+        // a mouse-blind TUI (agent CLI) gets NOTHING: the server's
+        // alternate-scroll emulation would type arrow keys into its composer
+        assert_eq!(mouse_action(Some(false), Some(false), 64, true), MouseAction::Drop);
+        // unknown foreground: drop, same reasoning as clicks
+        assert_eq!(mouse_action(None, None, 64, true), MouseAction::Drop);
     }
 
     #[test]
     fn clicks_forward_only_to_a_foreground_that_asked_for_them() {
         // a real mouse-aware TUI (vim, htop) gets the click
-        assert_eq!(mouse_action(Some(true), 0, true), MouseAction::ForwardRaw);
+        assert_eq!(mouse_action(Some(false), Some(true), 0, true), MouseAction::ForwardRaw);
         // a shell or an agent CLI does not: forwarding types SGR garbage into a
         // program that never enabled reporting, and holding the grab needed to
         // forward is what costs herdr its native selection
-        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::Drop);
+        assert_eq!(mouse_action(Some(false), Some(false), 0, true), MouseAction::Drop);
+        assert_eq!(mouse_action(Some(true), Some(false), 0, true), MouseAction::Drop);
         // and while we still don't know, the click is the cheaper thing to lose
-        assert_eq!(mouse_action(None, 0, true), MouseAction::Drop);
+        assert_eq!(mouse_action(None, None, 0, true), MouseAction::Drop);
+    }
+
+    #[test]
+    fn arrow_bursts_are_recognized_and_human_input_is_not() {
+        // herdr's wheel emulation: 3 identical arrows in one chunk
+        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A\x1b[A"), Some((true, 3)));
+        assert_eq!(whole_chunk_arrow_burst(b"\x1b[B\x1b[B\x1b[B"), Some((false, 3)));
+        // application cursor keys mode
+        assert_eq!(whole_chunk_arrow_burst(b"\x1bOA\x1bOA\x1bOA"), Some((true, 3)));
+        // two coalesced notches
+        assert_eq!(whole_chunk_arrow_burst(&b"\x1b[A".repeat(6)), Some((true, 6)));
+        // a single keypress is never a burst
+        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A"), None);
+        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A"), None);
+        // mixed directions or trailing bytes: not the emulation's shape
+        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A\x1b[B"), None);
+        assert_eq!(whole_chunk_arrow_burst(b"\x1b[A\x1b[A\x1b[Ax"), None);
+        // a bracketed paste of arrows keeps its prefix, so it never matches
+        assert_eq!(whole_chunk_arrow_burst(b"\x1b[200~\x1b[A\x1b[A\x1b[A\x1b[201~"), None);
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -473,22 +473,23 @@ fn parse_mouse(bytes: &[u8], at: usize) -> Option<(u32, u32, u32, bool, usize)> 
 /// How a parsed mouse event should be routed while in control mode.
 #[derive(Debug, PartialEq, Eq)]
 enum MouseAction {
-    /// wheel: send as a semantic terminal.scroll (server decides app vs scrollback)
-    Scroll { up: bool },
-    /// click/drag on a remote TUI: forward the raw SGR sequence
+    /// wheel/click/drag on a remote TUI or agent: forward the raw SGR sequence
     ForwardRaw,
-    /// click/drag at a process that never asked for the mouse: drop, keep it local
+    /// event at a process where forwarding could corrupt input: drop, keep it local
     Drop,
 }
 
-/// Wheel scrolls semantically for a shell (real scrollback to move) and for a
-/// mouse-aware TUI (the server synthesizes wheel events at the app) — but is
-/// DROPPED for a mouse-blind TUI. Those are alt-screen apps with no
-/// scrollback, so the server's alternate-scroll emulation turns the scroll
-/// into ARROW KEYS typed at the app; in an agent CLI that cycles the
-/// composer's prompt history, so an idle flick of the wheel rewrites what the
-/// user is about to send. No scroll beats corrupted input. The unknown
-/// foreground drops for the same reason clicks do below.
+/// A wheel forwards its raw SGR to any non-shell foreground and is dropped
+/// otherwise — the same policy as [`emit_wheel`] on the arrow-emulation path.
+/// A mouse-aware TUI asked for exactly this encoding; an agent CLI's
+/// fullscreen renderer consumes it as chat-view scrolling, and the
+/// classic/inline renderers' parsers swallow unrequested SGR without echo
+/// (probed against Claude Code and codex). A SHELL drops it — there is no
+/// safe delivery: the session API's `terminal.scroll` turned out to type
+/// history-cycling ARROW KEYS at any pane whose app never enabled the mouse
+/// (measured), and raw SGR at a prompt is garbage on the command line. No
+/// scroll beats corrupted input. The unknown foreground drops for the same
+/// reason clicks do below.
 ///
 /// Clicks and drags forward only when the foreground is *known* to want the
 /// mouse. Unknown drops: sending SGR bytes to a program that never enabled
@@ -502,8 +503,8 @@ fn mouse_action(
     press: bool,
 ) -> MouseAction {
     if press && (btn == 64 || btn == 65) {
-        if remote_is_shell == Some(true) || remote_wants_mouse == Some(true) {
-            MouseAction::Scroll { up: btn == 64 }
+        if remote_is_shell == Some(false) {
+            MouseAction::ForwardRaw
         } else {
             MouseAction::Drop
         }
@@ -1336,21 +1337,9 @@ impl App {
         // TUI — at a shell they're dropped so they don't garbage the prompt
         let mut rest: Vec<u8> = Vec::with_capacity(buf.len());
         let mut i = 0usize;
-        let mut scrolls: Vec<serde_json::Value> = Vec::new();
         while i < buf.len() {
-            if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
+            if let Some((btn, _x, _y, press, len)) = parse_mouse(&buf, i) {
                 match mouse_action(self.remote_is_shell, self.remote_wants_mouse, btn, press) {
-                    MouseAction::Scroll { up } => {
-                        scrolls.push(json!({
-                            "type": "terminal.scroll",
-                            "direction": if up { "up" } else { "down" },
-                            "lines": 3,
-                            "source": "wheel",
-                            "column": x.saturating_sub(1),
-                            "row": y.saturating_sub(1),
-                            "modifiers": 0,
-                        }));
-                    }
                     MouseAction::ForwardRaw => rest.extend_from_slice(&buf[i..i + len]),
                     MouseAction::Drop => {}
                 }
@@ -1359,9 +1348,6 @@ impl App {
                 rest.push(buf[i]);
                 i += 1;
             }
-        }
-        for s in scrolls {
-            self.send(s).await;
         }
         if !rest.is_empty() {
             let msg = json!({ "type": "terminal.input", "bytes": B64.encode(&rest) });
@@ -1397,33 +1383,29 @@ impl App {
         }
     }
 
-    /// A recognized wheel notch, routed by foreground: a shell's remote
-    /// scrollback scrolls semantically; a mouse-blind TUI (agent CLI) gets
-    /// the wheel re-materialized as SGR, which it consumes as chat-view
-    /// scrolling instead of having its composer history cycled; an unknown
-    /// foreground drops it — the uncertain case should cost the scroll, not
-    /// type junk into whatever is there.
+    /// A recognized wheel notch, re-materialized as an SGR wheel event for
+    /// any non-shell foreground and DROPPED for a shell or an unknown one.
+    ///
+    /// Why not the session API's `terminal.scroll`: it turned out to have
+    /// deliver-to-the-app semantics, not viewport semantics. It cannot reach
+    /// the server-side scrollback, and for a pane whose app never enabled the
+    /// mouse it falls back to typing ARROW KEYS at it (measured: three `^[[A`
+    /// echoed at the prompt, scrollback offset untouched) — at a shell prompt
+    /// those cycle command history, and at an agent composer they cycle
+    /// prompt history. The SGR event is safe across the board instead: a
+    /// mouse-aware TUI asked for exactly this encoding, a fullscreen agent
+    /// renderer consumes it as chat-view scrolling, and the classic/inline
+    /// agent renderers' input parsers swallow unrequested SGR without echo
+    /// (probed against both Claude Code and codex) — so the worst case is a
+    /// dead wheel, never junk in the composer. No scroll beats corrupted
+    /// input, which is also why a shell and the unknown foreground drop.
     async fn emit_wheel(&mut self, up: bool, arrows: usize) {
-        match self.remote_is_shell {
-            Some(true) => {
-                self.send(json!({
-                    "type": "terminal.scroll",
-                    "direction": if up { "up" } else { "down" },
-                    "lines": arrows,
-                    "source": "wheel",
-                    "column": 0,
-                    "row": 0,
-                    "modifiers": 0,
-                }))
-                .await;
-            }
-            Some(false) => {
-                let sgr: &[u8] = if up { b"\x1b[<64;1;1M" } else { b"\x1b[<65;1;1M" };
-                let bytes: Vec<u8> = sgr.repeat(arrows.div_ceil(WHEEL_ARROWS));
-                self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) })).await;
-            }
-            None => {}
+        if self.remote_is_shell != Some(false) {
+            return;
         }
+        let sgr: &[u8] = if up { b"\x1b[<64;1;1M" } else { b"\x1b[<65;1;1M" };
+        let bytes: Vec<u8> = sgr.repeat(arrows.div_ceil(WHEEL_ARROWS));
+        self.send(json!({ "type": "terminal.input", "bytes": B64.encode(&bytes) })).await;
     }
 
     async fn deliver_input(&mut self, buf: Vec<u8>) {
@@ -1732,20 +1714,15 @@ mod tests {
     }
 
     #[test]
-    fn wheel_scrolls_shells_and_mouse_tuis_but_never_blind_tuis() {
-        // a shell has scrollback: semantic scroll moves it
-        assert_eq!(
-            mouse_action(Some(true), Some(false), 64, true),
-            MouseAction::Scroll { up: true }
-        );
-        // a mouse-aware TUI gets the wheel via the server's app synthesis
-        assert_eq!(
-            mouse_action(Some(false), Some(true), 65, true),
-            MouseAction::Scroll { up: false }
-        );
-        // a mouse-blind TUI (agent CLI) gets NOTHING: the server's
-        // alternate-scroll emulation would type arrow keys into its composer
-        assert_eq!(mouse_action(Some(false), Some(false), 64, true), MouseAction::Drop);
+    fn wheel_forwards_to_any_non_shell_and_never_touches_shells() {
+        // a mouse-aware TUI asked for SGR wheel events — forward with coords
+        assert_eq!(mouse_action(Some(false), Some(true), 65, true), MouseAction::ForwardRaw);
+        // an agent CLI too: fullscreen renderers scroll their chat view with
+        // it, classic/inline parsers swallow it silently
+        assert_eq!(mouse_action(Some(false), Some(false), 64, true), MouseAction::ForwardRaw);
+        // a shell gets NOTHING: terminal.scroll would type history-cycling
+        // arrows and raw SGR is garbage on the command line
+        assert_eq!(mouse_action(Some(true), Some(false), 64, true), MouseAction::Drop);
         // unknown foreground: drop, same reasoning as clicks
         assert_eq!(mouse_action(None, None, 64, true), MouseAction::Drop);
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -612,6 +612,7 @@ mod tests {
             session: None,
             max_cols: None,
             max_rows: None,
+            mouse_local_apps: Vec::new(),
             api_transport: ApiTransport::Auto,
             always_control: true,
         }


### PR DESCRIPTION
## The problem

The foreground heuristic asks "is this a shell?" and treats every other answer as
a mouse-aware TUI, grabbing the mouse on its behalf.

Agent CLIs break that assumption. They are full-screen, so they answer "not a
shell" — but they never enable mouse reporting. The grab is held for them, and
holding the grab is exactly what stops herdr doing native drag-select.

On a host mirrored specifically to watch agents, nearly every pane is an agent.
Measured on one such mirror, 9 of 13 panes had `claude` or `codex` as the
foreground process, so text selection was unavailable across almost the whole
sidebar while the forwarded SGR clicks went to programs that had never asked for
them.

Reproduced against a live remote `claude` pane, by running the streamer under a
pty and watching what it writes to its own stdout:

| | `?1002h` (grab taken) | `?1002l` (released) |
|---|---|---|
| before | 1 | 0 |
| after | 0 | 0 |

`mouse_action` already half-knew this — the wheel is special-cased with the
comment *"a TUI that doesn't consume wheel events, like an agent CLI"* — but the
same reasoning was never extended to clicks and the grab.

## The change

"Does this process want the mouse?" is the question that matters, and it is
`false` for a shell and for an agent CLI, for two different reasons. Splitting it
from `is_shell` matters: an agent CLI *does* set DECCKM, so it must keep
application cursor keys. Collapsing the two answers would fix the mouse and break
the arrows. `Fg { is_shell, wants_mouse }` keeps them independent.

Grabbing becomes opt-in on evidence:

- clicks forward only to a foreground **known** to want the mouse. An unknown
  foreground drops the click — losing a click costs less than losing selection.
- the startup write no longer takes the mouse, so a pane you only ever look at is
  selectable immediately rather than after the first keystroke.
- the first frames kick a classification poll: the earliest point the remote pane
  is known to be live. The old lazy poll only ran on input, so a pane nobody
  typed into stayed unclassified indefinitely. It's budgeted (`MAX_FRAME_FG_POLLS`)
  because `poll` returns `None` on failure — retrying while unclassified would
  otherwise spawn an ssh handshake every `FG_POLL_INTERVAL` forever in a pane
  whose `process-info` never resolves, times every pane on the host.

`mouse_local_apps` (global, unioned per host) extends the built-in list. Agent
CLIs ship faster than any hardcoded list is updated, and an unlisted one silently
costs selection in every pane it runs in.

## What this trades

`mouse_action` is unchanged, but releasing the grab does mean the plugin stops
receiving wheel events at all in the panes it now releases for — so the semantic
`terminal.scroll` is not sent there. Worth stating plainly rather than claiming
the wheel is untouched.

It costs nothing where it matters, because an agent CLI runs on the alt screen
and has no scrollback for a scroll to reach. Measured on live panes in one
session:

```
claude pane : --source recent = 4914b   --source visible = 4914b   (identical)
shell pane  : --source recent = 5055b   --source visible = 2780b
```

The semantic scroll in an agent pane had nothing to move. Shell panes are
unaffected (the grab was already released for them), and a real mouse-aware TUI
still gets the grab — and therefore the wheel — once classified.

The one genuine regression is a short window: a `vim` pane wheel-scrolled in the
first few hundred ms, before its first classification lands, now scrolls the host
pane instead of the remote. Bounded by one poll.

## Compatibility

Real mouse-aware TUIs (`vim`, `htop`, `lazygit`, `nvim`, `emacs`) are unaffected
once classified — covered by a test. Shell panes behave as before. The behaviour
change is confined to panes whose foreground is an agent CLI or not yet
classified, which is where the bug lives.

## Tests

156 pass, clippy clean. New coverage: agent CLIs classify as not-a-shell *and*
not-wanting-the-mouse; genuine TUIs still receive clicks; the escape hatch
normalizes paths/`.exe`/case like the built-in lists; `--mouse-local` accepts
both comma-separated and repeated forms; the flag survives the daemon → streamer
argv round-trip.

## Upstream

While tracing this I confirmed there is no way to have both plugin-mediated wheel
scroll and herdr-native selection in the same pane — both need the mouse, and
`herdr api schema` (protocol 19) exposes nothing about a pane's mouse-reporting
state: no mouse, clipboard, or selection method among its 103 methods. That is
the gap `foreground.rs` documents, filed as herdrdev/herdr#2853. This PR picks
the better default until herdr can answer the question directly.
