### PR TITLE
fix: re-frame a text paste instead of stripping it

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1030,7 +1030,16 @@ impl App {
     }
 
     /// A complete paste body, markers already stripped. A file drop is
-    /// uploaded; anything else is forwarded verbatim as if it had been typed.
+    /// uploaded; anything else is re-framed and forwarded as a paste.
+    ///
+    /// Re-framing is the whole point of getting here: the markers were only
+    /// stripped so a drop could be recognised, and an ordinary paste that
+    /// reaches the remote pty *without* them is not a paste any more — the
+    /// remote app reads every newline in it as Enter, so a multi-line paste
+    /// submits itself a line at a time (an agent's composer takes the first
+    /// line and runs it). `deliver_input`, not `handle_stdin_inner`: a paste
+    /// body is data, so its bytes must not be re-read as a Ctrl+V clipboard
+    /// request, as mouse sequences, or as locally predicted keystrokes.
     async fn route_paste_body(&mut self, body: Vec<u8>) {
         if self.paste_inflight {
             self.paste_queue.push(Queued::Body(body));
@@ -1038,7 +1047,7 @@ impl App {
         }
         // lossy only for the probe; the forward path keeps the original bytes
         let Some(paths) = crate::paste::dropped_paths(&String::from_utf8_lossy(&body)) else {
-            self.handle_stdin_inner(body).await;
+            self.deliver_input(crate::paste::bracketed_bytes(&body)).await;
             return;
         };
 
@@ -1067,7 +1076,7 @@ impl App {
             // every path already exists over there, so the user meant those
             // files: forward what they actually dropped
             if let Some(body) = original {
-                self.handle_stdin_inner(body).await;
+                self.deliver_input(crate::paste::bracketed_bytes(&body)).await;
             }
         }
         if let Some(e) = result.error {
@@ -1266,10 +1275,11 @@ pub async fn run(args: Args) -> Result<()> {
     let raw = if tty {
         // 1002/1006: button-event mouse tracking with SGR encoding, so wheel and
         // clicks reach us instead of scrolling the hosting pane's scrollback
-        // 2004 (bracketed paste) is asked for purely to get framing: herdr
-        // only wraps a paste when the pane's app has enabled it, and a file
-        // drop otherwise arrives as bare text with no terminator at all. See
-        // `intercept_paste`; the markers never reach the remote.
+        // 2004 (bracketed paste) is asked for so herdr frames a paste for us:
+        // it only wraps one when the pane's app has enabled it, and a file
+        // drop otherwise arrives as bare text with no terminator at all. The
+        // framing is stripped only to recognise a drop and put back on the way
+        // out (`route_paste_body`), so the remote app still sees a paste.
         write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?1002h\x1b[?1006h\x1b[?2004h");
         RawMode::enable()
     } else {
@@ -1734,6 +1744,23 @@ mod tests {
             panic!("expected paste")
         };
         assert_eq!(body, b"caf\xe9", "0xE9 must not become U+FFFD");
+    }
+
+    #[test]
+    fn a_stripped_paste_is_reframed_byte_exact() {
+        // what `route_paste_body` sends on: the framing comes off to recognise
+        // a drop and has to go back on, or the remote app reads the newlines in
+        // a multi-line paste as Enter and submits it a line at a time
+        let body = b"first line\nsecond line".to_vec();
+        let framed = crate::paste::bracketed_bytes(&body);
+        assert_eq!(framed, seq(&[S, &body, E]));
+
+        let mut buf = Vec::new();
+        assert_eq!(
+            split(&mut buf, &framed),
+            PasteSplit::Complete { before: vec![], body, after: vec![] },
+            "re-framing must be exactly what the splitter undoes"
+        );
     }
 
     #[test]

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -165,11 +165,25 @@ async fn remote_command(
     })
 }
 
-pub fn bracketed(path: &str) -> Vec<u8> {
-    let mut b: Vec<u8> = b"\x1b[200~".to_vec();
-    b.extend_from_slice(path.as_bytes());
+/// Frame `body` as a bracketed paste for the remote pty.
+///
+/// The markers are what tell the remote app "this arrived as a paste, not as
+/// keystrokes" — without them every newline in the body reads as Enter, so a
+/// multi-line paste submits itself a line at a time. herdr only wraps a paste
+/// when the pane's app has enabled DECSET 2004, and the streamer enables it
+/// (see `pane::run`), so a paste reaching us is framed and has to leave framed
+/// too. Both ends of the payload are ours, so this is the one place that knows
+/// the byte sequences besides `split_paste`.
+pub fn bracketed_bytes(body: &[u8]) -> Vec<u8> {
+    let mut b: Vec<u8> = Vec::with_capacity(body.len() + 12);
+    b.extend_from_slice(b"\x1b[200~");
+    b.extend_from_slice(body);
     b.extend_from_slice(b"\x1b[201~");
     b
+}
+
+pub fn bracketed(path: &str) -> Vec<u8> {
+    bracketed_bytes(path.as_bytes())
 }
 
 /// Cap per dropped file. Enforced on the READ, not just the stat, so a file


### PR DESCRIPTION
Pasting more than one line into a mirror pane doesn't paste — it types. Three lines into a remote shell run three commands; into a remote agent, the first line becomes a turn and the rest scatter across the next ones.

`route_paste_body` strips the bracketed-paste markers to test the body for a file drop (#52) and then forwards the bare body to the remote pty. Without the framing it isn't a paste any more, so the remote app reads every newline in it as Enter. The framing now goes back on before the body is forwarded.

## The guard this removes

#52 stripped the markers on purpose, reasoning that the remote's app may not have bracketed paste on. I don't think that holds:

- It doesn't make a multi-line paste safe on such a remote. It makes it wrong on *every* remote — a worse failure than the one it avoids, and one that fires on the common case rather than the rare one.
- It is already not honoured. `handle_drop` and `handle_paste` both deliver `bracketed(path)` straight through to the remote, so the payloads that carry no newline at all keep their framing, while the one case where framing decides the outcome lost it. The asymmetry is backwards.
- A remote without 2004 now sees a literal `[200~` wrapped around text that was executing line by line regardless. bash >= 5.1, zsh, fish and every agent TUI enable it.

If you'd rather not assume that at all, the airtight version is to hand the body to the remote herdr's `pane.send_input` instead of writing bytes down the control stream: `encode_api_text` wraps per the remote *pane's* own `bracketed_paste` state, so the remote decides. I verified that path works against herdr 0.8.0 (a multi-line `pane.send_input` lands unsubmitted at the remote prompt), but it costs a round trip per paste and a new daemon -> streamer flag for the API socket path (whose live value flips between `<stem>-api.sock` and `<stem>-api-exec.sock`), so I left it out of this PR. Happy to build it if you prefer it.

## Also fixed by the same line

The non-drop path went through `handle_stdin_inner`, which re-reads its bytes as *input*. Delivering through `deliver_input` instead means a paste body is no longer:

- a Ctrl+V clipboard request when it happens to be a lone 0x16,
- mouse events when it contains SGR mouse bytes,
- keystrokes for the local predictor to draw, which for a multi-line paste drew garbage.

## Testing

150 tests, clippy clean (`--all-targets -D warnings`). One new table test, `a_stripped_paste_is_reframed_byte_exact`, pins re-framing as the exact inverse of `split_paste`, so the two places that know the marker bytes can't drift.

Verified live on a Linux host mirroring a mac (`herdr-mirror pane gigachad w2:p3`), with the sidebar viewed over ttyd in a browser so the paste is a real Cmd+V:

- three `echo` lines land on the remote prompt unsubmitted; before this they executed one by one,
- ordinary typing still executes,
- a single-line paste plus Enter still submits once,
- the same text sent through the remote herdr's own `pane.send_input` behaves identically, which is what says the remote end was fine all along and the hop was losing the framing.
