### PR TITLE
feat: agents_only — mirror only remote workspaces that have an agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ set `always_control = false` (globally or per host). Its mirrors become
 read-only: a live view with zero effect on the remote that escalates to control
 when you type and auto-releases after 1h idle (`ctrl+\` releases immediately).
 
+**Agents only** — `agents_only = true` (globally or per host) mirrors only the
+remote workspaces that have an agent in one of their panes. On a viewer of
+several machines the agents are the point and a remote's bare shells are noise —
+and a mirror pane is a process plus a connection apiece, so a machine with a
+dozen scratch workspaces costs real CPU to watch. It is a live filter, not a
+close: a workspace appears within seconds of its agent starting, and when the
+agent exits its mirror closes locally with the remote untouched. Closing those
+rows by hand instead is not equivalent — that tombstones them, which also hides
+the next agent to start in one.
+
 **Close / restore** — by default, closing a mirror (`prefix+x`) also closes the
 pane/workspace on the remote (`close_remote_on_local_close`; set it false to
 only stop mirroring and leave the remote — and its agent — running). When the
@@ -288,6 +298,12 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
 # max_cols / max_rows    # cap the size control asks the remote for, so a
                          # machine with its own display keeps its geometry.
                          # A ceiling only, and never applies to watch-only.
+# agents_only = false    # default. true mirrors only remote workspaces that
+                         # have an agent in one of their panes — for a viewer of
+                         # many machines, where a remote's bare shells are noise
+                         # and a process apiece. A live filter, not a close: a
+                         # workspace appears when its agent starts and its mirror
+                         # closes (remote untouched) when the agent exits.
 
 [hosts.work]
 target = "work"
@@ -299,6 +315,9 @@ target = "work"
 # max_rows = 58                      # always_control = false
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
+# agents_only = true                 # per-host override: filter one noisy host
+                                     # on an otherwise unfiltered sidebar, or
+                                     # mirror one machine whole under a global
 # enabled = true                     # false stops syncing this host without
                                      # deleting its config; mirrors stay put
 # api_transport = "auto"             # how to reach the remote API socket:

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,18 @@ pub struct HostConfig {
     /// the local pane so it fills). Default on; ideal for headless remotes. Turn
     /// off per host for a remote a human is actively using directly.
     pub always_control: bool,
+    /// mirror only remote workspaces that have an agent in one of their panes.
+    /// Default off: mirror everything, which is what a machine you work on
+    /// directly wants. Turn it on for a viewer of many remotes, where the
+    /// interesting rows are the agents and a remote's bare shells are noise
+    /// (and a pane apiece: each mirror pane is a process plus a connection).
+    ///
+    /// This is a live filter, NOT a close: a workspace whose agent appears is
+    /// mirrored on the next converge, and one whose agent goes away has its
+    /// mirror closed locally with the remote untouched. Deliberately not
+    /// implemented as a tombstone, which is keyed to the remote workspace and
+    /// would keep a future agent in that workspace hidden forever.
+    pub agents_only: bool,
     /// Cap the size control asks the remote for. `None` = uncapped: fill the
     /// local pane, which is right for a headless remote nobody looks at.
     /// Control is authoritative on the remote, so on a host with its own
@@ -160,6 +172,7 @@ struct RawConfig {
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
+    agents_only: Option<bool>,
     // toml::Table (preserve_order) keeps declaration order — the first host
     // is the remote-create fallback, so order is user-visible
     #[serde(default)]
@@ -181,6 +194,7 @@ struct RawHost {
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
+    agents_only: Option<bool>,
     api_transport: Option<String>,
 }
 
@@ -261,6 +275,7 @@ pub fn load_config(candidates: &[PathBuf]) -> Result<MirrorConfig> {
 pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     let raw: RawConfig = toml::from_str(text)?;
     let global_always_control = raw.always_control.unwrap_or(true);
+    let global_agents_only = raw.agents_only.unwrap_or(false);
     // 0 is treated as unset rather than "clamp to nothing", same as an empty
     // remote_bin: a cap that would starve the remote of every column is a typo,
     // not an instruction. Warn rather than dropping it silently — and say that
@@ -318,6 +333,7 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             remote_bin: h.remote_bin.filter(|s| !s.is_empty()),
             session: h.session.filter(|s| !s.is_empty()),
             always_control: h.always_control.unwrap_or(global_always_control),
+            agents_only: h.agents_only.unwrap_or(global_agents_only),
             max_cols: size_cap(h.max_cols).or(global_max_cols),
             max_rows: size_cap(h.max_rows).or(global_max_rows),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
@@ -373,6 +389,31 @@ mod tests {
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert_eq!(h.session, None); // default remote session
         assert!(h.always_control); // default on
+        assert!(!h.agents_only); // default off: mirror every remote workspace
+    }
+
+    /// Global default off, settable globally, overridable per host in both
+    /// directions — one noisy host filtered on an otherwise unfiltered viewer,
+    /// or one machine mirrored whole on a filtered one.
+    #[test]
+    fn agents_only_global_default_and_per_host_override() {
+        let c = parse_config(
+            "[hosts.a]\ntarget = \"a\"\n[hosts.b]\ntarget = \"b\"\nagents_only = true\n",
+        )
+        .unwrap();
+        let by = |n: &str| c.hosts.iter().find(|h| h.name == n).unwrap().agents_only;
+        assert!(!by("a")); // inherits the global default
+        assert!(by("b")); // opted in for this host only
+
+        let c = parse_config(
+            "agents_only = true\n\
+             [hosts.a]\ntarget = \"a\"\n\
+             [hosts.b]\ntarget = \"b\"\nagents_only = false\n",
+        )
+        .unwrap();
+        let by = |n: &str| c.hosts.iter().find(|h| h.name == n).unwrap().agents_only;
+        assert!(by("a")); // inherits global on
+        assert!(!by("b")); // opted back out
     }
 
     #[test]

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -647,6 +647,28 @@ fn pane_is_mirror(p: &PaneInfo) -> bool {
     is_marker(&p.foreground_cwd) || is_marker(&p.cwd)
 }
 
+/// Does this remote workspace hold a live agent? The predicate behind
+/// `agents_only` (see HostConfig).
+///
+/// `agent_panes` is the remote's own agent list, filtered by
+/// `AgentInfo::has_agent`, so the filter and the status pushed onto the mirror
+/// row are derived from one snapshot and cannot disagree.
+///
+/// A workspace with no panes in the snapshot counts as agentless: a
+/// just-created remote workspace is a bare shell, and it becomes mirrorable the
+/// moment an agent appears in it. Unlike the nested-mirror guard, which treats
+/// "no panes" as "nothing to skip", the question here is presence, not absence.
+fn ws_has_agent(panes: &[&PaneInfo], agent_panes: &HashSet<&str>) -> bool {
+    panes.iter().any(|p| agent_panes.contains(p.pane_id.as_str()))
+}
+
+/// The remote's agent panes: its agent list filtered by `AgentInfo::has_agent`,
+/// so a sparse release row ("no agent here any more") never counts as one.
+/// Shared by the converge filter and its tests so both agree by construction.
+fn agent_pane_ids(agents: &[AgentInfo]) -> HashSet<&str> {
+    agents.iter().filter(|a| a.has_agent()).map(|a| a.pane_id.as_str()).collect()
+}
+
 // --- the converge pass ---
 
 /// Returns the post-converge state so callers don't re-read the state file.
@@ -812,9 +834,68 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
         }
     }
 
+    // agents_only: skip remote workspaces with no agent in any pane. Same shape
+    // as the nested-mirror guard above, from the same snapshot the agent
+    // statuses are pushed from.
+    let agent_panes = agent_pane_ids(&remote_snap.agents);
+    let mut agentless_ws_ids: HashSet<String> = HashSet::new();
+    if host.agents_only {
+        for rws in &remote_snap.workspaces {
+            let panes: &[&PaneInfo] =
+                panes_by_ws.get(rws.workspace_id.as_str()).map(|v| v.as_slice()).unwrap_or(&[]);
+            if !ws_has_agent(panes, &agent_panes) {
+                agentless_ws_ids.insert(rws.workspace_id.clone());
+            }
+        }
+    }
+
+    // 2b. mirrors whose workspace stopped qualifying (its agent exited) are
+    //     closed here, not by section 2: the remote workspace is still present,
+    //     so the absence sweep never fires for it.
+    //
+    //     Marked as our own close, so a filter decision can never be mistaken
+    //     for user intent and reach the remote via close_remote_on_local_close.
+    //     The entries are REMOVED rather than tombstoned, because a tombstone
+    //     means "the user closed this, never recreate" — it would hide the
+    //     workspace for good, including the next agent to start in it.
+    let reap: Vec<String> = state
+        .workspaces
+        .iter()
+        .filter(|(rid, e)| {
+            agentless_ws_ids.contains(rid.as_str())
+                && !e.is_tombstoned()
+                && local_ws_ids.contains(&e.local_id)
+        })
+        .map(|(rid, _)| rid.clone())
+        .collect();
+    if !reap.is_empty() {
+        let tab_ws: HashMap<&str, &str> =
+            remote_snap.tabs.iter().map(|t| (t.tab_id.as_str(), t.workspace_id.as_str())).collect();
+        for rid in reap {
+            let entry = state.workspaces.remove(&rid).unwrap();
+            log.log(&format!(
+                "remote workspace {rid} has no agent — closing mirror {} (agents_only)",
+                entry.local_id
+            ));
+            mark_self_close(deps, &entry.local_id);
+            if let Err(e) =
+                deps.local.request("workspace.close", json!({ "workspace_id": entry.local_id })).await
+            {
+                log.log(&format!("close failed: {e}"));
+            }
+            local_ws_ids.remove(&entry.local_id);
+            // drop the tab/pane entries the closed workspace owned, so no stale
+            // mapping survives to be wired into a rebuilt mirror later
+            state.panes.retain(|prid, _| pane_ws.get(prid.as_str()).copied() != Some(rid.as_str()));
+            state.tabs.retain(|trid, _| tab_ws.get(trid.as_str()).copied() != Some(rid.as_str()));
+        }
+    }
+
     // 3. remote workspaces → ensure mirrors exist with the right label
     for rws in &remote_snap.workspaces {
-        if mirror_ws_ids.contains(&rws.workspace_id) {
+        if mirror_ws_ids.contains(&rws.workspace_id)
+            || agentless_ws_ids.contains(&rws.workspace_id)
+        {
             continue;
         }
         let label = format!("{}: {}", host.prefix, rws.label);
@@ -1526,10 +1607,73 @@ mod tests {
             remote_bin: None,
             session: None,
             always_control: true,
+            agents_only: false,
             max_cols: None,
             max_rows: None,
             api_transport: crate::config::ApiTransport::Auto,
         }
+    }
+
+    fn pane(pane_id: &str, ws: &str) -> PaneInfo {
+        PaneInfo {
+            pane_id: pane_id.into(),
+            tab_id: format!("{ws}:t1"),
+            workspace_id: ws.into(),
+            label: None,
+            cwd: None,
+            foreground_cwd: None,
+        }
+    }
+
+    fn agent_on(pane_id: &str) -> AgentInfo {
+        AgentInfo {
+            pane_id: pane_id.into(),
+            agent: Some("claude".into()),
+            agent_status: Some("idle".into()),
+            ..Default::default()
+        }
+    }
+
+    /// `agents_only` mirrors a workspace when ANY of its panes has an agent —
+    /// an agent beside two shells is still an agent workspace.
+    #[test]
+    fn ws_has_agent_needs_one_agent_pane() {
+        let panes = [pane("w1:p1", "w1"), pane("w1:p2", "w1"), pane("w1:p3", "w1")];
+        let refs: Vec<&PaneInfo> = panes.iter().collect();
+        let agents = [agent_on("w1:p2")];
+        assert!(ws_has_agent(&refs, &agent_pane_ids(&agents)));
+
+        // the same panes with the agent living in a DIFFERENT workspace
+        let elsewhere = [agent_on("w9:p1")];
+        assert!(!ws_has_agent(&refs, &agent_pane_ids(&elsewhere)));
+    }
+
+    /// A workspace with no panes in the snapshot is agentless, not
+    /// "unclassifiable": a fresh remote workspace is a bare shell, and it
+    /// becomes mirrorable the moment an agent starts in it. Note this is the
+    /// opposite of the nested-mirror guard, which skips the empty case.
+    #[test]
+    fn a_paneless_workspace_has_no_agent() {
+        assert!(!ws_has_agent(&[], &agent_pane_ids(&[agent_on("w1:p1")])));
+    }
+
+    /// The agent list also carries release rows — `agent: null`,
+    /// `agent_status: "unknown"` — which `has_agent` rejects. If those counted,
+    /// a workspace whose agent just exited would keep its mirror forever.
+    #[test]
+    fn a_released_agent_row_does_not_qualify() {
+        let panes = [pane("w1:p1", "w1")];
+        let refs: Vec<&PaneInfo> = panes.iter().collect();
+
+        let released =
+            [AgentInfo { pane_id: "w1:p1".into(), agent_status: Some("unknown".into()), ..Default::default() }];
+        assert!(agent_pane_ids(&released).is_empty());
+        assert!(!ws_has_agent(&refs, &agent_pane_ids(&released)));
+
+        // a status alone still counts, even with no agent kind reported
+        let status_only =
+            [AgentInfo { pane_id: "w1:p1".into(), agent_status: Some("working".into()), ..Default::default() }];
+        assert!(ws_has_agent(&refs, &agent_pane_ids(&status_only)));
     }
 
     fn leaf(pane_id: &str) -> LayoutNode {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -614,6 +614,7 @@ mod tests {
             max_rows: None,
             api_transport: ApiTransport::Auto,
             always_control: true,
+            agents_only: false,
         }
     }
 


### PR DESCRIPTION
## Why

I run titan as a viewer of 9 remote herdr servers. It works well, but 26 of the sidebar's 32 workspaces are mirrors, and most of them are somebody's bare shells — one host alone contributes 12 workspaces of which 3 have agents. The agents are the point; the rest is noise.

It isn't only visual. A mirror pane is a process plus its own ssh connection: measured on that setup, 32 mirror panes hold **~35% of one core steady-state and 534 MiB RSS** (sampled from `/proc`, not a startup average). Watching a dozen scratch shells nobody reads costs real CPU.

The config today offers `enabled = false`, which is all-or-nothing — dropping that host would take its 3 agents with it.

## What

`agents_only` (global, overridable per host, **default off**) skips remote workspaces with no agent in any pane.

The predicate is the remote's own `agents[]` filtered by the existing `AgentInfo::has_agent`, read from the same snapshot the mirror row's agent status is pushed from — so the filter can't disagree with the row it would otherwise have drawn.

```toml
agents_only = true          # or per host

[hosts.gigachad]
target = "gigachad"
agents_only = true          # 12 workspaces -> the 3 with agents
```

## It's a filter, not a close

That distinction is most of the diff:

- A workspace whose agent **starts** is mirrored on the next converge (events + poll), so it appears within seconds.
- A mirror whose agent **exits** is closed in a new step **2b**. It can't ride on section 2's absence sweep, because the remote workspace is still very much present — only its agent went away.
- That close goes through `mark_self_close`, so a filter decision can never be mistaken for user intent and reach the remote via `close_remote_on_local_close`. This felt like the sharpest edge in the change: without it, enabling a display option could close live agent workspaces on other machines.
- The state entries are **removed, not tombstoned**. A tombstone means "the user closed this, never recreate until restore", so it would hide that workspace permanently — including the next agent to start in it. That is precisely the trap in doing this by hand (close the noisy rows and they stay closed, keyed to the remote workspace id), and the reason this wants to be a config knob rather than a cleanup habit.
- Tab/pane entries owned by a reaped workspace are dropped with it, so no stale mapping survives to be wired into a rebuilt mirror.

A paneless workspace counts as agentless: a fresh remote workspace is a bare shell, and it becomes mirrorable the moment an agent appears. Note this is deliberately the **opposite** of the nested-mirror guard immediately above it, which treats "no panes" as "nothing to skip" — presence vs absence, so I documented it rather than leaving the asymmetry to be rediscovered.

Sections 4+ needed no changes: they're already gated on the workspace having a state entry, the same way the nested-mirror skip relies on.

## Tests

`cargo test`: **153 passed**, clippy clean on `--all-targets`. Four new tests, against a small shared `agent_pane_ids` helper so the tests exercise the same code the converge does rather than a copy of it:

- `ws_has_agent_needs_one_agent_pane` — an agent beside two shells still counts; the same panes with the agent in another workspace don't.
- `a_paneless_workspace_has_no_agent`
- `a_released_agent_row_does_not_qualify` — the release rows (`agent: null`, `agent_status: "unknown"`) that `has_agent` rejects must not keep a mirror alive; a status alone with no agent kind still counts.
- `agents_only_global_default_and_per_host_override` — both directions, plus the default-off assertion in `parses_minimal`.

## Smoke test against a live remote (done)

Ran the patched binary against a real remote box, fully isolated from the installed plugin: redirected `HOME` so it had its own config and state dirs, a distinct sidebar prefix (`smoke: `, so it could neither adopt nor be mistaken for the live `ocai: ` mirrors), and `once`/daemon runs against titan's real herdr. The installed plugin kept mirroring all 9 hosts concurrently the whole time.

The remote is one of my k8s agent boxes running herdr 0.8.0 with one live agent (`@clem`, which I was careful not to touch — verified healthy afterwards, still `idle` at its old context). The probe agent was a synthesized `herdr pane report-agent` row on a scratch workspace, so a real agent could appear and exit on demand:

| Pass | Action | Observed |
|---|---|---|
| 1 | converge, `agents_only = true`, remote has agent workspace + bare shell | only the agent workspace mirrored; bare shell filtered out; state map holds only the agent's remote id |
| 2 | `report-agent --state working` on the bare shell, converge | mirror created on that pass; local row carried the forwarded `working` status |
| 3 | `release-agent`, converge | step 2b fired: `remote workspace w6 has no agent — closing mirror w9A (agents_only)`; state entry **removed, no tombstone**; remote workspace and pane both still alive |
| 4 | agent reported again, converge | mirror **re-created** — the direct proof that removal-not-tombstoning is correct (a tombstone would have hidden it forever) |
| 5 | same reap with `close_remote_on_local_close = true` | reap closed the local mirror, remote survived |
| 6 | reap with the **daemon** running and `close_remote_on_local_close = true` | the local close event arrives on the daemon's event stream; `mark_self_close` swallowed it — no remote close attempted, remote workspace intact |
| 7 | `agents_only = false` (control) | the agentless workspace **is** mirrored — the flag is precisely what filters |

Pass 6 is the one that matters and the one the unit tests can't cover: one-shot mode never populates the close tracker (per its own comment — "one-shot: no local event stream, so there is no authoritative close signal"), so only a live daemon actually exercises the event-confirmed close path that `close_remote_on_local_close` consults.

Two honest footnotes:

- The daemon logged transient `streamer … not up … shell startup likely ate the exec; retyping` on freshly created panes (both mine and on v0.3.0's own path — it predates this change). The panes came up streaming anyway; final content matched the live installed mirror of the same agent byte for byte. Worth a look separately, but orthogonal to this PR.
- Teardown afterwards left no residue: no `smoke:` rows, no stray processes, the scratch workspace closed, and the installed daemon's 25 mirrors across 9 hosts untouched.

Default off, so existing configs mirror exactly what they do today.

