### PR TITLE
feat: "panes" close-through; fix: tab closes never counted as user intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,6 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
                          # (e.g. prefix+x) also closes it on the remote. Set
                          # false to only stop mirroring on a local close,
                          # leaving the remote pane and its agent running.
-                         # Or "panes": panes and tabs close through, but a
-                         # workspace close only stops mirroring — one wrong
-                         # prefix+x can cost a pane, never every agent in a
-                         # workspace.
 # always_control = true  # default. Mirror panes stay in control: writable, no
                          # idle release, and sized to your local pane so the
                          # remote fills it (ideal for headless remotes). Set

--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
                          # (e.g. prefix+x) also closes it on the remote. Set
                          # false to only stop mirroring on a local close,
                          # leaving the remote pane and its agent running.
+                         # Or "panes": panes and tabs close through, but a
+                         # workspace close only stops mirroring — one wrong
+                         # prefix+x can cost a pane, never every agent in a
+                         # workspace.
 # always_control = true  # default. Mirror panes stay in control: writable, no
                          # idle release, and sized to your local pane so the
                          # remote fills it (ideal for headless remotes). Set

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,26 @@ pub struct HostConfig {
     pub max_rows: Option<usize>,
 }
 
+/// How far a local close reaches onto the remote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseThrough {
+    /// workspaces AND panes/tabs close through (upstream default)
+    All,
+    /// panes and tabs close through; a workspace close only stops mirroring
+    Panes,
+    /// nothing closes through; every local close only stops mirroring
+    None,
+}
+
+impl CloseThrough {
+    pub fn workspaces(self) -> bool {
+        self == CloseThrough::All
+    }
+    pub fn panes(self) -> bool {
+        self != CloseThrough::None
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MirrorConfig {
     pub poll_seconds: u64,
@@ -125,10 +145,12 @@ pub struct MirrorConfig {
     /// host that remote-create actions target when invoked outside a mirror
     /// (falls back to the first host declared)
     pub default_host: Option<String>,
-    /// when true (the default), closing a mirror workspace/pane locally also
-    /// closes the matching object on the remote. Set false to make a local
-    /// close only stop mirroring, leaving the remote — and any agent — running.
-    pub close_remote_on_local_close: bool,
+    /// what a local close does to the remote (see [`CloseThrough`]). TOML
+    /// accepts `true` (everything — the default), `false` (nothing: a local
+    /// close only stops mirroring), or `"panes"` (panes and tabs close
+    /// through; closing a whole workspace only stops mirroring — one wrong
+    /// prefix+x can cost a pane, never every agent in a workspace).
+    pub close_remote_on_local_close: CloseThrough,
     pub hosts: Vec<HostConfig>,
     /// which hosts.toml this came from. `None` when parsed from a string
     /// (tests). Logged at startup so "which config won?" is never a guess.
@@ -156,7 +178,9 @@ struct RawConfig {
     autostart: Option<bool>,
     poll_seconds: Option<u64>,
     default_host: Option<String>,
-    close_remote_on_local_close: Option<bool>,
+    // bool or the string "panes" — validated in parse (a typo must warn, not
+    // silently become a default that closes remote agents)
+    close_remote_on_local_close: Option<toml::Value>,
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
@@ -343,11 +367,25 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             return Err(err(format!("hosts.toml: default_host \"{d}\" is not an enabled [hosts.*] entry")));
         }
     }
+    let close_through = match &raw.close_remote_on_local_close {
+        None => CloseThrough::All,
+        Some(toml::Value::Boolean(true)) => CloseThrough::All,
+        Some(toml::Value::Boolean(false)) => CloseThrough::None,
+        Some(toml::Value::String(s)) if s == "panes" => CloseThrough::Panes,
+        Some(v) => {
+            // an unrecognized value must not silently become the destructive
+            // default: fall back to the SAFE end and say so
+            warnings.push(format!(
+                "hosts.toml: close_remote_on_local_close = {v} not understood (want true, false, or \"panes\") — treating as false"
+            ));
+            CloseThrough::None
+        }
+    };
     Ok(MirrorConfig {
         poll_seconds: raw.poll_seconds.unwrap_or(60),
         autostart: raw.autostart.unwrap_or(true),
         default_host: raw.default_host,
-        close_remote_on_local_close: raw.close_remote_on_local_close.unwrap_or(true),
+        close_remote_on_local_close: close_through,
         hosts,
         source: None,
         shadowed: Vec::new(),
@@ -373,6 +411,25 @@ mod tests {
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert_eq!(h.session, None); // default remote session
         assert!(h.always_control); // default on
+    }
+
+    #[test]
+    fn close_through_parses_bool_string_and_rejects_garbage_safely() {
+        let base = "[hosts.a]\ntarget = \"a\"\n";
+        let c = parse_config(base).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::All); // default
+        let c = parse_config(&format!("close_remote_on_local_close = true\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::All);
+        let c = parse_config(&format!("close_remote_on_local_close = false\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::None);
+        let c = parse_config(&format!("close_remote_on_local_close = \"panes\"\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::Panes);
+        assert!(c.close_remote_on_local_close.panes());
+        assert!(!c.close_remote_on_local_close.workspaces());
+        // a typo must land on the SAFE end (nothing closes through) and warn
+        let c = parse_config(&format!("close_remote_on_local_close = \"pane\"\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::None);
+        assert!(c.warnings.iter().any(|w| w.contains("close_remote_on_local_close")));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,26 +117,6 @@ pub struct HostConfig {
     pub max_rows: Option<usize>,
 }
 
-/// How far a local close reaches onto the remote.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CloseThrough {
-    /// workspaces AND panes/tabs close through (upstream default)
-    All,
-    /// panes and tabs close through; a workspace close only stops mirroring
-    Panes,
-    /// nothing closes through; every local close only stops mirroring
-    None,
-}
-
-impl CloseThrough {
-    pub fn workspaces(self) -> bool {
-        self == CloseThrough::All
-    }
-    pub fn panes(self) -> bool {
-        self != CloseThrough::None
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct MirrorConfig {
     pub poll_seconds: u64,
@@ -145,12 +125,10 @@ pub struct MirrorConfig {
     /// host that remote-create actions target when invoked outside a mirror
     /// (falls back to the first host declared)
     pub default_host: Option<String>,
-    /// what a local close does to the remote (see [`CloseThrough`]). TOML
-    /// accepts `true` (everything — the default), `false` (nothing: a local
-    /// close only stops mirroring), or `"panes"` (panes and tabs close
-    /// through; closing a whole workspace only stops mirroring — one wrong
-    /// prefix+x can cost a pane, never every agent in a workspace).
-    pub close_remote_on_local_close: CloseThrough,
+    /// when true (the default), closing a mirror workspace/pane/tab locally
+    /// also closes the matching object on the remote. Set false to make a local
+    /// close only stop mirroring, leaving the remote — and any agent — running.
+    pub close_remote_on_local_close: bool,
     pub hosts: Vec<HostConfig>,
     /// which hosts.toml this came from. `None` when parsed from a string
     /// (tests). Logged at startup so "which config won?" is never a guess.
@@ -178,9 +156,7 @@ struct RawConfig {
     autostart: Option<bool>,
     poll_seconds: Option<u64>,
     default_host: Option<String>,
-    // bool or the string "panes" — validated in parse (a typo must warn, not
-    // silently become a default that closes remote agents)
-    close_remote_on_local_close: Option<toml::Value>,
+    close_remote_on_local_close: Option<bool>,
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
@@ -367,25 +343,11 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             return Err(err(format!("hosts.toml: default_host \"{d}\" is not an enabled [hosts.*] entry")));
         }
     }
-    let close_through = match &raw.close_remote_on_local_close {
-        None => CloseThrough::All,
-        Some(toml::Value::Boolean(true)) => CloseThrough::All,
-        Some(toml::Value::Boolean(false)) => CloseThrough::None,
-        Some(toml::Value::String(s)) if s == "panes" => CloseThrough::Panes,
-        Some(v) => {
-            // an unrecognized value must not silently become the destructive
-            // default: fall back to the SAFE end and say so
-            warnings.push(format!(
-                "hosts.toml: close_remote_on_local_close = {v} not understood (want true, false, or \"panes\") — treating as false"
-            ));
-            CloseThrough::None
-        }
-    };
     Ok(MirrorConfig {
         poll_seconds: raw.poll_seconds.unwrap_or(60),
         autostart: raw.autostart.unwrap_or(true),
         default_host: raw.default_host,
-        close_remote_on_local_close: close_through,
+        close_remote_on_local_close: raw.close_remote_on_local_close.unwrap_or(true),
         hosts,
         source: None,
         shadowed: Vec::new(),
@@ -411,25 +373,6 @@ mod tests {
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert_eq!(h.session, None); // default remote session
         assert!(h.always_control); // default on
-    }
-
-    #[test]
-    fn close_through_parses_bool_string_and_rejects_garbage_safely() {
-        let base = "[hosts.a]\ntarget = \"a\"\n";
-        let c = parse_config(base).unwrap();
-        assert_eq!(c.close_remote_on_local_close, CloseThrough::All); // default
-        let c = parse_config(&format!("close_remote_on_local_close = true\n{base}")).unwrap();
-        assert_eq!(c.close_remote_on_local_close, CloseThrough::All);
-        let c = parse_config(&format!("close_remote_on_local_close = false\n{base}")).unwrap();
-        assert_eq!(c.close_remote_on_local_close, CloseThrough::None);
-        let c = parse_config(&format!("close_remote_on_local_close = \"panes\"\n{base}")).unwrap();
-        assert_eq!(c.close_remote_on_local_close, CloseThrough::Panes);
-        assert!(c.close_remote_on_local_close.panes());
-        assert!(!c.close_remote_on_local_close.workspaces());
-        // a typo must land on the SAFE end (nothing closes through) and warn
-        let c = parse_config(&format!("close_remote_on_local_close = \"pane\"\n{base}")).unwrap();
-        assert_eq!(c.close_remote_on_local_close, CloseThrough::None);
-        assert!(c.warnings.iter().any(|w| w.contains("close_remote_on_local_close")));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -68,7 +68,7 @@ struct HostCtx {
     host: HostConfig,
     local: ApiClient,
     log: Logger,
-    close_remote_on_local_close: bool,
+    close_remote_on_local_close: crate::config::CloseThrough,
     closes: crate::closes::Closes,
 }
 
@@ -455,6 +455,10 @@ async fn local_events_task(
             json!({ "type": "workspace.created" }),
             json!({ "type": "workspace.closed" }),
             json!({ "type": "pane.closed" }),
+            // closing a TAB emits only tab_closed — no pane_closed for the
+            // panes inside it — so without this a tab close never counts as
+            // user intent and close-through silently degrades to tombstoning
+            json!({ "type": "tab.closed" }),
             // renaming a mirror tab locally is intent for the remote tab, which
             // converge resolves against the label it last stamped; without this
             // the rename is never noticed and the next converge reverts it
@@ -479,6 +483,7 @@ async fn local_events_task(
                     let key = match e.event.as_str() {
                         "workspace_closed" => Some("workspace_id"),
                         "pane_closed" => Some("pane_id"),
+                        "tab_closed" => Some("tab_id"),
                         _ => None,
                     };
                     if let Some(k) = key {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -68,7 +68,7 @@ struct HostCtx {
     host: HostConfig,
     local: ApiClient,
     log: Logger,
-    close_remote_on_local_close: crate::config::CloseThrough,
+    close_remote_on_local_close: bool,
     closes: crate::closes::Closes,
 }
 

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -335,7 +335,7 @@ pub struct ConvergeDeps {
     pub state_dir: PathBuf,
     pub log: Logger,
     /// mirror closing a workspace/pane locally onto the remote (see MirrorConfig)
-    pub close_remote_on_local_close: bool,
+    pub close_remote_on_local_close: crate::config::CloseThrough,
     /// event-confirmed local closes. Absence from the local snapshot is
     /// ambiguous (rebuild in flight, failed converge, server restart), so only a
     /// close event that wasn't our own may close the remote.
@@ -688,12 +688,14 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
     //    event-confirmed user close (see closes.rs) — never by absence alone,
     //    which also happens mid-rebuild, after a failed converge, or while the
     //    local server is restarting.
-    let close_remote = deps.close_remote_on_local_close;
+    let close_remote_ws = deps.close_remote_on_local_close.workspaces();
+    let close_remote_panes = deps.close_remote_on_local_close.panes();
     let mine: HashSet<String> = state
         .workspaces
         .values()
         .map(|e| e.local_id.clone())
         .chain(state.panes.values().map(|e| e.local_id.clone()))
+        .chain(state.tabs.values().map(|e| e.local_id.clone()))
         .collect();
     let user_closed = match deps.closes.lock() {
         Ok(mut t) => t.take_user_closed(&mine),
@@ -703,7 +705,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
     for (rid, entry) in state.workspaces.iter_mut() {
         if !entry.is_tombstoned() && !local_ws_ids.contains(&entry.local_id) && remote_ws_ids.contains(rid.as_str()) {
             entry.tombstone = Some(true);
-            if close_remote && user_closed.contains(&entry.local_id) {
+            if close_remote_ws && user_closed.contains(&entry.local_id) {
                 ws_close_remote.push(rid.clone());
             } else {
                 log.log(&format!("workspace mirror for {rid} was closed locally — tombstoning"));
@@ -718,6 +720,8 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
     }
     let pane_ws: HashMap<&str, &str> =
         remote_snap.panes.iter().map(|p| (p.pane_id.as_str(), p.workspace_id.as_str())).collect();
+    let pane_tab: HashMap<&str, &str> =
+        remote_snap.panes.iter().map(|p| (p.pane_id.as_str(), p.tab_id.as_str())).collect();
     let mut drop_panes: Vec<String> = Vec::new();
     let mut pane_close_remote: Vec<String> = Vec::new();
     for (rid, entry) in state.panes.iter_mut() {
@@ -729,7 +733,14 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
             match ws_entry {
                 Some(w) if !w.is_tombstoned() && local_ws_ids.contains(&w.local_id) => {
                     entry.tombstone = Some(true);
-                    if close_remote && user_closed.contains(&entry.local_id) {
+                    // user intent covers the pane itself AND its whole tab:
+                    // closing a tab emits only tab_closed, so the panes inside
+                    // it are claimed through their tab's mapped local id
+                    let tab_closed = pane_tab
+                        .get(rid.as_str())
+                        .and_then(|t| state.tabs.get(*t))
+                        .is_some_and(|e| user_closed.contains(&e.local_id));
+                    if close_remote_panes && (user_closed.contains(&entry.local_id) || tab_closed) {
                         pane_close_remote.push(rid.clone());
                     } else {
                         log.log(&format!("pane mirror for {rid} was closed locally — tombstoning"));

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -335,7 +335,7 @@ pub struct ConvergeDeps {
     pub state_dir: PathBuf,
     pub log: Logger,
     /// mirror closing a workspace/pane locally onto the remote (see MirrorConfig)
-    pub close_remote_on_local_close: crate::config::CloseThrough,
+    pub close_remote_on_local_close: bool,
     /// event-confirmed local closes. Absence from the local snapshot is
     /// ambiguous (rebuild in flight, failed converge, server restart), so only a
     /// close event that wasn't our own may close the remote.
@@ -688,8 +688,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
     //    event-confirmed user close (see closes.rs) — never by absence alone,
     //    which also happens mid-rebuild, after a failed converge, or while the
     //    local server is restarting.
-    let close_remote_ws = deps.close_remote_on_local_close.workspaces();
-    let close_remote_panes = deps.close_remote_on_local_close.panes();
+    let close_remote = deps.close_remote_on_local_close;
     let mine: HashSet<String> = state
         .workspaces
         .values()
@@ -705,7 +704,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
     for (rid, entry) in state.workspaces.iter_mut() {
         if !entry.is_tombstoned() && !local_ws_ids.contains(&entry.local_id) && remote_ws_ids.contains(rid.as_str()) {
             entry.tombstone = Some(true);
-            if close_remote_ws && user_closed.contains(&entry.local_id) {
+            if close_remote && user_closed.contains(&entry.local_id) {
                 ws_close_remote.push(rid.clone());
             } else {
                 log.log(&format!("workspace mirror for {rid} was closed locally — tombstoning"));
@@ -740,7 +739,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                         .get(rid.as_str())
                         .and_then(|t| state.tabs.get(*t))
                         .is_some_and(|e| user_closed.contains(&e.local_id));
-                    if close_remote_panes && (user_closed.contains(&entry.local_id) || tab_closed) {
+                    if close_remote && (user_closed.contains(&entry.local_id) || tab_closed) {
                         pane_close_remote.push(rid.clone());
                     } else {
                         log.log(&format!("pane mirror for {rid} was closed locally — tombstoning"));


### PR DESCRIPTION
Two things, one small diff:

## `close_remote_on_local_close = "panes"` — the middle setting

`true` makes prefix+x on a mirror a remote kill switch (a workspace close takes every agent in it); `false` makes local closes purely cosmetic. Day-to-day the wanted behavior sits in between: closing a mirror **tab or pane** should close the real one — it matches creating them from the mirror side — while closing a whole **workspace** should only stop mirroring, so one wrong keystroke can cost a pane, never every agent at once.

TOML accepts `true` (everything — unchanged default), `false` (nothing), or `"panes"`. An unrecognized value warns and lands on the safe end (`false`) rather than silently becoming the destructive default.

## Fix: tab closes never counted as user intent

Closing a tab emits only `tab_closed` — no `pane_closed` for the panes inside it (verified against herdr 0.8.0's event stream) — and the local close watcher never subscribed to it. So at ANY setting, closing a mirror **tab** degraded to tombstoning instead of closing through; only individual pane closes ever worked. The watcher now records `tab_closed`, and the converge claims a missing pane through its tab's mapped local id as well as its own.

## Verified live (herdr 0.8.0, ssh host)

- close a local mirror **pane** → remote pane closes
- close a local mirror **tab** → remote tab closes (previously: tombstoned, remote survived)
- under `"panes"`: close a local mirror **workspace** → remote workspace and its agents untouched
- `workspace_closed` payload checked: the flat `workspace_id` field is still present, so workspace intent tracking is unaffected

`cargo test` green (adds a parse test covering all three values and the garbage-lands-safe case); clippy `-D warnings` clean. Independent of #54/#56.
