### PR TITLE
fix: recover mirrored terminal sessions after SSH loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "equivalent"
@@ -37,6 +81,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +105,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "toml",
  "unicode-width",
@@ -172,6 +227,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +354,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ base64 = "0.22"
 libc = "0.2"
 unicode-width = "0.2"
 fnv = "1.0.7"
+sha2 = "0.10"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -285,6 +285,11 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
                          # idle release, and sized to your local pane so the
                          # remote fills it (ideal for headless remotes). Set
                          # false for read-only mirrors that escalate on type.
+# takeover_on_reconnect = false
+                         # legacy Herdr only. Safe default: never evict an
+                         # unknown controller while recovering. Opting in
+                         # permits one takeover retry per pane per 60 seconds;
+                         # watch-only mirrors still never take over.
 # max_cols / max_rows    # cap the size control asks the remote for, so a
                          # machine with its own display keeps its geometry.
                          # A ceiling only, and never applies to watch-only.
@@ -299,6 +304,7 @@ target = "work"
 # max_rows = 58                      # always_control = false
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
+# takeover_on_reconnect = false      # per-host legacy override
 # enabled = true                     # false stops syncing this host without
                                      # deleting its config; mirrors stay put
 # api_transport = "auto"             # how to reach the remote API socket:
@@ -309,6 +315,15 @@ target = "work"
 [hosts.vps]                          # add more hosts freely; each is independent
 target = "ssh://niko@203.0.113.7:2222"
 ```
+
+Herdr protocol 21 peers automatically use a persisted, host-scoped controller
+identity plus a 20-second lease. The mirror sends heartbeats every two seconds,
+reconnects when acknowledgements stop, and safely replaces only its own stale
+claim. Older peers keep their released behavior; automatic takeover stays off
+unless explicitly enabled above. The controller identity lives in
+`~/.local/state/herdr-mirror/controller-id.json`; daemons sharing that state
+directory intentionally act as one controller, while a copied file regenerates
+when the machine identity changes.
 
 ## Devcontainer
 

--- a/README.md
+++ b/README.md
@@ -316,14 +316,19 @@ target = "work"
 target = "ssh://niko@203.0.113.7:2222"
 ```
 
-Herdr protocol 21 peers automatically use a persisted, host-scoped controller
+Herdr protocol 22 peers automatically use a persisted, host-scoped controller
 identity plus a 20-second lease. The mirror sends heartbeats every two seconds,
-reconnects when acknowledgements stop, and safely replaces only its own stale
-claim. Older peers keep their released behavior; automatic takeover stays off
+reconnects when acknowledgements stop, persists Herdr's latest claim token per
+remote pane, and records a monotonic attempt generation before every dial. The
+token reclaims the exact stale connection; the generation rejects delayed old
+dials and still recovers when a newer ready record was lost. Priority control output and full-frame resync keep a slow or
+blocked stream from looking healthy while its display is stale. Older peers keep their released behavior; automatic takeover stays off
 unless explicitly enabled above. The controller identity lives in
 `~/.local/state/herdr-mirror/controller-id.json`; daemons sharing that state
 directory intentionally act as one controller, while a copied file regenerates
 when the machine identity changes.
+Per-pane claim tokens and duplicate-streamer locks live beside it under the
+same state directory; stale lock artifacts are collected during acquisition.
 
 ## Devcontainer
 

--- a/src/child_supervisor.rs
+++ b/src/child_supervisor.rs
@@ -1,0 +1,114 @@
+use std::io;
+use std::time::Duration;
+
+use tokio::process::Child;
+use tokio::sync::{oneshot, watch};
+
+const TERM_GRACE: Duration = Duration::from_millis(250);
+const KILL_GRACE: Duration = Duration::from_millis(200);
+
+pub(crate) struct ChildSupervisor {
+    cancel: Option<oneshot::Sender<()>>,
+    exited: watch::Receiver<bool>,
+}
+
+impl ChildSupervisor {
+    pub(crate) fn start(mut child: Child) -> (Self, watch::Receiver<bool>) {
+        let pid = child.id().map(|value| value as i32);
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let (exited_tx, exited_rx) = watch::channel(false);
+        tokio::spawn(async move {
+            let reaped = tokio::select! {
+                status = child.wait() => status.is_ok(),
+                _ = cancel_rx => terminate_and_reap(&mut child, pid).await,
+            };
+            if reaped {
+                let _ = exited_tx.send(true);
+            }
+        });
+        (
+            Self {
+                cancel: Some(cancel_tx),
+                exited: exited_rx.clone(),
+            },
+            exited_rx,
+        )
+    }
+
+    pub(crate) async fn cancel_and_wait(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(());
+        }
+        if *self.exited.borrow() {
+            return;
+        }
+        let _ = tokio::time::timeout(
+            Duration::from_millis(500),
+            self.exited.wait_for(|exited| *exited),
+        )
+        .await;
+    }
+}
+
+impl Drop for ChildSupervisor {
+    fn drop(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(());
+        }
+    }
+}
+
+async fn terminate_and_reap(child: &mut Child, pid: Option<i32>) -> bool {
+    if let Some(pid) = pid {
+        unsafe {
+            libc::kill(pid, libc::SIGTERM);
+        }
+    }
+    if matches!(
+        tokio::time::timeout(TERM_GRACE, child.wait()).await,
+        Ok(Ok(_))
+    ) {
+        return true;
+    }
+    let _ = child.start_kill();
+    matches!(
+        tokio::time::timeout(KILL_GRACE, child.wait()).await,
+        Ok(Ok(_))
+    )
+}
+
+pub(crate) async fn wait_for_exit(exited: &mut watch::Receiver<bool>) -> io::Result<()> {
+    if *exited.borrow() {
+        return Ok(());
+    }
+    exited
+        .wait_for(|value| *value)
+        .await
+        .map(|_| ())
+        .map_err(|_| io::Error::other("child supervisor stopped before reporting exit"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+    use std::time::Instant;
+
+    #[tokio::test]
+    async fn cancellation_reaps_a_term_ignoring_child_within_the_bound() {
+        let mut command = tokio::process::Command::new("sh");
+        command
+            .args(["-c", "trap '' TERM; while :; do sleep 1; done"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = command.spawn().unwrap();
+        let pid = child.id().unwrap() as i32;
+        let (mut supervisor, _) = ChildSupervisor::start(child);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let started = Instant::now();
+        supervisor.cancel_and_wait().await;
+        assert!(started.elapsed() < Duration::from_millis(550));
+        assert_eq!(unsafe { libc::kill(pid, 0) }, -1, "child must be reaped");
+    }
+}

--- a/src/claim_token.rs
+++ b/src/claim_token.rs
@@ -1,0 +1,129 @@
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+
+use crate::util::{err, Result};
+
+const MAX_TOKEN_BYTES: u64 = 32;
+
+fn path(state_dir: &Path, streamer_key: &str) -> PathBuf {
+    state_dir
+        .join("claim-tokens")
+        .join(format!("v1-{streamer_key}.token"))
+}
+
+fn generation_path(state_dir: &Path, streamer_key: &str) -> PathBuf {
+    state_dir
+        .join("claim-tokens")
+        .join(format!("v1-{streamer_key}.generation"))
+}
+
+pub(crate) fn load(state_dir: &Path, streamer_key: &str) -> Result<Option<u64>> {
+    let path = path(state_dir, streamer_key);
+    let file = match std::fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if file.metadata()?.len() > MAX_TOKEN_BYTES {
+        return Err(err("terminal claim token file is oversized"));
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_TOKEN_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_TOKEN_BYTES {
+        return Err(err("terminal claim token file is oversized"));
+    }
+    let text = std::str::from_utf8(&bytes)?.trim();
+    let token = text
+        .parse::<u64>()
+        .map_err(|_| err("terminal claim token file is invalid"))?;
+    Ok(Some(token))
+}
+
+pub(crate) fn save(state_dir: &Path, streamer_key: &str, token: u64) -> Result<()> {
+    save_number(&path(state_dir, streamer_key), token)
+}
+
+pub(crate) fn next_generation(state_dir: &Path, streamer_key: &str) -> Result<u64> {
+    let path = generation_path(state_dir, streamer_key);
+    let current = match read_number(&path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(error) => return Err(error.into()),
+    };
+    let next = current
+        .checked_add(1)
+        .ok_or_else(|| err("terminal controller generation exhausted"))?;
+    save_number(&path, next)?;
+    Ok(next)
+}
+
+fn read_number(path: &Path) -> std::io::Result<u64> {
+    let file = std::fs::File::open(path)?;
+    if file.metadata()?.len() > MAX_TOKEN_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "terminal controller number file is oversized",
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_TOKEN_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_TOKEN_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "terminal controller number file is oversized",
+        ));
+    }
+    let text = std::str::from_utf8(&bytes)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?
+        .trim();
+    text.parse::<u64>()
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+fn save_number(path: &Path, value: u64) -> Result<()> {
+    let dir = path.parent().ok_or_else(|| err("number path has no parent"))?;
+    fs::create_dir_all(dir)?;
+    let tmp = dir.join(format!(
+        ".number.{}-{}-{}.tmp",
+        std::process::id(),
+        value,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(&tmp)?;
+    writeln!(file, "{value}")?;
+    file.sync_all()?;
+    fs::rename(&tmp, path)?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_roundtrips_and_replaces_atomically() {
+        let dir = std::env::temp_dir().join(format!(
+            "herdr-mirror-claim-token-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        assert_eq!(load(&dir, "pane").unwrap(), None);
+        save(&dir, "pane", 7).unwrap();
+        assert_eq!(load(&dir, "pane").unwrap(), Some(7));
+        save(&dir, "pane", 9).unwrap();
+        assert_eq!(load(&dir, "pane").unwrap(), Some(9));
+        assert_eq!(next_generation(&dir, "pane").unwrap(), 1);
+        assert_eq!(next_generation(&dir, "pane").unwrap(), 2);
+        fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,10 @@ pub struct HostConfig {
     /// the local pane so it fills). Default on; ideal for headless remotes. Turn
     /// off per host for a remote a human is actively using directly.
     pub always_control: bool,
+    /// Legacy Herdr only: permit one bounded automatic `--takeover` retry after
+    /// the exact existing-controller rejection. Safe default is false because
+    /// legacy controllers have no stable identity.
+    pub takeover_on_reconnect: bool,
     /// Cap the size control asks the remote for. `None` = uncapped: fill the
     /// local pane, which is right for a headless remote nobody looks at.
     /// Control is authoritative on the remote, so on a host with its own
@@ -158,6 +162,7 @@ struct RawConfig {
     default_host: Option<String>,
     close_remote_on_local_close: Option<bool>,
     always_control: Option<bool>,
+    takeover_on_reconnect: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
     // toml::Table (preserve_order) keeps declaration order — the first host
@@ -179,6 +184,7 @@ struct RawHost {
     session: Option<String>,
     enabled: Option<bool>,
     always_control: Option<bool>,
+    takeover_on_reconnect: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
     api_transport: Option<String>,
@@ -261,6 +267,7 @@ pub fn load_config(candidates: &[PathBuf]) -> Result<MirrorConfig> {
 pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     let raw: RawConfig = toml::from_str(text)?;
     let global_always_control = raw.always_control.unwrap_or(true);
+    let global_takeover_on_reconnect = raw.takeover_on_reconnect.unwrap_or(false);
     // 0 is treated as unset rather than "clamp to nothing", same as an empty
     // remote_bin: a cap that would starve the remote of every column is a typo,
     // not an instruction. Warn rather than dropping it silently — and say that
@@ -318,6 +325,9 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             remote_bin: h.remote_bin.filter(|s| !s.is_empty()),
             session: h.session.filter(|s| !s.is_empty()),
             always_control: h.always_control.unwrap_or(global_always_control),
+            takeover_on_reconnect: h
+                .takeover_on_reconnect
+                .unwrap_or(global_takeover_on_reconnect),
             max_cols: size_cap(h.max_cols).or(global_max_cols),
             max_rows: size_cap(h.max_rows).or(global_max_rows),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
@@ -388,6 +398,23 @@ mod tests {
         let b = c.hosts.iter().find(|h| h.name == "b").unwrap();
         assert!(!a.always_control); // inherits global off
         assert!(b.always_control); // per-host override on
+    }
+
+    #[test]
+    fn takeover_on_reconnect_is_safe_by_default_and_overridable_per_host() {
+        let c = parse_config(
+            "takeover_on_reconnect = true\n\
+             [hosts.a]\ntarget = \"a\"\n\
+             [hosts.b]\ntarget = \"b\"\ntakeover_on_reconnect = false\n",
+        )
+        .unwrap();
+        let a = c.hosts.iter().find(|h| h.name == "a").unwrap();
+        let b = c.hosts.iter().find(|h| h.name == "b").unwrap();
+        assert!(a.takeover_on_reconnect);
+        assert!(!b.takeover_on_reconnect);
+
+        let defaults = parse_config("[hosts.safe]\ntarget = \"safe\"\n").unwrap();
+        assert!(!defaults.hosts[0].takeover_on_reconnect);
     }
 
     #[test]

--- a/src/controller_identity.rs
+++ b/src/controller_identity.rs
@@ -1,0 +1,215 @@
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::util::{err, Result};
+
+const ID_FILE: &str = "controller-id.json";
+
+#[derive(Deserialize, Serialize)]
+struct StoredIdentity {
+    id: String,
+    machine: Option<String>,
+}
+
+pub fn controller_id(state_dir: &Path, scope: &str) -> Result<String> {
+    let stored = load_or_create(state_dir, machine_fingerprint())?;
+    let mut hash = Sha256::new();
+    hash.update(b"herdr-mirror-controller-v1");
+    hash.update((stored.id.len() as u64).to_be_bytes());
+    hash.update(stored.id.as_bytes());
+    hash.update((scope.len() as u64).to_be_bytes());
+    hash.update(scope.as_bytes());
+    Ok(hex(&hash.finalize()))
+}
+
+fn load_or_create(state_dir: &Path, machine: Option<String>) -> Result<StoredIdentity> {
+    fs::create_dir_all(state_dir)?;
+    let lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .mode(0o600)
+        .open(state_dir.join("controller-id.lock"))?;
+    if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let path = state_dir.join(ID_FILE);
+    match fs::read_to_string(&path) {
+        Ok(text) => {
+            let mut stored = parse(&text)?;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+            if stored.machine.is_some() && machine.is_some() && stored.machine != machine {
+                let replacement = StoredIdentity {
+                    id: random_id()?,
+                    machine,
+                };
+                write_atomic(&path, &replacement)?;
+                return Ok(replacement);
+            }
+            if stored.machine.is_none() && machine.is_some() {
+                stored.machine = machine;
+                write_atomic(&path, &stored)?;
+            }
+            Ok(stored)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let created = StoredIdentity {
+                id: random_id()?,
+                machine,
+            };
+            write_atomic(&path, &created)?;
+            Ok(created)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn parse(text: &str) -> Result<StoredIdentity> {
+    if text.len() > 1024 {
+        return Err(err("controller identity file is oversized"));
+    }
+    let stored: StoredIdentity = serde_json::from_str(text)?;
+    let valid = stored.id.len() == 64 && stored.id.bytes().all(|byte| byte.is_ascii_hexdigit());
+    if !valid {
+        return Err(err("controller identity file contains an invalid id"));
+    }
+    Ok(stored)
+}
+
+fn random_id() -> Result<String> {
+    let mut bytes = [0_u8; 32];
+    std::fs::File::open("/dev/urandom")?.read_exact(&mut bytes)?;
+    Ok(hex(&bytes))
+}
+
+fn write_atomic(path: &Path, identity: &StoredIdentity) -> Result<()> {
+    let suffix = random_id()?;
+    let tmp = path.with_extension(format!("tmp-{}-{}", std::process::id(), &suffix[..12]));
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .open(&tmp)?;
+    file.write_all(&serde_json::to_vec(identity)?)?;
+    file.sync_all()?;
+    fs::rename(tmp, path)?;
+    Ok(())
+}
+
+fn machine_fingerprint() -> Option<String> {
+    for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"] {
+        if let Ok(value) = fs::read_to_string(path) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_owned());
+            }
+        }
+    }
+    let output = std::process::Command::new("ioreg")
+        .args(["-rd1", "-c", "IOPlatformExpertDevice"])
+        .output()
+        .ok()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines()
+        .find_map(|line| line.split_once("IOPlatformUUID")?.1.split('"').nth(2))
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "herdr-mirror-controller-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn identity_is_stable_per_scope_and_distinct_across_host_entries() {
+        let dir = temp_dir("scopes");
+        let first = controller_id(&dir, "work").unwrap();
+        assert_eq!(controller_id(&dir, "work").unwrap(), first);
+        assert_ne!(controller_id(&dir, "alias-to-work").unwrap(), first);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn copied_state_regenerates_on_machine_mismatch() {
+        let dir = temp_dir("machine");
+        let first = load_or_create(&dir, Some("machine-a".into())).unwrap();
+        let second = load_or_create(&dir, Some("machine-b".into())).unwrap();
+        assert_ne!(first.id, second.id);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn a_later_machine_fingerprint_binds_without_changing_the_identity() {
+        let dir = temp_dir("late-machine");
+        let first = load_or_create(&dir, None).unwrap();
+        let bound = load_or_create(&dir, Some("machine-a".into())).unwrap();
+        assert_eq!(first.id, bound.id);
+        assert_eq!(bound.machine.as_deref(), Some("machine-a"));
+        let replacement = load_or_create(&dir, Some("machine-b".into())).unwrap();
+        assert_ne!(bound.id, replacement.id);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn concurrent_creation_publishes_one_complete_identity() {
+        let dir = temp_dir("concurrent");
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let dir = dir.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    load_or_create(&dir, Some("machine".into())).unwrap().id
+                })
+            })
+            .collect();
+        let ids: std::collections::HashSet<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+        assert_eq!(ids.len(), 1);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn malformed_and_oversized_identity_files_fail_clearly() {
+        for (name, contents, expected) in [
+            ("malformed", "not-json".to_owned(), "expected ident"),
+            ("oversized", "x".repeat(1025), "oversized"),
+        ] {
+            let dir = temp_dir(name);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join(ID_FILE), contents).unwrap();
+            let error = load_or_create(&dir, Some("machine".into()))
+                .err()
+                .expect("invalid identity must fail")
+                .to_string();
+            assert!(error.contains(expected), "unexpected error: {error}");
+            fs::remove_dir_all(dir).unwrap();
+        }
+    }
+}

--- a/src/controller_identity.rs
+++ b/src/controller_identity.rs
@@ -4,6 +4,7 @@ use std::os::fd::AsRawFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use std::sync::Once;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -11,6 +12,8 @@ use sha2::{Digest, Sha256};
 use crate::util::{err, Result};
 
 const ID_FILE: &str = "controller-id.json";
+const MAX_IDENTITY_BYTES: u64 = 1024;
+static MISSING_MACHINE_WARNING: Once = Once::new();
 
 #[derive(Deserialize, Serialize)]
 struct StoredIdentity {
@@ -42,7 +45,7 @@ fn load_or_create(state_dir: &Path, machine: Option<String>) -> Result<StoredIde
         return Err(std::io::Error::last_os_error().into());
     }
     let path = state_dir.join(ID_FILE);
-    match fs::read_to_string(&path) {
+    match read_identity_file(&path) {
         Ok(text) => {
             let mut stored = parse(&text)?;
             fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
@@ -57,6 +60,8 @@ fn load_or_create(state_dir: &Path, machine: Option<String>) -> Result<StoredIde
             if stored.machine.is_none() && machine.is_some() {
                 stored.machine = machine;
                 write_atomic(&path, &stored)?;
+            } else if stored.machine.is_none() {
+                warn_missing_machine_fingerprint();
             }
             Ok(stored)
         }
@@ -65,11 +70,46 @@ fn load_or_create(state_dir: &Path, machine: Option<String>) -> Result<StoredIde
                 id: random_id()?,
                 machine,
             };
+            if created.machine.is_none() {
+                warn_missing_machine_fingerprint();
+            }
             write_atomic(&path, &created)?;
             Ok(created)
         }
         Err(error) => Err(error.into()),
     }
+}
+
+fn read_identity_file(path: &Path) -> std::io::Result<String> {
+    let file = std::fs::File::open(path)?;
+    if file.metadata()?.len() > MAX_IDENTITY_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "controller identity file is oversized",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(MAX_IDENTITY_BYTES as usize);
+    file.take(MAX_IDENTITY_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_IDENTITY_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "controller identity file is oversized",
+        ));
+    }
+    String::from_utf8(bytes).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "controller identity file is not UTF-8",
+        )
+    })
+}
+
+fn warn_missing_machine_fingerprint() {
+    MISSING_MACHINE_WARNING.call_once(|| {
+        eprintln!(
+            "herdr-mirror: machine fingerprint unavailable; controller identity copied to another machine may collide"
+        );
+    });
 }
 
 fn parse(text: &str) -> Result<StoredIdentity> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -217,10 +217,6 @@ async fn run_connected(
         close_remote_on_local_close: ctx.close_remote_on_local_close,
         closes: ctx.closes.clone(),
         terminal_session_reconnect: status.terminal_session_reconnect,
-        controller_id: status
-            .terminal_session_reconnect
-            .then(|| crate::controller_identity::controller_id(&ctx.env_state_dir, &ctx.host.name))
-            .transpose()?,
     };
     // broadcast-only first: subscribing a since-dead pane id is rejected, so
     // converge must prune the map before the per-pane upgrade
@@ -452,39 +448,42 @@ async fn heal_zombie_mirrors(
         // falls back to its default and the next converge reconciles.
         let mut remote_host = crate::remote::RemoteHost::new(h, state_dir);
         let reconnect = match remote_host.ensure_ready().await {
-            Ok(()) => remote_host.status().await.ok(),
-            Err(error) => {
-                log.log(&format!(
-                    "[{}] reconnect capability re-probe failed during streamer heal: {error}",
-                    h.name
-                ));
-                None
-            }
-        };
-        let terminal_session_reconnect = reconnect
-            .as_ref()
-            .is_some_and(|status| status.terminal_session_reconnect);
-        let controller_id = if terminal_session_reconnect {
-            match crate::controller_identity::controller_id(state_dir, &h.name) {
-                Ok(id) => Some(id),
+            Ok(()) => match remote_host.status().await {
+                Ok(status) => status,
                 Err(error) => {
                     log.log(&format!(
-                        "[{}] controller identity unavailable during streamer heal: {error}",
+                        "[{}] reconnect capability re-probe failed during streamer heal: {error}; deferring heal",
                         h.name
                     ));
-                    None
+                    let _ = pokers[i].try_send(());
+                    continue;
                 }
+            },
+            Err(error) => {
+                log.log(&format!(
+                    "[{}] reconnect capability re-probe failed during streamer heal: {error}; deferring heal",
+                    h.name
+                ));
+                let _ = pokers[i].try_send(());
+                continue;
             }
-        } else {
-            None
         };
-        let terminal_session_reconnect = terminal_session_reconnect && controller_id.is_some();
+        let terminal_session_reconnect = reconnect.terminal_session_reconnect;
+        if terminal_session_reconnect {
+            if let Err(error) = crate::controller_identity::controller_id(state_dir, &h.name) {
+                log.log(&format!(
+                    "[{}] controller identity unavailable during streamer heal: {error}; deferring heal",
+                    h.name
+                ));
+                let _ = pokers[i].try_send(());
+                continue;
+            }
+        }
         let cmd_for = crate::mirror::cmd_for_pane(
             h,
             state_dir,
             &HashMap::new(),
             terminal_session_reconnect,
-            controller_id.as_deref(),
         );
         for (remote_pane_id, local_pane_id) in dead {
             let argv = cmd_for(&remote_pane_id);
@@ -827,10 +826,6 @@ pub async fn cmd_once(env: Env) -> Result<()> {
             // closes a remote object, which is the correct conservative default
             closes: crate::closes::new_closes(),
             terminal_session_reconnect: status.terminal_session_reconnect,
-            controller_id: status
-                .terminal_session_reconnect
-                .then(|| crate::controller_identity::controller_id(&env.state_dir, &h.name))
-                .transpose()?,
         })
         .await?;
         state.remote_session = Some(crate::state::RemoteSessionStatus {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -197,7 +197,15 @@ async fn run_connected(
     // would otherwise be re-probed via streamlocal on every single reconnect
     // for the life of the daemon
     remote_host.hint_transport(*remembered_transport);
-    let (remote, _status) = remote_host.connect_api().await?;
+    let (remote, status) = remote_host.connect_api().await?;
+    ctx.log.log(&format!(
+        "[{}] herdr protocols client={:?} server={:?} compatible={} reconnect_v1={}",
+        ctx.host.name,
+        status.client_protocol,
+        status.server_protocol,
+        status.compatible,
+        status.terminal_session_reconnect
+    ));
     *remembered_transport = remember_transport(remote_host.last_api_transport, exec_streak);
     *backoff_idx = 0;
     let deps = ConvergeDeps {
@@ -208,12 +216,24 @@ async fn run_connected(
         log: ctx.log.clone(),
         close_remote_on_local_close: ctx.close_remote_on_local_close,
         closes: ctx.closes.clone(),
+        terminal_session_reconnect: status.terminal_session_reconnect,
+        controller_id: status
+            .terminal_session_reconnect
+            .then(|| crate::controller_identity::controller_id(&ctx.env_state_dir, &ctx.host.name))
+            .transpose()?,
     };
     // broadcast-only first: subscribing a since-dead pane id is rejected, so
     // converge must prune the map before the per-pane upgrade
     let mut stream = remote.subscribe(sub_list(&[])).await?;
     let mut subscribed_key = String::from("<broadcast>");
-    let state = converge(&deps).await?;
+    let mut state = converge(&deps).await?;
+    state.remote_session = Some(crate::state::RemoteSessionStatus {
+        client_protocol: status.client_protocol,
+        server_protocol: status.server_protocol,
+        compatible: status.compatible,
+        reconnect_v1: status.terminal_session_reconnect,
+    });
+    save_state(&ctx.env_state_dir, &ctx.host.name, &state)?;
     resubscribe(ctx, &remote, &mut stream, &mut subscribed_key, &state).await?;
     ctx.log.log(&format!("[{}] connected and synced", ctx.host.name));
 
@@ -430,7 +450,42 @@ async fn heal_zombie_mirrors(
         //
         // Sizes live in the remote layout, which we don't have here; the wrapper
         // falls back to its default and the next converge reconciles.
-        let cmd_for = crate::mirror::cmd_for_pane(h, state_dir, &HashMap::new());
+        let mut remote_host = crate::remote::RemoteHost::new(h, state_dir);
+        let reconnect = match remote_host.ensure_ready().await {
+            Ok(()) => remote_host.status().await.ok(),
+            Err(error) => {
+                log.log(&format!(
+                    "[{}] reconnect capability re-probe failed during streamer heal: {error}",
+                    h.name
+                ));
+                None
+            }
+        };
+        let terminal_session_reconnect = reconnect
+            .as_ref()
+            .is_some_and(|status| status.terminal_session_reconnect);
+        let controller_id = if terminal_session_reconnect {
+            match crate::controller_identity::controller_id(state_dir, &h.name) {
+                Ok(id) => Some(id),
+                Err(error) => {
+                    log.log(&format!(
+                        "[{}] controller identity unavailable during streamer heal: {error}",
+                        h.name
+                    ));
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let terminal_session_reconnect = terminal_session_reconnect && controller_id.is_some();
+        let cmd_for = crate::mirror::cmd_for_pane(
+            h,
+            state_dir,
+            &HashMap::new(),
+            terminal_session_reconnect,
+            controller_id.as_deref(),
+        );
         for (remote_pane_id, local_pane_id) in dead {
             let argv = cmd_for(&remote_pane_id);
             crate::mirror::spawn_streamer_pane(local, state_dir, &local_pane_id, &argv, log).await;
@@ -711,7 +766,27 @@ pub fn cmd_status(env: &Env) -> Result<()> {
         let state = load_state(&env.state_dir, &h.name);
         let ws = state.workspaces.values().filter(|w| !w.is_tombstoned()).count();
         let panes = state.panes.values().filter(|p| !p.is_tombstoned()).count();
-        println!("host {} ({}): {ws} mirror workspaces, {panes} mirror panes", h.name, h.target);
+        println!(
+            "host {} ({}): {ws} mirror workspaces, {panes} mirror panes",
+            h.name, h.target
+        );
+        if let Some(remote) = &state.remote_session {
+            println!(
+                "  terminal reconnect: {} (client protocol {}, server protocol {}, compatible={})",
+                if remote.reconnect_v1 {
+                    "active"
+                } else {
+                    "legacy"
+                },
+                remote
+                    .client_protocol
+                    .map_or_else(|| "unknown".into(), |value| value.to_string()),
+                remote
+                    .server_protocol
+                    .map_or_else(|| "unknown".into(), |value| value.to_string()),
+                remote.compatible
+            );
+        }
         let tombs: Vec<String> = state
             .workspaces
             .iter()
@@ -739,8 +814,8 @@ pub async fn cmd_once(env: Env) -> Result<()> {
     let local = ApiClient::connect(&env.local_socket).await?;
     for h in &config.hosts {
         let mut remote_host = crate::remote::RemoteHost::new(h, &env.state_dir);
-        let (remote, _status) = remote_host.connect_api().await?;
-        converge(&ConvergeDeps {
+        let (remote, status) = remote_host.connect_api().await?;
+        let mut state = converge(&ConvergeDeps {
             local: local.clone(),
             remote,
             host: h.clone(),
@@ -751,8 +826,20 @@ pub async fn cmd_once(env: Env) -> Result<()> {
             // close signal — an empty tracker means this pass syncs but never
             // closes a remote object, which is the correct conservative default
             closes: crate::closes::new_closes(),
+            terminal_session_reconnect: status.terminal_session_reconnect,
+            controller_id: status
+                .terminal_session_reconnect
+                .then(|| crate::controller_identity::controller_id(&env.state_dir, &h.name))
+                .transpose()?,
         })
         .await?;
+        state.remote_session = Some(crate::state::RemoteSessionStatus {
+            client_protocol: status.client_protocol,
+            server_protocol: status.server_protocol,
+            compatible: status.compatible,
+            reconnect_v1: status.terminal_session_reconnect,
+        });
+        save_state(&env.state_dir, &h.name, &state)?;
         log.log(&format!("[{}] one-shot mirror complete", h.name));
     }
     Ok(())

--- a/src/frame_stream.rs
+++ b/src/frame_stream.rs
@@ -1,0 +1,118 @@
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+
+use crate::util::{err, Result};
+
+const MAX_FRAME_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CompleteFrame {
+    pub seq: u64,
+    pub width: usize,
+    pub height: usize,
+    pub full: bool,
+    pub bytes: Vec<u8>,
+}
+
+struct PendingFrame {
+    seq: u64,
+    width: usize,
+    height: usize,
+    full: bool,
+    total_bytes: usize,
+    next_index: usize,
+    bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+pub struct FrameAssembler {
+    pending: Option<PendingFrame>,
+}
+
+impl FrameAssembler {
+    pub fn start(
+        &mut self,
+        seq: u64,
+        width: usize,
+        height: usize,
+        full: bool,
+        total_bytes: usize,
+    ) -> Result<()> {
+        if total_bytes > MAX_FRAME_BYTES {
+            return Err(err("terminal frame exceeds 2 MiB limit"));
+        }
+        self.pending = Some(PendingFrame {
+            seq,
+            width,
+            height,
+            full,
+            total_bytes,
+            next_index: 0,
+            bytes: Vec::with_capacity(total_bytes),
+        });
+        Ok(())
+    }
+
+    pub fn chunk(&mut self, seq: u64, index: usize, encoded: &str) -> Result<()> {
+        let pending = self
+            .pending
+            .as_mut()
+            .ok_or_else(|| err("frame chunk before start"))?;
+        if pending.seq != seq || pending.next_index != index {
+            self.pending = None;
+            return Err(err("terminal frame chunk sequence mismatch"));
+        }
+        let decoded = B64.decode(encoded)?;
+        if pending.bytes.len().saturating_add(decoded.len()) > pending.total_bytes {
+            self.pending = None;
+            return Err(err("terminal frame chunk exceeds declared size"));
+        }
+        pending.bytes.extend_from_slice(&decoded);
+        pending.next_index += 1;
+        Ok(())
+    }
+
+    pub fn finish(&mut self, seq: u64) -> Result<CompleteFrame> {
+        let pending = self
+            .pending
+            .take()
+            .ok_or_else(|| err("frame end before start"))?;
+        if pending.seq != seq || pending.bytes.len() != pending.total_bytes {
+            return Err(err("terminal frame ended incomplete"));
+        }
+        Ok(CompleteFrame {
+            seq,
+            width: pending.width,
+            height: pending.height,
+            full: pending.full,
+            bytes: pending.bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunks_reassemble_exactly_and_gaps_reset_the_frame() {
+        let mut assembler = FrameAssembler::default();
+        assembler.start(4, 80, 24, true, 5).unwrap();
+        assembler.chunk(4, 0, &B64.encode(b"hel")).unwrap();
+        assembler.chunk(4, 1, &B64.encode(b"lo")).unwrap();
+        assert_eq!(
+            assembler.finish(4).unwrap(),
+            CompleteFrame {
+                seq: 4,
+                width: 80,
+                height: 24,
+                full: true,
+                bytes: b"hello".to_vec(),
+            }
+        );
+
+        assembler.start(5, 80, 24, false, 1).unwrap();
+        assert!(assembler.chunk(5, 1, &B64.encode(b"x")).is_err());
+        assert!(assembler.finish(5).is_err());
+    }
+}

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -463,6 +463,21 @@ mod tests {
     }
 
     #[test]
+    fn clearing_status_restores_the_remote_cursor() {
+        let mut g = Grid::new();
+        g.resize(10, 2);
+        g.apply("\x1b[2;3H\x1b[?25h");
+        let mut r = Renderer::new();
+        r.status("connected");
+        let hidden = r.paint(&g, 10, 2);
+        assert!(!hidden.contains("\x1b[2;3H\x1b[?25h"));
+
+        r.status("");
+        let restored = r.paint(&g, 10, 2);
+        assert!(restored.contains("\x1b[2;3H\x1b[?25h"));
+    }
+
+    #[test]
     fn renderer_bottom_anchors_and_status() {
         let mut g = Grid::new();
         g.resize(5, 10);

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -16,11 +16,13 @@ pub(crate) enum Action {
 
 pub(crate) struct Liveness {
     enabled: bool,
+    active: bool,
     ready: bool,
     heartbeat_at: Option<Instant>,
     watchdog_at: Option<Instant>,
     nonce: u64,
     last_ack_nonce: u64,
+    wake_probe_nonce: Option<u64>,
     wall_sample: SystemTime,
     monotonic_sample: Instant,
 }
@@ -29,22 +31,39 @@ impl Liveness {
     pub(crate) fn new(enabled: bool, now: Instant, wall_now: SystemTime) -> Self {
         Self {
             enabled,
+            active: false,
             ready: false,
             heartbeat_at: None,
             watchdog_at: None,
             nonce: 0,
             last_ack_nonce: 0,
+            wake_probe_nonce: None,
             wall_sample: wall_now,
             monotonic_sample: now,
         }
     }
 
     pub(crate) fn connected(&mut self, now: Instant, wall_now: SystemTime) {
+        self.active = true;
         self.ready = false;
         self.heartbeat_at = None;
         self.watchdog_at = self.enabled.then_some(now + READY_TIMEOUT);
+        self.wake_probe_nonce = None;
         self.wall_sample = wall_now;
         self.monotonic_sample = now;
+    }
+
+    pub(crate) fn disconnected(&mut self) {
+        self.active = false;
+        self.ready = false;
+        self.heartbeat_at = None;
+        self.watchdog_at = None;
+        self.wake_probe_nonce = None;
+    }
+
+    pub(crate) fn disable(&mut self) {
+        self.enabled = false;
+        self.disconnected();
     }
 
     pub(crate) fn ready(&mut self, now: Instant, wall_now: SystemTime) {
@@ -59,10 +78,17 @@ impl Liveness {
     }
 
     pub(crate) fn acknowledge(&mut self, nonce: u64, now: Instant) -> bool {
-        if !self.enabled || nonce <= self.last_ack_nonce || nonce > self.nonce {
+        if !self.enabled || !self.active || nonce <= self.last_ack_nonce || nonce > self.nonce {
             return false;
         }
         self.last_ack_nonce = nonce;
+        if self
+            .wake_probe_nonce
+            .is_some_and(|wake_nonce| nonce != wake_nonce)
+        {
+            return false;
+        }
+        self.wake_probe_nonce = None;
         self.watchdog_at = Some(now + ACK_TIMEOUT);
         true
     }
@@ -76,7 +102,7 @@ impl Liveness {
     }
 
     pub(crate) fn poll(&mut self, now: Instant, wall_now: SystemTime) -> Option<Action> {
-        if !self.enabled {
+        if !self.enabled || !self.active {
             return None;
         }
         let wall_elapsed = wall_now
@@ -89,8 +115,10 @@ impl Liveness {
         if self.ready && wall_elapsed >= monotonic_elapsed.saturating_add(WAKE_DIVERGENCE) {
             self.watchdog_at = Some(now + WAKE_ACK_GRACE);
             self.heartbeat_at = Some(now + HEARTBEAT_INTERVAL);
+            let nonce = self.next_nonce();
+            self.wake_probe_nonce = Some(nonce);
             return Some(Action::Heartbeat {
-                nonce: self.next_nonce(),
+                nonce,
                 wake_probe: true,
             });
         }
@@ -98,6 +126,7 @@ impl Liveness {
             let waiting_for_ready = !self.ready;
             self.heartbeat_at = None;
             self.watchdog_at = None;
+            self.active = false;
             return Some(Action::Reconnect { waiting_for_ready });
         }
         if self.ready && self.heartbeat_at.is_some_and(|deadline| deadline <= now) {
@@ -179,5 +208,59 @@ mod tests {
                 waiting_for_ready: false,
             })
         );
+    }
+
+    #[test]
+    fn delayed_pre_suspend_ack_cannot_satisfy_the_wake_probe() {
+        let start = Instant::now();
+        let wall = SystemTime::UNIX_EPOCH + Duration::from_secs(10_000);
+        let mut liveness = Liveness::new(true, start, wall);
+        liveness.connected(start, wall);
+        liveness.ready(start, wall);
+        assert!(matches!(
+            liveness.poll(start + Duration::from_secs(2), wall + Duration::from_secs(2)),
+            Some(Action::Heartbeat { nonce: 1, .. })
+        ));
+        let resumed = start + Duration::from_millis(2_100);
+        assert!(matches!(
+            liveness.poll(resumed, wall + Duration::from_secs(60)),
+            Some(Action::Heartbeat {
+                nonce: 2,
+                wake_probe: true
+            })
+        ));
+        assert!(!liveness.acknowledge(1, resumed + Duration::from_millis(100)));
+        assert_eq!(
+            liveness.poll(
+                resumed + WAKE_ACK_GRACE,
+                wall + Duration::from_secs(61)
+            ),
+            Some(Action::Reconnect {
+                waiting_for_ready: false
+            })
+        );
+        let replacement = resumed + WAKE_ACK_GRACE + Duration::from_millis(100);
+        liveness.connected(replacement, wall + Duration::from_secs(62));
+        liveness.ready(replacement, wall + Duration::from_secs(62));
+        assert!(matches!(
+            liveness.poll(
+                replacement + HEARTBEAT_INTERVAL,
+                wall + Duration::from_secs(64)
+            ),
+            Some(Action::Heartbeat { nonce: 3, .. })
+        ));
+        assert!(liveness.acknowledge(3, replacement + HEARTBEAT_INTERVAL));
+    }
+
+    #[test]
+    fn disconnected_sessions_have_no_live_deadlines() {
+        let start = Instant::now();
+        let wall = SystemTime::UNIX_EPOCH;
+        let mut liveness = Liveness::new(true, start, wall);
+        liveness.connected(start, wall);
+        liveness.disconnected();
+        assert_eq!(liveness.heartbeat_at(), None);
+        assert_eq!(liveness.watchdog_at(), None);
+        assert_eq!(liveness.poll(start + READY_TIMEOUT, wall), None);
     }
 }

--- a/src/liveness.rs
+++ b/src/liveness.rs
@@ -1,0 +1,183 @@
+use std::time::{Duration, SystemTime};
+
+use tokio::time::Instant;
+
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+const ACK_TIMEOUT: Duration = Duration::from_secs(4);
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const WAKE_DIVERGENCE: Duration = Duration::from_secs(2);
+const WAKE_ACK_GRACE: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Action {
+    Heartbeat { nonce: u64, wake_probe: bool },
+    Reconnect { waiting_for_ready: bool },
+}
+
+pub(crate) struct Liveness {
+    enabled: bool,
+    ready: bool,
+    heartbeat_at: Option<Instant>,
+    watchdog_at: Option<Instant>,
+    nonce: u64,
+    last_ack_nonce: u64,
+    wall_sample: SystemTime,
+    monotonic_sample: Instant,
+}
+
+impl Liveness {
+    pub(crate) fn new(enabled: bool, now: Instant, wall_now: SystemTime) -> Self {
+        Self {
+            enabled,
+            ready: false,
+            heartbeat_at: None,
+            watchdog_at: None,
+            nonce: 0,
+            last_ack_nonce: 0,
+            wall_sample: wall_now,
+            monotonic_sample: now,
+        }
+    }
+
+    pub(crate) fn connected(&mut self, now: Instant, wall_now: SystemTime) {
+        self.ready = false;
+        self.heartbeat_at = None;
+        self.watchdog_at = self.enabled.then_some(now + READY_TIMEOUT);
+        self.wall_sample = wall_now;
+        self.monotonic_sample = now;
+    }
+
+    pub(crate) fn ready(&mut self, now: Instant, wall_now: SystemTime) {
+        if !self.enabled {
+            return;
+        }
+        self.ready = true;
+        self.heartbeat_at = Some(now + HEARTBEAT_INTERVAL);
+        self.watchdog_at = Some(now + ACK_TIMEOUT);
+        self.wall_sample = wall_now;
+        self.monotonic_sample = now;
+    }
+
+    pub(crate) fn acknowledge(&mut self, nonce: u64, now: Instant) -> bool {
+        if !self.enabled || nonce <= self.last_ack_nonce || nonce > self.nonce {
+            return false;
+        }
+        self.last_ack_nonce = nonce;
+        self.watchdog_at = Some(now + ACK_TIMEOUT);
+        true
+    }
+
+    pub(crate) fn heartbeat_at(&self) -> Option<Instant> {
+        self.heartbeat_at
+    }
+
+    pub(crate) fn watchdog_at(&self) -> Option<Instant> {
+        self.watchdog_at
+    }
+
+    pub(crate) fn poll(&mut self, now: Instant, wall_now: SystemTime) -> Option<Action> {
+        if !self.enabled {
+            return None;
+        }
+        let wall_elapsed = wall_now
+            .duration_since(self.wall_sample)
+            .unwrap_or_default();
+        let monotonic_elapsed = now.duration_since(self.monotonic_sample);
+        self.wall_sample = wall_now;
+        self.monotonic_sample = now;
+
+        if self.ready && wall_elapsed >= monotonic_elapsed.saturating_add(WAKE_DIVERGENCE) {
+            self.watchdog_at = Some(now + WAKE_ACK_GRACE);
+            self.heartbeat_at = Some(now + HEARTBEAT_INTERVAL);
+            return Some(Action::Heartbeat {
+                nonce: self.next_nonce(),
+                wake_probe: true,
+            });
+        }
+        if self.watchdog_at.is_some_and(|deadline| deadline <= now) {
+            let waiting_for_ready = !self.ready;
+            self.heartbeat_at = None;
+            self.watchdog_at = None;
+            return Some(Action::Reconnect { waiting_for_ready });
+        }
+        if self.ready && self.heartbeat_at.is_some_and(|deadline| deadline <= now) {
+            self.heartbeat_at = Some(now + HEARTBEAT_INTERVAL);
+            return Some(Action::Heartbeat {
+                nonce: self.next_nonce(),
+                wake_probe: false,
+            });
+        }
+        None
+    }
+
+    fn next_nonce(&mut self) -> u64 {
+        self.nonce = self.nonce.saturating_add(1);
+        self.nonce
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blackholed_ack_recovery_fits_the_end_to_end_budget() {
+        let start = Instant::now();
+        let wall = SystemTime::UNIX_EPOCH + Duration::from_secs(10_000);
+        let mut liveness = Liveness::new(true, start, wall);
+        liveness.connected(start, wall);
+        liveness.ready(start, wall);
+        assert_eq!(
+            liveness.poll(
+                start + Duration::from_secs(2),
+                wall + Duration::from_secs(2)
+            ),
+            Some(Action::Heartbeat {
+                nonce: 1,
+                wake_probe: false,
+            })
+        );
+        assert_eq!(
+            liveness.poll(
+                start + Duration::from_secs(4),
+                wall + Duration::from_secs(4)
+            ),
+            Some(Action::Reconnect {
+                waiting_for_ready: false,
+            })
+        );
+        let reaped = start + Duration::from_millis(4_500);
+        liveness.connected(reaped, wall + Duration::from_millis(4_500));
+        liveness.ready(
+            reaped + Duration::from_secs(5),
+            wall + Duration::from_millis(9_500),
+        );
+        assert!(reaped + Duration::from_secs(5) <= start + Duration::from_millis(9_500));
+    }
+
+    #[test]
+    fn wall_clock_divergence_sends_a_wake_probe_then_recovers_after_one_second() {
+        let start = Instant::now();
+        let wall = SystemTime::UNIX_EPOCH + Duration::from_secs(10_000);
+        let mut liveness = Liveness::new(true, start, wall);
+        liveness.connected(start, wall);
+        liveness.ready(start, wall);
+        let resumed = start + Duration::from_millis(200);
+        assert_eq!(
+            liveness.poll(resumed, wall + Duration::from_secs(30)),
+            Some(Action::Heartbeat {
+                nonce: 1,
+                wake_probe: true,
+            })
+        );
+        assert_eq!(
+            liveness.poll(
+                resumed + Duration::from_secs(1),
+                wall + Duration::from_secs(31)
+            ),
+            Some(Action::Reconnect {
+                waiting_for_ready: false,
+            })
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@
 mod api;
 mod binding;
 mod child_supervisor;
+mod claim_token;
 mod closes;
 mod config;
 mod controller_identity;
@@ -94,7 +95,11 @@ fn run_on(rt: &tokio::runtime::Runtime, cmd: &str, rest: &[String]) -> Result<()
         "teardown" => rt.block_on(daemon::cmd_teardown(Env::resolve()?)),
         "pane" => {
             let args = pane::parse_args(&rest[1..])?;
-            rt.block_on(pane::run(args))
+            let state_dir = util::home_dir()
+                .join(".local")
+                .join("state")
+                .join("herdr-mirror");
+            rt.block_on(pane::run(args, state_dir))
         }
         "remote-workspace" => rt.block_on(remote_action::run_cmd(Env::resolve()?, "workspace", None)),
         "remote-tab" => rt.block_on(remote_action::run_cmd(Env::resolve()?, "tab", None)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,21 +11,28 @@
 
 mod api;
 mod binding;
+mod child_supervisor;
 mod closes;
 mod config;
+mod controller_identity;
 mod daemon;
 mod docker;
 mod foreground;
+mod frame_stream;
 mod grid;
 mod layout_sync;
+mod liveness;
 mod mirror;
+mod ownership;
 mod pane;
 mod paste;
+mod pending_input;
 mod predict;
 mod remote;
 mod remote_action;
 mod ssh_relay;
 mod state;
+mod streamer_lock;
 mod util;
 
 use util::{Env, Result};

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -341,7 +341,6 @@ pub struct ConvergeDeps {
     /// close event that wasn't our own may close the remote.
     pub closes: crate::closes::Closes,
     pub terminal_session_reconnect: bool,
-    pub controller_id: Option<String>,
 }
 
 /// argv for one mirror pane: this same binary in `pane` mode. Panes without a
@@ -351,7 +350,6 @@ pub(crate) fn cmd_for_pane(
     state_dir: &std::path::Path,
     sizes: &HashMap<String, LayoutRect>,
     terminal_session_reconnect: bool,
-    controller_id: Option<&str>,
 ) -> impl Fn(&str) -> Vec<String> {
     let exe = std::env::current_exe()
         .map(|p| p.display().to_string())
@@ -372,7 +370,6 @@ pub(crate) fn cmd_for_pane(
         .display()
         .to_string();
     let sizes = sizes.clone();
-    let controller_id = controller_id.map(str::to_owned);
     move |pane_id: &str| {
         let transport = if kind.is_docker() { "docker" } else { "ssh" };
         let identity = crate::streamer_lock::StreamerIdentity {
@@ -392,9 +389,6 @@ pub(crate) fn cmd_for_pane(
         argv.extend(["--streamer-key".into(), identity.key()]);
         if terminal_session_reconnect {
             argv.push("--terminal-reconnect".into());
-            if let Some(controller_id) = &controller_id {
-                argv.extend(["--controller-id".into(), controller_id.clone()]);
-            }
         }
         // omit --remote-bin when auto (PATH then ~/.local/bin/herdr); pane
         // defaults to the same resolution so the argv stays short
@@ -710,7 +704,6 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
         &deps.state_dir,
         &sizes,
         deps.terminal_session_reconnect,
-        deps.controller_id.as_deref(),
     );
     let _ = std::fs::create_dir_all(mirror_pane_cwd(&deps.state_dir));
 
@@ -1650,7 +1643,7 @@ mod tests {
     #[test]
     fn ssh_pane_argv_is_stable() {
         let state_dir = std::path::Path::new("/state");
-        let cmd = cmd_for_pane(&ssh_host(), state_dir, &HashMap::new(), false, None);
+        let cmd = cmd_for_pane(&ssh_host(), state_dir, &HashMap::new(), false);
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1683,7 +1676,6 @@ mod tests {
             std::path::Path::new("/state"),
             &HashMap::new(),
             false,
-            None,
         );
         let argv = cmd("w1:p1");
         assert_eq!(
@@ -1714,7 +1706,6 @@ mod tests {
             std::path::Path::new("/state"),
             &HashMap::new(),
             false,
-            None,
         );
         let argv = cmd("w1:p1");
         assert_eq!(
@@ -1739,19 +1730,18 @@ mod tests {
     }
 
     #[test]
-    fn protocol_21_capability_reaches_the_streamer() {
+    fn protocol_22_capability_reaches_the_streamer() {
         let host = ssh_host();
         let cmd = cmd_for_pane(
             &host,
             std::path::Path::new("/state"),
             &HashMap::new(),
             true,
-            Some("controller-123"),
         );
         let argv = cmd("w1:p1");
         let parsed = crate::pane::parse_args(&argv[2..]).unwrap();
         assert!(parsed.terminal_reconnect);
-        assert_eq!(parsed.controller_id.as_deref(), Some("controller-123"));
+        assert!(!argv.iter().any(|arg| arg == "--controller-id"));
     }
 
     /// Docker hosts append their flags *after* the ssh-shaped prefix, so the
@@ -1768,7 +1758,6 @@ mod tests {
             std::path::Path::new("/state"),
             &HashMap::new(),
             false,
-            None,
         );
         let argv = cmd("w1:p1");
         assert_eq!(
@@ -1807,7 +1796,6 @@ mod tests {
             std::path::Path::new("/state"),
             &HashMap::new(),
             false,
-            None,
         );
         let argv = cmd("w1:p1");
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
@@ -1828,7 +1816,6 @@ mod tests {
             std::path::Path::new("/state"),
             &HashMap::new(),
             false,
-            None,
         );
         let argv = cmd("w1:p1");
         assert_eq!(
@@ -1858,7 +1845,6 @@ mod tests {
             std::path::Path::new("/state"),
             &HashMap::new(),
             false,
-            None,
         )("w1:p1");
         assert!(!uncapped
             .iter()
@@ -1871,7 +1857,6 @@ mod tests {
             std::path::Path::new("/state"),
             &HashMap::new(),
             false,
-            None,
         )("w1:p1");
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
         assert_eq!(parsed.max_cols, Some(212));

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -340,6 +340,8 @@ pub struct ConvergeDeps {
     /// ambiguous (rebuild in flight, failed converge, server restart), so only a
     /// close event that wasn't our own may close the remote.
     pub closes: crate::closes::Closes,
+    pub terminal_session_reconnect: bool,
+    pub controller_id: Option<String>,
 }
 
 /// argv for one mirror pane: this same binary in `pane` mode. Panes without a
@@ -348,14 +350,18 @@ pub(crate) fn cmd_for_pane(
     host: &HostConfig,
     state_dir: &std::path::Path,
     sizes: &HashMap<String, LayoutRect>,
+    terminal_session_reconnect: bool,
+    controller_id: Option<&str>,
 ) -> impl Fn(&str) -> Vec<String> {
     let exe = std::env::current_exe()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "herdr-mirror".into());
     let target = host.target.clone();
+    let controller_scope = host.name.clone();
     let remote_bin = host.remote_bin.clone();
     let session = host.session.clone();
     let always_control = host.always_control;
+    let takeover_on_reconnect = host.takeover_on_reconnect;
     let max_cols = host.max_cols;
     let max_rows = host.max_rows;
     let kind = host.kind.clone();
@@ -366,13 +372,30 @@ pub(crate) fn cmd_for_pane(
         .display()
         .to_string();
     let sizes = sizes.clone();
+    let controller_id = controller_id.map(str::to_owned);
     move |pane_id: &str| {
+        let transport = if kind.is_docker() { "docker" } else { "ssh" };
+        let identity = crate::streamer_lock::StreamerIdentity {
+            transport,
+            controller_scope: &controller_scope,
+            target: &target,
+            session: session.as_deref(),
+            pane: pane_id,
+        };
         let mut argv = vec![
             exe.clone(),
             "pane".into(),
             target.clone(),
             pane_id.to_string(),
         ];
+        argv.extend(["--controller-scope".into(), controller_scope.clone()]);
+        argv.extend(["--streamer-key".into(), identity.key()]);
+        if terminal_session_reconnect {
+            argv.push("--terminal-reconnect".into());
+            if let Some(controller_id) = &controller_id {
+                argv.extend(["--controller-id".into(), controller_id.clone()]);
+            }
+        }
         // omit --remote-bin when auto (PATH then ~/.local/bin/herdr); pane
         // defaults to the same resolution so the argv stays short
         if let Some(bin) = &remote_bin {
@@ -383,6 +406,9 @@ pub(crate) fn cmd_for_pane(
         }
         if always_control {
             argv.push("--always-control".into());
+        }
+        if takeover_on_reconnect {
+            argv.push("--takeover-on-reconnect".into());
         }
         // absent when uncapped, so the argv of an unconfigured host is unchanged
         if let Some(c) = max_cols {
@@ -594,7 +620,9 @@ pub(crate) async fn spawn_streamer_pane(
     // alive-check right before each resend keeps a late-starting streamer
     // from getting the line typed into its stdin (which would forward it to
     // the remote pane as text).
-    let (Some(ssh_target), Some(pane_target)) = (argv.get(2).cloned(), argv.get(3).cloned())
+    let Some(streamer_key) = argv
+        .windows(2)
+        .find_map(|pair| (pair[0] == "--streamer-key").then(|| pair[1].clone()))
     else {
         return;
     };
@@ -603,11 +631,11 @@ pub(crate) async fn spawn_streamer_pane(
     tokio::spawn(async move {
         for wait_ms in [3000u64, 4000] {
             tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
-            if crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target) {
+            if crate::util::streamer_alive(&state_dir, &streamer_key) {
                 return;
             }
             log.log(&format!(
-                "streamer for {pane_target} not up in {pane_id} — shell startup likely ate the exec; retyping"
+                "streamer not up in {pane_id} — shell startup likely ate the exec; retyping"
             ));
             if local
                 .request("pane.send_text", json!({ "pane_id": pane_id, "text": line }))
@@ -618,9 +646,9 @@ pub(crate) async fn spawn_streamer_pane(
             }
         }
         tokio::time::sleep(std::time::Duration::from_millis(4000)).await;
-        if !crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target) {
+        if !crate::util::streamer_alive(&state_dir, &streamer_key) {
             log.log(&format!(
-                "streamer for {pane_target} still not up in {pane_id} after retries — pane left as a shell"
+                "streamer still not up in {pane_id} after retries — pane left as a shell"
             ));
         }
     });
@@ -677,7 +705,13 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
             sizes.insert(p.pane_id.clone(), p.rect.clone());
         }
     }
-    let cmd_for = cmd_for_pane(&deps.host, &deps.state_dir, &sizes);
+    let cmd_for = cmd_for_pane(
+        &deps.host,
+        &deps.state_dir,
+        &sizes,
+        deps.terminal_session_reconnect,
+        deps.controller_id.as_deref(),
+    );
     let _ = std::fs::create_dir_all(mirror_pane_cwd(&deps.state_dir));
 
     // 1. detect mirrors that are gone locally. Always tombstone (never remove)
@@ -1526,6 +1560,7 @@ mod tests {
             remote_bin: None,
             session: None,
             always_control: true,
+            takeover_on_reconnect: false,
             max_cols: None,
             max_rows: None,
             api_transport: crate::config::ApiTransport::Auto,
@@ -1615,7 +1650,7 @@ mod tests {
     #[test]
     fn ssh_pane_argv_is_stable() {
         let state_dir = std::path::Path::new("/state");
-        let cmd = cmd_for_pane(&ssh_host(), state_dir, &HashMap::new());
+        let cmd = cmd_for_pane(&ssh_host(), state_dir, &HashMap::new(), false, None);
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1623,6 +1658,10 @@ mod tests {
                 "pane",
                 "vps",
                 "w1:p1",
+                "--controller-scope",
+                "vps",
+                "--streamer-key",
+                "4e46992d9e2a167cf9842589c043624a32102a64fb5717ed985aaaa7faee06a7",
                 // no --remote-bin: auto (PATH then ~/.local/bin/herdr)
                 "--always-control",
                 "--ctl-path",
@@ -1639,7 +1678,13 @@ mod tests {
     fn ssh_pane_argv_carries_explicit_remote_bin() {
         let mut host = ssh_host();
         host.remote_bin = Some("/opt/herdr".into());
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            false,
+            None,
+        );
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1647,6 +1692,10 @@ mod tests {
                 "pane",
                 "vps",
                 "w1:p1",
+                "--controller-scope",
+                "vps",
+                "--streamer-key",
+                "4e46992d9e2a167cf9842589c043624a32102a64fb5717ed985aaaa7faee06a7",
                 "--remote-bin",
                 "/opt/herdr",
                 "--always-control",
@@ -1660,7 +1709,13 @@ mod tests {
     fn ssh_pane_argv_carries_remote_session() {
         let mut host = ssh_host();
         host.session = Some("work".into());
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            false,
+            None,
+        );
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1668,6 +1723,10 @@ mod tests {
                 "pane",
                 "vps",
                 "w1:p1",
+                "--controller-scope",
+                "vps",
+                "--streamer-key",
+                "bef6cd8e8cd0379c19d654391f3655b3a146d64b122ed5cf2a92a21dd9d04fdf",
                 "--session",
                 "work",
                 "--always-control",
@@ -1679,16 +1738,38 @@ mod tests {
         assert_eq!(parsed.session.as_deref(), Some("work"));
     }
 
+    #[test]
+    fn protocol_21_capability_reaches_the_streamer() {
+        let host = ssh_host();
+        let cmd = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            true,
+            Some("controller-123"),
+        );
+        let argv = cmd("w1:p1");
+        let parsed = crate::pane::parse_args(&argv[2..]).unwrap();
+        assert!(parsed.terminal_reconnect);
+        assert_eq!(parsed.controller_id.as_deref(), Some("controller-123"));
+    }
+
     /// Docker hosts append their flags *after* the ssh-shaped prefix, so the
     /// two argv layouts share a stable head and only diverge at the tail.
     #[test]
-    fn docker_pane_argv_carries_container_and_no_identity_token() {
+    fn docker_pane_argv_carries_container_and_scoped_identity() {
         let mut host = ssh_host();
         host.name = "token".into();
         host.target = "/Users/n/proj".into();
         host.kind = crate::config::HostKind::DockerFolder("/Users/n/proj".into());
         host.docker_bin = "/usr/local/bin/docker".into();
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            false,
+            None,
+        );
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1696,8 +1777,11 @@ mod tests {
                 "pane",
                 "/Users/n/proj",
                 "w1:p1",
+                "--controller-scope",
+                "token",
+                "--streamer-key",
+                "4cd82b069262aaf98c25f8dfb9f65f706bf4534c261e0ff92caed50b326ee087",
                 "--always-control",
-                // no identity token at all: healing asks herdr per pane
                 "--container-folder",
                 "/Users/n/proj",
                 "--docker-bin",
@@ -1718,7 +1802,13 @@ mod tests {
         // absolute path (GUI-launched daemons without /usr/local/bin on PATH)
         // would then silently get "cannot run docker".
         host.docker_bin = "/usr/local/bin/docker".into();
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            false,
+            None,
+        );
         let argv = cmd("w1:p1");
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
         assert_eq!(parsed.pane_target, "w1:p1");
@@ -1728,17 +1818,32 @@ mod tests {
         assert_eq!(ct.docker_bin, "/usr/local/bin/docker", "--docker-bin must round-trip");
     }
 
-    /// always_control is the only conditional flag; its absence must not
-    /// disturb the position of --ctl-path.
+    /// always_control remains conditional; scoped identity is always present.
     #[test]
     fn ssh_pane_argv_without_always_control() {
         let mut host = ssh_host();
         host.always_control = false;
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            false,
+            None,
+        );
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
-            ["pane", "vps", "w1:p1", "--ctl-path", "/state/vps.ctl"]
+            [
+                "pane",
+                "vps",
+                "w1:p1",
+                "--controller-scope",
+                "vps",
+                "--streamer-key",
+                "4e46992d9e2a167cf9842589c043624a32102a64fb5717ed985aaaa7faee06a7",
+                "--ctl-path",
+                "/state/vps.ctl"
+            ]
         );
     }
 
@@ -1748,12 +1853,26 @@ mod tests {
     fn size_caps_reach_the_streamer_argv() {
         let mut host = ssh_host();
         host.always_control = false;
-        let uncapped = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
-        assert!(!uncapped.iter().any(|a| a == "--max-cols" || a == "--max-rows"));
+        let uncapped = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            false,
+            None,
+        )("w1:p1");
+        assert!(!uncapped
+            .iter()
+            .any(|a| a == "--max-cols" || a == "--max-rows"));
 
         host.max_cols = Some(212);
         host.max_rows = Some(58);
-        let argv = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        let argv = cmd_for_pane(
+            &host,
+            std::path::Path::new("/state"),
+            &HashMap::new(),
+            false,
+            None,
+        )("w1:p1");
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
         assert_eq!(parsed.max_cols, Some(212));
         assert_eq!(parsed.max_rows, Some(58));

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -1,0 +1,109 @@
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+pub const OWNER_CONFLICT_SUFFIX: &str = "already has an attached client; retry with --takeover";
+pub const TAKEN_OVER_REASON: &str = "terminal attach taken over";
+const TAKEOVER_COOLDOWN: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CollisionDecision {
+    ObserveSticky,
+    RetryWithTakeover,
+}
+
+#[derive(Debug, Default)]
+pub struct LegacyTakeoverPolicy {
+    last_attempt: Option<Instant>,
+}
+
+impl LegacyTakeoverPolicy {
+    pub fn decide(
+        &mut self,
+        reason: &str,
+        always_control: bool,
+        enabled: bool,
+        now: Instant,
+    ) -> Option<CollisionDecision> {
+        if reason.starts_with("owned_by_other")
+            || reason.starts_with("taken_over")
+            || reason.ends_with(TAKEN_OVER_REASON)
+        {
+            return Some(CollisionDecision::ObserveSticky);
+        }
+        if !reason.ends_with(OWNER_CONFLICT_SUFFIX) {
+            return None;
+        }
+        if !always_control || !enabled {
+            return Some(CollisionDecision::ObserveSticky);
+        }
+        let cooled_down = self.last_attempt.is_none_or(|last| {
+            now.checked_duration_since(last)
+                .is_some_and(|elapsed| elapsed >= TAKEOVER_COOLDOWN)
+        });
+        if !cooled_down {
+            return Some(CollisionDecision::ObserveSticky);
+        }
+        self.last_attempt = Some(now);
+        Some(CollisionDecision::RetryWithTakeover)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opted_in_always_control_retries_one_takeover_per_cooldown() {
+        let mut policy = LegacyTakeoverPolicy::default();
+        let now = Instant::now();
+
+        assert_eq!(
+            policy.decide(OWNER_CONFLICT_SUFFIX, true, true, now),
+            Some(CollisionDecision::RetryWithTakeover)
+        );
+        assert_eq!(
+            policy.decide(
+                OWNER_CONFLICT_SUFFIX,
+                true,
+                true,
+                now + Duration::from_secs(59)
+            ),
+            Some(CollisionDecision::ObserveSticky)
+        );
+        assert_eq!(
+            policy.decide(OWNER_CONFLICT_SUFFIX, true, true, now + TAKEOVER_COOLDOWN),
+            Some(CollisionDecision::RetryWithTakeover)
+        );
+    }
+
+    #[test]
+    fn safe_modes_never_take_over() {
+        let now = Instant::now();
+        for (always_control, enabled) in [(true, false), (false, true), (false, false)] {
+            let mut policy = LegacyTakeoverPolicy::default();
+            assert_eq!(
+                policy.decide(OWNER_CONFLICT_SUFFIX, always_control, enabled, now),
+                Some(CollisionDecision::ObserveSticky)
+            );
+        }
+    }
+
+    #[test]
+    fn a_displaced_stream_never_immediately_takes_back() {
+        let mut policy = LegacyTakeoverPolicy::default();
+        assert_eq!(
+            policy.decide(TAKEN_OVER_REASON, true, true, Instant::now()),
+            Some(CollisionDecision::ObserveSticky)
+        );
+    }
+
+    #[test]
+    fn unrelated_failures_remain_on_the_normal_reconnect_path() {
+        let mut policy = LegacyTakeoverPolicy::default();
+        assert_eq!(
+            policy.decide("ssh timeout", true, true, Instant::now()),
+            None
+        );
+    }
+}

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -64,6 +64,16 @@ pub struct Args {
     /// start and stay in control: writable, no idle release, and sized to the
     /// local pane so it fills. Set by the daemon from per-host config.
     pub always_control: bool,
+    /// Legacy Herdr only: permit one bounded `--takeover` retry after the exact
+    /// existing-controller rejection. Defaults off.
+    pub takeover_on_reconnect: bool,
+    /// Stable configured host key used to derive controller ownership and
+    /// duplicate-streamer identity. Direct invocations default to ssh_target.
+    pub controller_scope: Option<String>,
+    /// Daemon-computed cross-process key. Recomputed and verified by pane mode.
+    pub streamer_key: Option<String>,
+    pub terminal_reconnect: bool,
+    pub controller_id: Option<String>,
     /// upper bound on the size control asks the remote for. `None` = uncapped
     /// (fill the local pane). Set by the daemon from per-host config; observe
     /// is never capped, since it doesn't resize anything.
@@ -97,6 +107,11 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
         session: None,
         control_idle_secs: 3600,
         always_control: false,
+        takeover_on_reconnect: false,
+        controller_scope: None,
+        streamer_key: None,
+        terminal_reconnect: false,
+        controller_id: None,
         max_cols: None,
         max_rows: None,
         ctl_path: None,
@@ -125,6 +140,11 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                     next("--control-idle")?.parse().map_err(|_| err("--control-idle must be a number"))?
             }
             "--always-control" => args.always_control = true,
+            "--takeover-on-reconnect" => args.takeover_on_reconnect = true,
+            "--controller-scope" => args.controller_scope = Some(next("--controller-scope")?),
+            "--streamer-key" => args.streamer_key = Some(next("--streamer-key")?),
+            "--terminal-reconnect" => args.terminal_reconnect = true,
+            "--controller-id" => args.controller_id = Some(next("--controller-id")?),
             // 0 is unset here for the same reason config treats it that way:
             // a zero cap would ask the remote for a zero-column terminal, which
             // herdr rejects outright, killing the session twice over and
@@ -194,6 +214,10 @@ struct Frame {
     height: Option<usize>,
     bytes: Option<String>,
     reason: Option<String>,
+    nonce: Option<u64>,
+    code: Option<String>,
+    index: Option<usize>,
+    total_bytes: Option<usize>,
 }
 
 enum Msg {
@@ -210,8 +234,21 @@ enum Msg {
 struct Session {
     gen: u64,
     mode: Mode,
-    pid: i32,
     stdin: ChildStdin,
+    supervisor: crate::child_supervisor::ChildSupervisor,
+}
+
+impl Session {
+    async fn stop(mut self, release: bool) {
+        if release && self.mode == Mode::Control {
+            let _ = self
+                .stdin
+                .write_all(b"{\"type\":\"terminal.release\"}\n")
+                .await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        self.supervisor.cancel_and_wait().await;
+    }
 }
 
 /// POSIX single-quote: an embedded ' can't break the remote shell parse.
@@ -219,15 +256,20 @@ pub(crate) fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx: mpsc::Sender<Msg>) -> Result<Session> {
+fn spawn_session(
+    args: &Args,
+    mode: Mode,
+    takeover: bool,
+    cols: usize,
+    rows: usize,
+    gen: u64,
+    tx: mpsc::Sender<Msg>,
+) -> Result<Session> {
     // Configured paths stay unquoted so remote-shell ~ expands; auto mode is an
     // `sh -c` resolver that takes the trailing words as "$@" (see
     // config::remote_herdr_expr).
-    let bin = crate::config::remote_herdr_expr(
-        args.remote_bin.as_deref(),
-        args.session.as_deref(),
-    );
-    let cmd = format!(
+    let bin = crate::config::remote_herdr_expr(args.remote_bin.as_deref(), args.session.as_deref());
+    let mut cmd = format!(
         "exec {} terminal session {} {} --cols {} --rows {}",
         bin,
         mode.as_str(),
@@ -235,6 +277,18 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         cols,
         rows
     );
+    if mode == Mode::Control && takeover {
+        cmd.push_str(" --takeover");
+    }
+    if args.terminal_reconnect {
+        cmd.push_str(" --lease-ms 20000");
+        if mode == Mode::Control {
+            if let Some(controller_id) = &args.controller_id {
+                cmd.push_str(" --controller-id ");
+                cmd.push_str(&sh_quote(controller_id));
+            }
+        }
+    }
     // ssh and docker differ only in how the command is carried; the streaming
     // contract (piped stdio, herdr's frames on stdout) is identical
     let mut builder = match &args.container {
@@ -264,11 +318,12 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
-    let pid = child.id().map(|p| p as i32).unwrap_or(0);
     let stdin = child.stdin.take().ok_or_else(|| err("no child stdin"))?;
     let stdout = child.stdout.take().ok_or_else(|| err("no child stdout"))?;
     let stderr = child.stderr.take().ok_or_else(|| err("no child stderr"))?;
+    let (supervisor, mut exited) = crate::child_supervisor::ChildSupervisor::start(child);
     let started = Instant::now();
+    let structured = args.terminal_reconnect;
 
     tokio::spawn(async move {
         // ssh errors arrive on stderr; the server's failure reason arrives as
@@ -292,22 +347,45 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         while let Ok(Some(line)) = lines.next_line().await {
             let Ok(frame) = serde_json::from_str::<Frame>(&line) else { continue };
             if frame.kind == "terminal.closed" {
-                if let Some(r) = &frame.reason {
-                    close_reason = r.clone();
-                }
+                close_reason = match (&frame.code, &frame.reason) {
+                    (Some(code), Some(reason)) => format!("{code}: {reason}"),
+                    (Some(code), None) => code.clone(),
+                    (None, Some(reason)) => reason.clone(),
+                    (None, None) => String::new(),
+                };
             }
             if tx.send(Msg::Frame { gen, frame }).await.is_err() {
                 break;
             }
         }
-        let _ = child.wait().await;
+        let _ = crate::child_supervisor::wait_for_exit(&mut exited).await;
         stderr_task.abort();
         let tail = err_tail.lock().unwrap().trim().to_string();
-        let reason = if close_reason.is_empty() { tail } else { close_reason };
-        let _ = tx.send(Msg::SessionExit { gen, mode, reason, uptime: started.elapsed() }).await;
+        let reason = if close_reason.is_empty() {
+            if tail.is_empty() && structured {
+                "transport_closed".to_owned()
+            } else {
+                tail
+            }
+        } else {
+            close_reason
+        };
+        let _ = tx
+            .send(Msg::SessionExit {
+                gen,
+                mode,
+                reason,
+                uptime: started.elapsed(),
+            })
+            .await;
     });
 
-    Ok(Session { gen, mode, pid, stdin })
+    Ok(Session {
+        gen,
+        mode,
+        stdin,
+        supervisor,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -655,7 +733,15 @@ struct App {
     /// consecutive quick control failures → fall back to observe
     control_failures: u32,
     control_sticky: bool,
-    pending_input: Vec<Vec<u8>>,
+    takeover_policy: crate::ownership::LegacyTakeoverPolicy,
+    next_control_takeover: bool,
+    session_ready: bool,
+    heartbeat_status_visible: bool,
+    ownership_hint: Option<String>,
+    frame_assembler: crate::frame_stream::FrameAssembler,
+    frame_resync_pending: bool,
+    liveness: crate::liveness::Liveness,
+    pending_input: crate::pending_input::PendingInput,
     last_input: Instant,
     hint_clear_at: Option<Instant>,
     /// predictive local echo — draws keystrokes optimistically, frame-verified
@@ -823,14 +909,8 @@ impl App {
     /// Stop the child (clean release first for control) — never leave an
     /// orphan holding the remote attach lock.
     fn stop_session(&mut self) {
-        if let Some(mut s) = self.session.take() {
-            tokio::spawn(async move {
-                if s.mode == Mode::Control {
-                    let _ = s.stdin.write_all(b"{\"type\":\"terminal.release\"}\n").await;
-                }
-                tokio::time::sleep(Duration::from_millis(150)).await;
-                unsafe { libc::kill(s.pid, libc::SIGTERM) };
-            });
+        if let Some(session) = self.session.take() {
+            tokio::spawn(session.stop(true));
         }
     }
 
@@ -838,37 +918,47 @@ impl App {
         self.mode = m;
         // re-earn prediction confidence against the new session's frames
         self.predict = Predictor::new();
+        self.frame_resync_pending = false;
         let (cols, rows) = match m {
             Mode::Observe => self.observe_size(),
             Mode::Control => self.control_size(),
         };
-        if let Some(s) = self.session.take() {
-            unsafe { libc::kill(s.pid, libc::SIGTERM) };
+        if let Some(mut session) = self.session.take() {
+            session.supervisor.cancel_and_wait().await;
         }
         self.next_gen += 1;
-        match spawn_session(&self.args, m, cols, rows, self.next_gen, self.tx.clone()) {
-            Ok(mut s) => {
+        let takeover = m == Mode::Control && std::mem::take(&mut self.next_control_takeover);
+        match spawn_session(
+            &self.args,
+            m,
+            takeover,
+            cols,
+            rows,
+            self.next_gen,
+            self.tx.clone(),
+        ) {
+            Ok(s) => {
+                self.session_ready = false;
+                self.heartbeat_status_visible = self.args.terminal_reconnect;
+                self.liveness
+                    .connected(Instant::now(), std::time::SystemTime::now());
                 if m == Mode::Control {
                     self.last_input = Instant::now();
-                    // keystrokes typed while the control session was spinning up
-                    for buf in std::mem::take(&mut self.pending_input) {
-                        let line = json!({ "type": "terminal.input", "bytes": B64.encode(&buf) }).to_string() + "\n";
-                        let _ = s.stdin.write_all(line.as_bytes()).await;
-                    }
-                } else {
-                    self.pending_input.clear();
                 }
                 self.session = Some(s);
                 // warm the foreground classification before the user mouses
                 self.spawn_foreground_poll(false);
                 // always-control has no release, so no "ctrl+\ to release" hint
-                self.renderer.status(
-                    if m == Mode::Control && !self.args.always_control {
-                        "CONTROL — ctrl+\\ to release"
-                    } else {
-                        ""
-                    },
-                );
+                let status = if self.args.terminal_reconnect {
+                    "connecting — waiting for terminal.ready"
+                } else if m == Mode::Observe {
+                    self.ownership_hint.as_deref().unwrap_or("")
+                } else if !self.args.always_control {
+                    "CONTROL — ctrl+\\ to release"
+                } else {
+                    ""
+                };
+                self.renderer.status(status);
             }
             Err(e) => self.schedule_reconnect(m, &e.to_string()),
         }
@@ -920,44 +1010,175 @@ impl App {
         self.switch_at = Some(Instant::now() + SWITCH_GAP);
     }
 
-    fn handle_frame(&mut self, gen: u64, frame: Frame) {
-        if self.session.as_ref().map(|s| s.gen) != Some(gen) {
-            return; // stale frame from a replaced session
+    async fn mark_session_ready(&mut self) {
+        if self.session_ready {
+            return;
         }
-        if frame.kind == "terminal.closed" {
-            let suffix = frame.reason.as_deref().map(|r| format!(": {r}")).unwrap_or_default();
-            self.renderer.status(&format!("remote terminal closed{suffix}"));
+        self.session_ready = true;
+        let now = Instant::now();
+        self.liveness.ready(now, std::time::SystemTime::now());
+        if self.args.terminal_reconnect {
+            self.heartbeat_status_visible = false;
+            self.renderer
+                .status(self.ownership_hint.as_deref().unwrap_or(""));
             self.paint();
+        }
+        if self.mode != Mode::Control {
             return;
         }
-        if frame.kind != "terminal.frame" {
-            return;
+        self.ownership_hint = None;
+        let drained = self.pending_input.drain_ready(now);
+        if let Some(session) = self.session.as_mut() {
+            for buf in drained.chunks {
+                let line = json!({ "type": "terminal.input", "bytes": B64.encode(&buf) })
+                    .to_string()
+                    + "\n";
+                let _ = session.stdin.write_all(line.as_bytes()).await;
+            }
         }
-        let Some(bytes) = &frame.bytes else { return };
+        if drained.dropped_bytes > 0 {
+            self.hint(&format!(
+                "dropped {} buffered input bytes after reconnect",
+                drained.dropped_bytes
+            ));
+        }
+    }
+
+    fn apply_terminal_frame(
+        &mut self,
+        seq: Option<u64>,
+        full: bool,
+        width: usize,
+        height: usize,
+        bytes: &[u8],
+    ) {
         self.backoff_idx = 0;
-        self.renderer.status("");
-        self.grid
-            .resize(frame.width.unwrap_or(self.grid.width), frame.height.unwrap_or(self.grid.height));
-        if frame.full == Some(true) {
+        self.renderer
+            .status(self.ownership_hint.as_deref().unwrap_or(""));
+        self.grid.resize(width, height);
+        if full {
             self.grid.clear();
         }
-        if let Ok(decoded) = B64.decode(bytes) {
-            self.grid.apply(&String::from_utf8_lossy(&decoded));
-            // reconcile predictive echo against the authoritative frame
-            self.predict.on_frame(&self.grid);
-        }
+        self.grid.apply(&String::from_utf8_lossy(bytes));
+        self.predict.on_frame(&self.grid);
         if self.args.dump {
-            let lines: Vec<String> = self.grid.text_lines().into_iter().filter(|l| !l.is_empty()).collect();
+            let lines: Vec<String> = self
+                .grid
+                .text_lines()
+                .into_iter()
+                .filter(|line| !line.is_empty())
+                .collect();
             println!(
-                "--- frame seq={:?} full={:?} {}x{} ---\n{}",
-                frame.seq,
-                frame.full,
-                frame.width.unwrap_or(0),
-                frame.height.unwrap_or(0),
+                "--- frame seq={seq:?} full={full:?} {width}x{height} ---\n{}",
                 lines.join("\n")
             );
         } else {
             self.paint();
+        }
+    }
+
+    async fn handle_frame(&mut self, gen: u64, frame: Frame) {
+        if self.session.as_ref().map(|s| s.gen) != Some(gen) {
+            return; // stale frame from a replaced session
+        }
+        match frame.kind.as_str() {
+            "terminal.ready" => self.mark_session_ready().await,
+            "terminal.heartbeat_ack"
+                if frame
+                    .nonce
+                    .is_some_and(|nonce| self.liveness.acknowledge(nonce, Instant::now()))
+                    && std::mem::take(&mut self.heartbeat_status_visible) =>
+            {
+                self.renderer
+                    .status(self.ownership_hint.as_deref().unwrap_or(""));
+                self.paint();
+            }
+            "terminal.heartbeat_ack" => {}
+            "terminal.frame.start" => {
+                let full = frame.full.unwrap_or(false);
+                if self
+                    .frame_assembler
+                    .start(
+                        frame.seq.unwrap_or(0),
+                        frame.width.unwrap_or(0),
+                        frame.height.unwrap_or(0),
+                        full,
+                        frame.total_bytes.unwrap_or(0),
+                    )
+                    .is_err()
+                {
+                    self.request_frame_resync().await;
+                } else if full {
+                    self.frame_resync_pending = false;
+                }
+            }
+            "terminal.frame.chunk" => {
+                let output_ack = frame.seq.zip(frame.index);
+                let result = match (frame.seq, frame.index, frame.bytes.as_deref()) {
+                    (Some(seq), Some(index), Some(bytes)) => {
+                        self.frame_assembler.chunk(seq, index, bytes)
+                    }
+                    _ => Err(err("malformed terminal frame chunk")),
+                };
+                if let Some((seq, index)) = output_ack {
+                    self.send(json!({
+                        "type": "terminal.output_ack",
+                        "seq": seq,
+                        "index": index,
+                    }))
+                    .await;
+                }
+                if result.is_err() {
+                    self.request_frame_resync().await;
+                }
+            }
+            "terminal.frame.end" => {
+                let result = frame
+                    .seq
+                    .ok_or_else(|| err("malformed terminal frame end"))
+                    .and_then(|seq| self.frame_assembler.finish(seq));
+                match result {
+                    Ok(complete) => {
+                        self.mark_session_ready().await;
+                        self.apply_terminal_frame(
+                            Some(complete.seq),
+                            complete.full,
+                            complete.width,
+                            complete.height,
+                            &complete.bytes,
+                        );
+                    }
+                    Err(_) => self.request_frame_resync().await,
+                }
+            }
+            "terminal.frame" => {
+                let Some(bytes) = frame
+                    .bytes
+                    .as_deref()
+                    .and_then(|bytes| B64.decode(bytes).ok())
+                else {
+                    return;
+                };
+                self.mark_session_ready().await;
+                self.apply_terminal_frame(
+                    frame.seq,
+                    frame.full.unwrap_or(false),
+                    frame.width.unwrap_or(self.grid.width),
+                    frame.height.unwrap_or(self.grid.height),
+                    &bytes,
+                );
+            }
+            "terminal.closed" => {
+                let detail = frame
+                    .code
+                    .as_deref()
+                    .or(frame.reason.as_deref())
+                    .unwrap_or("closed");
+                self.renderer
+                    .status(&format!("remote terminal closed: {detail}"));
+                self.paint();
+            }
+            _ => {}
         }
     }
 
@@ -971,7 +1192,39 @@ impl App {
         // control that dies quickly twice is failing (refused/dropped): fall
         // back to observe so the pane stays viewable; a keystroke retries
         if exited_mode == Mode::Control {
-            self.control_failures = if uptime < QUICK_CONTROL_FAILURE { self.control_failures + 1 } else { 0 };
+            if let Some(decision) = self.takeover_policy.decide(
+                &reason_line,
+                self.args.always_control,
+                self.args.takeover_on_reconnect,
+                Instant::now(),
+            ) {
+                match decision {
+                    crate::ownership::CollisionDecision::RetryWithTakeover => {
+                        self.next_control_takeover = true;
+                        self.renderer.status("controller occupied — taking over…");
+                        self.paint();
+                        self.reconnect_at = Some((Instant::now() + SWITCH_GAP, Mode::Control));
+                    }
+                    crate::ownership::CollisionDecision::ObserveSticky => {
+                        self.control_failures = 0;
+                        self.control_sticky = true;
+                        self.ownership_hint = Some(
+                            if reason_line.ends_with(crate::ownership::TAKEN_OVER_REASON) {
+                                "control taken by another client — viewing only".into()
+                            } else {
+                                "control held elsewhere — viewing only; takeover is disabled".into()
+                            },
+                        );
+                        self.switch_mode(Mode::Observe);
+                    }
+                }
+                return;
+            }
+            self.control_failures = if uptime < QUICK_CONTROL_FAILURE {
+                self.control_failures + 1
+            } else {
+                0
+            };
             if self.control_failures >= 2 {
                 self.control_failures = 0;
                 self.control_sticky = true;
@@ -988,6 +1241,45 @@ impl App {
         if let Some(s) = self.session.as_mut() {
             let line = msg.to_string() + "\n";
             let _ = s.stdin.write_all(line.as_bytes()).await;
+        }
+    }
+
+    async fn request_frame_resync(&mut self) {
+        if self.frame_resync_pending {
+            return;
+        }
+        self.frame_resync_pending = true;
+        self.send(json!({ "type": "terminal.resync" })).await;
+    }
+
+    async fn poll_liveness(&mut self) {
+        match self
+            .liveness
+            .poll(Instant::now(), std::time::SystemTime::now())
+        {
+            Some(crate::liveness::Action::Heartbeat { nonce, wake_probe }) => {
+                if wake_probe {
+                    self.heartbeat_status_visible = true;
+                    self.renderer
+                        .status("wake detected — probing terminal path…");
+                    self.paint();
+                }
+                self.send(json!({
+                    "type": "terminal.heartbeat",
+                    "nonce": nonce,
+                }))
+                .await;
+            }
+            Some(crate::liveness::Action::Reconnect { waiting_for_ready }) => {
+                self.renderer.status(if waiting_for_ready {
+                    "terminal ready timeout — reconnecting…"
+                } else {
+                    "terminal heartbeat timeout — reconnecting…"
+                });
+                self.paint();
+                self.connect(self.mode).await;
+            }
+            None => {}
         }
     }
 
@@ -1126,7 +1418,8 @@ impl App {
             }
             // any keystroke takes control and is delivered once the session is up
             self.control_sticky = false;
-            self.pending_input.push(buf);
+            self.ownership_hint = None;
+            self.pending_input.push(Instant::now(), buf);
             self.switch_mode(Mode::Control);
             return;
         }
@@ -1145,7 +1438,7 @@ impl App {
         if self.switching_to == Some(Mode::Control) || self.session.is_none() {
             // spinning up or awaiting reconnect: queue the keystroke (flushed
             // on connect) and, if in backoff, reconnect now
-            self.pending_input.push(buf);
+            self.pending_input.push(Instant::now(), buf);
             if let Some((_, m)) = self.reconnect_at {
                 self.reconnect_at = Some((Instant::now(), m));
             }
@@ -1204,13 +1497,13 @@ impl App {
     async fn deliver_input(&mut self, buf: Vec<u8>) {
         if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
             self.control_sticky = false;
-            self.pending_input.push(buf);
+            self.pending_input.push(Instant::now(), buf);
             self.switch_mode(Mode::Control);
             return;
         }
         self.last_input = Instant::now();
         if self.switching_to == Some(Mode::Control) || self.session.is_none() {
-            self.pending_input.push(buf);
+            self.pending_input.push(Instant::now(), buf);
             if let Some((_, m)) = self.reconnect_at {
                 self.reconnect_at = Some((Instant::now(), m));
             }
@@ -1237,30 +1530,41 @@ impl App {
 // ---------------------------------------------------------------------------
 // main
 
-/// Removes the streamer pidfile on any exit path out of `run` (stale files
-/// from a hard kill are harmless — the daemon checks the pid is alive).
-struct PidfileGuard(std::path::PathBuf);
-impl Drop for PidfileGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.0);
-    }
-}
-
 pub async fn run(args: Args) -> Result<()> {
-    // announce ourselves so the daemon can tell its typed `exec` took
-    // (see util::streamer_pid_path); --dump is a human diagnostic, not a
-    // daemon-spawned streamer, so it must not claim the slot
-    let _pidfile = (!args.dump).then(|| {
-        let state_dir =
-            crate::util::home_dir().join(".local").join("state").join("herdr-mirror");
-        let path =
-            crate::util::streamer_pid_path(&state_dir, &args.ssh_target, &args.pane_target);
-        if let Some(dir) = path.parent() {
-            let _ = std::fs::create_dir_all(dir);
+    // Claim the cross-process streamer slot before opening SSH. --dump is a
+    // human diagnostic and deliberately does not participate in daemon healing.
+    let _streamer_lock = if args.dump {
+        None
+    } else {
+        let state_dir = crate::util::home_dir()
+            .join(".local")
+            .join("state")
+            .join("herdr-mirror");
+        let scope = args.controller_scope.as_deref().unwrap_or(&args.ssh_target);
+        let transport = if args.container.is_some() {
+            "docker"
+        } else {
+            "ssh"
+        };
+        let identity = crate::streamer_lock::StreamerIdentity {
+            transport,
+            controller_scope: scope,
+            target: &args.ssh_target,
+            session: args.session.as_deref(),
+            pane: &args.pane_target,
+        };
+        let computed = identity.key();
+        if args
+            .streamer_key
+            .as_deref()
+            .is_some_and(|key| key != computed)
+        {
+            return Err(err("streamer key does not match pane identity"));
         }
-        let _ = std::fs::write(&path, std::process::id().to_string());
-        PidfileGuard(path)
-    });
+        Some(crate::streamer_lock::StreamerLock::acquire(
+            &state_dir, &identity,
+        )?)
+    };
 
     let tty = !args.dump && unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1;
     let raw = if tty {
@@ -1297,6 +1601,8 @@ pub async fn run(args: Args) -> Result<()> {
         });
     }
 
+    let now = Instant::now();
+    let terminal_reconnect = args.terminal_reconnect;
     let mut app = App {
         args,
         tty,
@@ -1312,8 +1618,20 @@ pub async fn run(args: Args) -> Result<()> {
         reconnect_at: None,
         control_failures: 0,
         control_sticky: false,
-        pending_input: Vec::new(),
-        last_input: Instant::now(),
+        takeover_policy: crate::ownership::LegacyTakeoverPolicy::default(),
+        next_control_takeover: false,
+        session_ready: false,
+        heartbeat_status_visible: false,
+        ownership_hint: None,
+        frame_assembler: crate::frame_stream::FrameAssembler::default(),
+        frame_resync_pending: false,
+        liveness: crate::liveness::Liveness::new(
+            terminal_reconnect,
+            now,
+            std::time::SystemTime::now(),
+        ),
+        pending_input: crate::pending_input::PendingInput::default(),
+        last_input: now,
         hint_clear_at: None,
         predict: Predictor::new(),
         remote_is_shell: None,
@@ -1356,6 +1674,10 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     loop {
+        // Every pane event comes back through this loop, so sleep/wake clock
+        // divergence is noticed immediately when any activity resumes. With no
+        // activity, the two-second heartbeat deadline is the upper bound.
+        app.poll_liveness().await;
         // earliest pending deadline: mode-switch gap, reconnect, hint clear, idle release
         let idle_at = (app.mode == Mode::Control
             && app.switching_to.is_none()
@@ -1370,13 +1692,15 @@ pub async fn run(args: Args) -> Result<()> {
             idle_at,
             app.predict.deadline(),
             app.settle_at,
+            app.liveness.heartbeat_at(),
+            app.liveness.watchdog_at(),
         ]);
 
         tokio::select! {
             msg = rx.recv() => {
                 match msg {
                     None => break,
-                    Some(Msg::Frame { gen, frame }) => app.handle_frame(gen, frame),
+                    Some(Msg::Frame { gen, frame }) => app.handle_frame(gen, frame).await,
                     Some(Msg::SessionExit { gen, mode, reason, uptime }) => app.handle_exit(gen, mode, reason, uptime),
                     Some(Msg::Stdin(buf)) => app.handle_stdin(buf).await,
                     // keep the last good classification if a poll failed (None)
@@ -1447,12 +1771,8 @@ pub async fn run(args: Args) -> Result<()> {
     }
 
     // clean shutdown: release control if held, kill the ssh child, restore tty
-    if let Some(mut s) = app.session.take() {
-        if s.mode == Mode::Control {
-            let _ = s.stdin.write_all(b"{\"type\":\"terminal.release\"}\n").await;
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        unsafe { libc::kill(s.pid, libc::SIGTERM) };
+    if let Some(session) = app.session.take() {
+        session.stop(true).await;
     }
     if tty {
         // ?1l with the rest: leaving the hosting pane in application cursor mode

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -73,7 +73,7 @@ pub struct Args {
     /// Daemon-computed cross-process key. Recomputed and verified by pane mode.
     pub streamer_key: Option<String>,
     pub terminal_reconnect: bool,
-    pub controller_id: Option<String>,
+    controller_id: Option<String>,
     /// upper bound on the size control asks the remote for. `None` = uncapped
     /// (fill the local pane). Set by the daemon from per-host config; observe
     /// is never capped, since it doesn't resize anything.
@@ -144,7 +144,6 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
             "--controller-scope" => args.controller_scope = Some(next("--controller-scope")?),
             "--streamer-key" => args.streamer_key = Some(next("--streamer-key")?),
             "--terminal-reconnect" => args.terminal_reconnect = true,
-            "--controller-id" => args.controller_id = Some(next("--controller-id")?),
             // 0 is unset here for the same reason config treats it that way:
             // a zero cap would ask the remote for a zero-column terminal, which
             // herdr rejects outright, killing the session twice over and
@@ -218,6 +217,7 @@ struct Frame {
     code: Option<String>,
     index: Option<usize>,
     total_bytes: Option<usize>,
+    claim_token: Option<u64>,
 }
 
 enum Msg {
@@ -238,13 +238,21 @@ struct Session {
     supervisor: crate::child_supervisor::ChildSupervisor,
 }
 
+#[derive(Clone, Copy)]
+struct ReconnectClaim {
+    token: Option<u64>,
+    generation: u64,
+}
+
 impl Session {
     async fn stop(mut self, release: bool) {
         if release && self.mode == Mode::Control {
-            let _ = self
-                .stdin
-                .write_all(b"{\"type\":\"terminal.release\"}\n")
-                .await;
+            let _ = tokio::time::timeout(
+                SESSION_WRITE_TIMEOUT,
+                self.stdin
+                    .write_all(b"{\"type\":\"terminal.release\"}\n"),
+            )
+            .await;
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
         self.supervisor.cancel_and_wait().await;
@@ -260,11 +268,12 @@ fn spawn_session(
     args: &Args,
     mode: Mode,
     takeover: bool,
-    cols: usize,
-    rows: usize,
+    reconnect_claim: Option<ReconnectClaim>,
+    size: (usize, usize),
     gen: u64,
     tx: mpsc::Sender<Msg>,
 ) -> Result<Session> {
+    let (cols, rows) = size;
     // Configured paths stay unquoted so remote-shell ~ expands; auto mode is an
     // `sh -c` resolver that takes the trailing words as "$@" (see
     // config::remote_herdr_expr).
@@ -286,6 +295,14 @@ fn spawn_session(
             if let Some(controller_id) = &args.controller_id {
                 cmd.push_str(" --controller-id ");
                 cmd.push_str(&sh_quote(controller_id));
+                if let Some(claim) = reconnect_claim {
+                    if let Some(claim_token) = claim.token {
+                        cmd.push_str(" --replace-claim-token ");
+                        cmd.push_str(&claim_token.to_string());
+                    }
+                    cmd.push_str(" --controller-generation ");
+                    cmd.push_str(&claim.generation.to_string());
+                }
             }
         }
     }
@@ -676,6 +693,9 @@ const GONE_BACKOFF_MS: u64 = 60_000;
 
 const SWITCH_GAP: Duration = Duration::from_millis(200);
 const QUICK_CONTROL_FAILURE: Duration = Duration::from_secs(4);
+const WAKE_RETRY_WINDOW: Duration = Duration::from_secs(30);
+const WAKE_RETRY_DELAY: Duration = Duration::from_secs(1);
+const SESSION_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Is this failure "the pane we stream is gone", as opposed to any other
 /// failure that happens to mention something missing?
@@ -701,6 +721,16 @@ fn target_gone(reason: &str, pane_target: &str) -> bool {
         .contains(&format!("terminal target {} not found", pane_target.to_ascii_lowercase()))
 }
 
+fn reconnect_flags_unsupported(reason: &str) -> bool {
+    let reason = reason.to_ascii_lowercase();
+    ["--controller-id", "--lease-ms", "--replace-claim-token"]
+        .iter()
+        .any(|flag| reason.contains(flag))
+        && ["unknown", "unexpected", "unrecognized"]
+            .iter()
+            .any(|word| reason.contains(word))
+}
+
 /// Delay before the next attempt, and the ladder position to keep.
 ///
 /// Pure so the rung and the ladder-resume are testable without a live pane.
@@ -712,6 +742,22 @@ fn reconnect_delay(gone: bool, idx: usize) -> (u64, usize) {
         return (GONE_BACKOFF_MS, idx);
     }
     (BACKOFF[idx.min(BACKOFF.len() - 1)], idx + 1)
+}
+
+fn control_input_needs_buffer(
+    switching_to: Option<Mode>,
+    session_present: bool,
+    session_ready: bool,
+) -> bool {
+    switching_to == Some(Mode::Control) || !session_present || !session_ready
+}
+
+fn bound_reconnect_delay(delay_ms: u64, wake_retry_until: Option<Instant>, now: Instant) -> u64 {
+    if wake_retry_until.is_some_and(|deadline| now < deadline) {
+        delay_ms.min(WAKE_RETRY_DELAY.as_millis() as u64)
+    } else {
+        delay_ms
+    }
 }
 
 struct App {
@@ -730,16 +776,21 @@ struct App {
 
     backoff_idx: usize,
     reconnect_at: Option<(Instant, Mode)>,
+    wake_retry_until: Option<Instant>,
     /// consecutive quick control failures → fall back to observe
     control_failures: u32,
     control_sticky: bool,
     takeover_policy: crate::ownership::LegacyTakeoverPolicy,
     next_control_takeover: bool,
     session_ready: bool,
+    claim_token: Option<u64>,
+    claim_token_key: String,
+    state_dir: std::path::PathBuf,
     heartbeat_status_visible: bool,
     ownership_hint: Option<String>,
     frame_assembler: crate::frame_stream::FrameAssembler,
     frame_resync_pending: bool,
+    last_frame_seq: Option<u64>,
     liveness: crate::liveness::Liveness,
     pending_input: crate::pending_input::PendingInput,
     last_input: Instant,
@@ -916,9 +967,14 @@ impl App {
 
     async fn connect(&mut self, m: Mode) {
         self.mode = m;
+        self.reconnect_at = None;
+        self.switching_to = None;
         // re-earn prediction confidence against the new session's frames
         self.predict = Predictor::new();
+        self.frame_assembler = crate::frame_stream::FrameAssembler::default();
         self.frame_resync_pending = false;
+        self.last_frame_seq = None;
+        self.liveness.disconnected();
         let (cols, rows) = match m {
             Mode::Observe => self.observe_size(),
             Mode::Control => self.control_size(),
@@ -928,12 +984,26 @@ impl App {
         }
         self.next_gen += 1;
         let takeover = m == Mode::Control && std::mem::take(&mut self.next_control_takeover);
+        let reconnect_claim = if m == Mode::Control && self.args.terminal_reconnect {
+            match crate::claim_token::next_generation(&self.state_dir, &self.claim_token_key) {
+                Ok(generation) => Some(ReconnectClaim {
+                    token: self.claim_token,
+                    generation,
+                }),
+                Err(error) => {
+                    self.schedule_reconnect(m, &format!("cannot allocate controller generation: {error}"));
+                    return;
+                }
+            }
+        } else {
+            None
+        };
         match spawn_session(
             &self.args,
             m,
             takeover,
-            cols,
-            rows,
+            reconnect_claim,
+            (cols, rows),
             self.next_gen,
             self.tx.clone(),
         ) {
@@ -965,12 +1035,16 @@ impl App {
     }
 
     fn schedule_reconnect(&mut self, m: Mode, reason: &str) {
+        if self.args.dump && !reason.is_empty() {
+            eprintln!("herdr-mirror: {m:?} session reconnecting: {reason}");
+        }
         // Only slow down once we are back in observe. In control the existing
         // quick-failure fallback needs its fast retries to reach two failures
         // and drop the pane to observe within seconds; a 60s rung there would
         // leave an always_control pane stuck in control for a minute.
         let gone = m == Mode::Observe && target_gone(reason, &self.args.pane_target);
         let (delay, idx) = reconnect_delay(gone, self.backoff_idx);
+        let delay = bound_reconnect_delay(delay, self.wake_retry_until, Instant::now());
         self.backoff_idx = idx;
 
         if gone {
@@ -1010,11 +1084,21 @@ impl App {
         self.switch_at = Some(Instant::now() + SWITCH_GAP);
     }
 
-    async fn mark_session_ready(&mut self) {
+    async fn mark_session_ready(&mut self, claim_token: Option<u64>) {
         if self.session_ready {
             return;
         }
         self.session_ready = true;
+        if self.mode == Mode::Control {
+            self.claim_token = claim_token.or(self.claim_token);
+            if let Some(token) = claim_token {
+                if let Err(error) =
+                    crate::claim_token::save(&self.state_dir, &self.claim_token_key, token)
+                {
+                    eprintln!("herdr-mirror: cannot persist terminal claim token: {error}");
+                }
+            }
+        }
         let now = Instant::now();
         self.liveness.ready(now, std::time::SystemTime::now());
         if self.args.terminal_reconnect {
@@ -1033,7 +1117,11 @@ impl App {
                 let line = json!({ "type": "terminal.input", "bytes": B64.encode(&buf) })
                     .to_string()
                     + "\n";
-                let _ = session.stdin.write_all(line.as_bytes()).await;
+                let _ = tokio::time::timeout(
+                    SESSION_WRITE_TIMEOUT,
+                    session.stdin.write_all(line.as_bytes()),
+                )
+                .await;
             }
         }
         if drained.dropped_bytes > 0 {
@@ -1082,7 +1170,7 @@ impl App {
             return; // stale frame from a replaced session
         }
         match frame.kind.as_str() {
-            "terminal.ready" => self.mark_session_ready().await,
+            "terminal.ready" => self.mark_session_ready(frame.claim_token).await,
             "terminal.heartbeat_ack"
                 if frame
                     .nonce
@@ -1139,7 +1227,16 @@ impl App {
                     .and_then(|seq| self.frame_assembler.finish(seq));
                 match result {
                     Ok(complete) => {
-                        self.mark_session_ready().await;
+                        if !complete.full
+                            && self
+                                .last_frame_seq
+                                .is_some_and(|last| complete.seq != last.saturating_add(1))
+                        {
+                            self.request_frame_resync().await;
+                            return;
+                        }
+                        self.last_frame_seq = Some(complete.seq);
+                        self.mark_session_ready(frame.claim_token).await;
                         self.apply_terminal_frame(
                             Some(complete.seq),
                             complete.full,
@@ -1159,7 +1256,16 @@ impl App {
                 else {
                     return;
                 };
-                self.mark_session_ready().await;
+                if !frame.full.unwrap_or(false)
+                    && frame.seq.zip(self.last_frame_seq).is_some_and(|(seq, last)| {
+                        seq != last.saturating_add(1)
+                    })
+                {
+                    self.request_frame_resync().await;
+                    return;
+                }
+                self.last_frame_seq = frame.seq.or(self.last_frame_seq);
+                self.mark_session_ready(frame.claim_token).await;
                 self.apply_terminal_frame(
                     frame.seq,
                     frame.full.unwrap_or(false),
@@ -1187,8 +1293,23 @@ impl App {
             return; // an old child we already replaced/killed
         }
         self.session = None;
+        self.session_ready = false;
+        self.liveness.disconnected();
         let reason_line =
             reason.lines().map(str::trim).rfind(|l| !l.is_empty()).unwrap_or("").to_string();
+        if self.args.terminal_reconnect && reconnect_flags_unsupported(&reason_line) {
+            self.args.terminal_reconnect = false;
+            self.args.controller_id = None;
+            self.claim_token = None;
+            self.liveness.disable();
+            self.heartbeat_status_visible = false;
+            self.ownership_hint = Some(
+                "remote Herdr no longer supports reconnect leases — using safe legacy mode"
+                    .into(),
+            );
+            self.schedule_reconnect(exited_mode, &reason_line);
+            return;
+        }
         // control that dies quickly twice is failing (refused/dropped): fall
         // back to observe so the pane stays viewable; a keystroke retries
         if exited_mode == Mode::Control {
@@ -1220,28 +1341,44 @@ impl App {
                 }
                 return;
             }
-            self.control_failures = if uptime < QUICK_CONTROL_FAILURE {
-                self.control_failures + 1
-            } else {
-                0
-            };
-            if self.control_failures >= 2 {
-                self.control_failures = 0;
-                self.control_sticky = true;
-                self.switch_mode(Mode::Observe);
-                let suffix = if reason_line.is_empty() { String::new() } else { format!(" ({reason_line})") };
-                self.hint(&format!("control unavailable — viewing only{suffix}; type to retry"));
-                return;
+            if !self.args.terminal_reconnect {
+                self.control_failures = if uptime < QUICK_CONTROL_FAILURE {
+                    self.control_failures + 1
+                } else {
+                    0
+                };
+                if self.control_failures >= 2 {
+                    self.control_failures = 0;
+                    self.control_sticky = true;
+                    self.switch_mode(Mode::Observe);
+                    let suffix = if reason_line.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" ({reason_line})")
+                    };
+                    self.hint(&format!(
+                        "control unavailable — viewing only{suffix}; type to retry"
+                    ));
+                    return;
+                }
             }
         }
         self.schedule_reconnect(exited_mode, &reason_line);
     }
 
-    async fn send(&mut self, msg: serde_json::Value) {
+    async fn send(&mut self, msg: serde_json::Value) -> bool {
         if let Some(s) = self.session.as_mut() {
             let line = msg.to_string() + "\n";
-            let _ = s.stdin.write_all(line.as_bytes()).await;
+            return matches!(
+                tokio::time::timeout(
+                    SESSION_WRITE_TIMEOUT,
+                    s.stdin.write_all(line.as_bytes())
+                )
+                .await,
+                Ok(Ok(()))
+            );
         }
+        false
     }
 
     async fn request_frame_resync(&mut self) {
@@ -1259,6 +1396,7 @@ impl App {
         {
             Some(crate::liveness::Action::Heartbeat { nonce, wake_probe }) => {
                 if wake_probe {
+                    self.wake_retry_until = Some(Instant::now() + WAKE_RETRY_WINDOW);
                     self.heartbeat_status_visible = true;
                     self.renderer
                         .status("wake detected — probing terminal path…");
@@ -1435,7 +1573,11 @@ impl App {
             }
             return;
         }
-        if self.switching_to == Some(Mode::Control) || self.session.is_none() {
+        if control_input_needs_buffer(
+            self.switching_to,
+            self.session.is_some(),
+            self.session_ready,
+        ) {
             // spinning up or awaiting reconnect: queue the keystroke (flushed
             // on connect) and, if in backoff, reconnect now
             self.pending_input.push(Instant::now(), buf);
@@ -1502,7 +1644,11 @@ impl App {
             return;
         }
         self.last_input = Instant::now();
-        if self.switching_to == Some(Mode::Control) || self.session.is_none() {
+        if control_input_needs_buffer(
+            self.switching_to,
+            self.session.is_some(),
+            self.session_ready,
+        ) {
             self.pending_input.push(Instant::now(), buf);
             if let Some((_, m)) = self.reconnect_at {
                 self.reconnect_at = Some((Instant::now(), m));
@@ -1530,30 +1676,40 @@ impl App {
 // ---------------------------------------------------------------------------
 // main
 
-pub async fn run(args: Args) -> Result<()> {
+pub async fn run(mut args: Args, state_dir: std::path::PathBuf) -> Result<()> {
     // Claim the cross-process streamer slot before opening SSH. --dump is a
     // human diagnostic and deliberately does not participate in daemon healing.
+    let scope = args.controller_scope.as_deref().unwrap_or(&args.ssh_target);
+    let transport = if args.container.is_some() {
+        "docker"
+    } else {
+        "ssh"
+    };
+    let identity = crate::streamer_lock::StreamerIdentity {
+        transport,
+        controller_scope: scope,
+        target: &args.ssh_target,
+        session: args.session.as_deref(),
+        pane: &args.pane_target,
+    };
+    let computed = identity.key();
+    if args.terminal_reconnect {
+        args.controller_id = Some(crate::controller_identity::controller_id(&state_dir, scope)?);
+    }
+    let claim_token = if args.terminal_reconnect {
+        match crate::claim_token::load(&state_dir, &computed) {
+            Ok(token) => token,
+            Err(error) => {
+                eprintln!("herdr-mirror: ignoring invalid terminal claim token: {error}");
+                None
+            }
+        }
+    } else {
+        None
+    };
     let _streamer_lock = if args.dump {
         None
     } else {
-        let state_dir = crate::util::home_dir()
-            .join(".local")
-            .join("state")
-            .join("herdr-mirror");
-        let scope = args.controller_scope.as_deref().unwrap_or(&args.ssh_target);
-        let transport = if args.container.is_some() {
-            "docker"
-        } else {
-            "ssh"
-        };
-        let identity = crate::streamer_lock::StreamerIdentity {
-            transport,
-            controller_scope: scope,
-            target: &args.ssh_target,
-            session: args.session.as_deref(),
-            pane: &args.pane_target,
-        };
-        let computed = identity.key();
         if args
             .streamer_key
             .as_deref()
@@ -1616,15 +1772,20 @@ pub async fn run(args: Args) -> Result<()> {
         next_gen: 0,
         backoff_idx: 0,
         reconnect_at: None,
+        wake_retry_until: None,
         control_failures: 0,
         control_sticky: false,
         takeover_policy: crate::ownership::LegacyTakeoverPolicy::default(),
         next_control_takeover: false,
         session_ready: false,
+        claim_token,
+        claim_token_key: computed,
+        state_dir,
         heartbeat_status_visible: false,
         ownership_hint: None,
         frame_assembler: crate::frame_stream::FrameAssembler::default(),
         frame_resync_pending: false,
+        last_frame_seq: None,
         liveness: crate::liveness::Liveness::new(
             terminal_reconnect,
             now,
@@ -2094,6 +2255,16 @@ mod tests {
     }
 
     #[test]
+    fn remote_downgrade_is_detected_only_from_reconnect_flag_rejection() {
+        assert!(reconnect_flags_unsupported(
+            "error: unexpected argument '--controller-id' found"
+        ));
+        assert!(reconnect_flags_unsupported("unknown option: --lease-ms"));
+        assert!(!reconnect_flags_unsupported("ssh: connection timed out"));
+        assert!(!reconnect_flags_unsupported("unknown host"));
+    }
+
+    #[test]
     fn a_gone_target_slows_down_without_consuming_the_ladder() {
         // the fix: 10s forever becomes one attempt a minute
         assert_eq!(reconnect_delay(true, 0), (GONE_BACKOFF_MS, 0));
@@ -2110,6 +2281,30 @@ mod tests {
         let (_, idx) = reconnect_delay(false, 0);
         let (_, idx) = reconnect_delay(true, idx);
         assert_eq!(reconnect_delay(false, idx), (2000, 2));
+    }
+
+    #[test]
+    fn control_input_stays_buffered_until_the_candidate_is_ready() {
+        assert!(control_input_needs_buffer(None, true, false));
+        assert!(control_input_needs_buffer(Some(Mode::Control), true, true));
+        assert!(control_input_needs_buffer(None, false, false));
+        assert!(!control_input_needs_buffer(None, true, true));
+    }
+
+    #[test]
+    fn wake_recovery_caps_every_backoff_rung_for_thirty_seconds() {
+        let now = Instant::now();
+        let wake_retry_until = Some(now + WAKE_RETRY_WINDOW);
+        for delay in [1_000, 2_000, 5_000, 10_000, GONE_BACKOFF_MS] {
+            assert_eq!(
+                bound_reconnect_delay(delay, wake_retry_until, now),
+                1_000
+            );
+        }
+        assert_eq!(
+            bound_reconnect_delay(10_000, wake_retry_until, now + WAKE_RETRY_WINDOW),
+            10_000
+        );
     }
 
 }

--- a/src/pending_input.rs
+++ b/src/pending_input.rs
@@ -1,0 +1,100 @@
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+const MAX_PENDING_BYTES: usize = 64 * 1024;
+const MAX_PENDING_AGE: Duration = Duration::from_secs(10);
+
+struct Entry {
+    queued_at: Instant,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct DrainedInput {
+    pub chunks: Vec<Vec<u8>>,
+    pub dropped_bytes: usize,
+}
+
+#[derive(Default)]
+pub struct PendingInput {
+    entries: VecDeque<Entry>,
+    queued_bytes: usize,
+    dropped_bytes: usize,
+}
+
+impl PendingInput {
+    pub fn push(&mut self, queued_at: Instant, bytes: Vec<u8>) {
+        self.expire(queued_at);
+        if bytes.len() > MAX_PENDING_BYTES
+            || self.queued_bytes.saturating_add(bytes.len()) > MAX_PENDING_BYTES
+        {
+            self.dropped_bytes = self.dropped_bytes.saturating_add(bytes.len());
+            return;
+        }
+        self.queued_bytes += bytes.len();
+        self.entries.push_back(Entry { queued_at, bytes });
+    }
+
+    pub fn drain_ready(&mut self, now: Instant) -> DrainedInput {
+        self.expire(now);
+        self.queued_bytes = 0;
+        DrainedInput {
+            chunks: self.entries.drain(..).map(|entry| entry.bytes).collect(),
+            dropped_bytes: std::mem::take(&mut self.dropped_bytes),
+        }
+    }
+
+    fn expire(&mut self, now: Instant) {
+        while self.entries.front().is_some_and(|entry| {
+            now.checked_duration_since(entry.queued_at)
+                .is_some_and(|age| age >= MAX_PENDING_AGE)
+        }) {
+            if let Some(entry) = self.entries.pop_front() {
+                self.queued_bytes = self.queued_bytes.saturating_sub(entry.bytes.len());
+                self.dropped_bytes = self.dropped_bytes.saturating_add(entry.bytes.len());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_is_held_until_acquisition_and_drained_in_order() {
+        let now = Instant::now();
+        let mut pending = PendingInput::default();
+        pending.push(now, b"one".to_vec());
+        pending.push(now + Duration::from_millis(1), b"two".to_vec());
+
+        assert_eq!(
+            pending.drain_ready(now + Duration::from_secs(1)),
+            DrainedInput {
+                chunks: vec![b"one".to_vec(), b"two".to_vec()],
+                dropped_bytes: 0
+            }
+        );
+    }
+
+    #[test]
+    fn stale_and_excess_input_is_bounded_and_reported() {
+        let now = Instant::now();
+        let mut pending = PendingInput::default();
+        pending.push(now, vec![b'a'; 32]);
+        pending.push(
+            now + Duration::from_secs(11),
+            vec![b'b'; MAX_PENDING_BYTES + 1],
+        );
+
+        assert_eq!(
+            pending.drain_ready(now + Duration::from_secs(11)),
+            DrainedInput {
+                chunks: Vec::new(),
+                dropped_bytes: MAX_PENDING_BYTES + 33
+            }
+        );
+    }
+}

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -39,6 +39,38 @@ pub struct RemoteStatus {
     pub socket: String,
     pub supported: bool,
     pub reason: Option<String>,
+    pub client_protocol: Option<u32>,
+    pub server_protocol: Option<u32>,
+    pub compatible: bool,
+    pub terminal_session_reconnect: bool,
+}
+
+#[derive(Deserialize)]
+struct StatusClient {
+    version: Option<String>,
+    protocol: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct StatusServerCapabilities {
+    #[serde(default)]
+    terminal_session_reconnect_v1: bool,
+}
+
+#[derive(Deserialize)]
+struct StatusServer {
+    running: Option<bool>,
+    socket: Option<String>,
+    version: Option<String>,
+    protocol: Option<u32>,
+    compatible: Option<bool>,
+    capabilities: Option<StatusServerCapabilities>,
+}
+
+#[derive(Deserialize)]
+struct StatusJson {
+    client: Option<StatusClient>,
+    server: Option<StatusServer>,
 }
 
 struct SshOutput {
@@ -331,53 +363,10 @@ impl RemoteHost {
             self.cfg.remote_bin.as_deref(),
             self.cfg.session.as_deref(),
         );
-        let out = self.exec(&format!("exec {} status --json", bin), 15000).await?;
-        #[derive(Deserialize)]
-        struct Client {
-            version: Option<String>,
-        }
-        #[derive(Deserialize)]
-        struct Server {
-            running: Option<bool>,
-            socket: Option<String>,
-            version: Option<String>,
-        }
-        #[derive(Deserialize)]
-        struct StatusJson {
-            client: Option<Client>,
-            server: Option<Server>,
-        }
-        let parsed: StatusJson = serde_json::from_str(&out)?;
-        let version = parsed
-            .server
-            .as_ref()
-            .and_then(|s| s.version.clone())
-            .or(parsed.client.and_then(|c| c.version))
-            .unwrap_or_else(|| "unknown".into());
-        let running = parsed.server.as_ref().and_then(|s| s.running) == Some(true);
-        let socket = parsed.server.and_then(|s| s.socket).unwrap_or_default();
-        let mut status = RemoteStatus { socket, supported: false, reason: None };
-        if !running {
-            // Name the session, or this reads as "that machine's herdr is
-            // down" while the default session is running perfectly and only
-            // the configured one is stopped — which is the common way to get
-            // here once `session` is in play (a typo, or `herdr session stop`).
-            status.reason = Some(match &self.cfg.session {
-                Some(name) => format!("remote herdr session {name:?} is not running"),
-                None => "remote herdr server is not running".into(),
-            });
-            return Ok(status);
-        }
-        match version_supported(&version) {
-            Some(true) => status.supported = true,
-            Some(false) => {
-                status.reason = Some(format!(
-                    "remote herdr {version} lacks terminal session streams (need >= 0.7.2 or preview {MIN_PREVIEW_BUILD})"
-                ))
-            }
-            None => status.reason = Some(format!("cannot parse remote version {version}")),
-        }
-        Ok(status)
+        let out = self
+            .exec(&format!("exec {} status --json", bin), 15000)
+            .await?;
+        parse_remote_status(&out, self.cfg.session.as_deref())
     }
 
     pub async fn forward_api(&mut self, remote_socket: &str) -> Result<PathBuf> {
@@ -570,6 +559,66 @@ fn nonempty(e: &str, code: i32) -> String {
     }
 }
 
+fn parse_remote_status(out: &str, session: Option<&str>) -> Result<RemoteStatus> {
+    let parsed: StatusJson = serde_json::from_str(out)?;
+    let client_protocol = parsed.client.as_ref().and_then(|client| client.protocol);
+    let server_protocol = parsed.server.as_ref().and_then(|server| server.protocol);
+    let version = parsed
+        .server
+        .as_ref()
+        .and_then(|server| server.version.clone())
+        .or_else(|| {
+            parsed
+                .client
+                .as_ref()
+                .and_then(|client| client.version.clone())
+        })
+        .unwrap_or_else(|| "unknown".into());
+    let running = parsed.server.as_ref().and_then(|server| server.running) == Some(true);
+    let compatible = parsed.server.as_ref().and_then(|server| server.compatible) == Some(true);
+    let reconnect_capability = parsed
+        .server
+        .as_ref()
+        .and_then(|server| server.capabilities.as_ref())
+        .is_some_and(|capabilities| capabilities.terminal_session_reconnect_v1);
+    let terminal_session_reconnect = running
+        && compatible
+        && client_protocol == server_protocol
+        && client_protocol.is_some_and(|protocol| protocol >= 21)
+        && reconnect_capability;
+    let socket = parsed
+        .server
+        .as_ref()
+        .and_then(|server| server.socket.clone())
+        .unwrap_or_default();
+    let mut status = RemoteStatus {
+        socket,
+        supported: false,
+        reason: None,
+        client_protocol,
+        server_protocol,
+        compatible,
+        terminal_session_reconnect,
+    };
+    if !running {
+        status.reason = Some(match session {
+            Some(name) => format!("remote herdr session {name:?} is not running"),
+            None => "remote herdr server is not running".into(),
+        });
+        return Ok(status);
+    }
+    match version_supported(&version) {
+        Some(true) => status.supported = true,
+        Some(false) => {
+            status.reason = Some(format!(
+                "remote herdr {version} lacks terminal session streams (need >= 0.7.2 or preview {MIN_PREVIEW_BUILD})"
+            ));
+        }
+        None => status.reason = Some(format!("cannot parse remote version {version}")),
+    }
+    Ok(status)
+}
+
 /// `Some(true)` = supported, `Some(false)` = too old, `None` = unparseable.
 fn version_supported(version: &str) -> Option<bool> {
     let core = version.split(['-', '+']).next()?;
@@ -614,6 +663,7 @@ mod tests {
             max_rows: None,
             api_transport: ApiTransport::Auto,
             always_control: true,
+            takeover_on_reconnect: false,
         }
     }
 
@@ -732,5 +782,32 @@ mod tests {
         assert_eq!(version_supported("0.7.1-preview.2026-07-04-aaaa"), Some(true));
         assert_eq!(version_supported("0.7.1-preview.2026-06-29-aaaa"), Some(false));
         assert_eq!(version_supported("garbage"), None);
+    }
+
+    #[test]
+    fn reconnect_capability_requires_compatible_protocol_21_on_both_sides() {
+        let capable = parse_remote_status(
+            r#"{
+                "client":{"version":"0.8.1","protocol":21},
+                "server":{"running":true,"version":"0.8.1","protocol":21,
+                    "compatible":true,"socket":"/tmp/herdr.sock",
+                    "capabilities":{"terminal_session_reconnect_v1":true}}
+            }"#,
+            None,
+        )
+        .unwrap();
+        assert!(capable.terminal_session_reconnect);
+
+        for json in [
+            r#"{"client":{"version":"0.8.1","protocol":20},"server":{"running":true,"version":"0.8.1","protocol":20,"compatible":true,"capabilities":{"terminal_session_reconnect_v1":true}}}"#,
+            r#"{"client":{"version":"0.8.1","protocol":21},"server":{"running":true,"version":"0.8.1","protocol":20,"compatible":false,"capabilities":{"terminal_session_reconnect_v1":true}}}"#,
+            r#"{"client":{"version":"0.8.1","protocol":21},"server":{"running":true,"version":"0.8.1","protocol":21,"compatible":true,"capabilities":{}}}"#,
+        ] {
+            assert!(
+                !parse_remote_status(json, None)
+                    .unwrap()
+                    .terminal_session_reconnect
+            );
+        }
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -584,7 +584,7 @@ fn parse_remote_status(out: &str, session: Option<&str>) -> Result<RemoteStatus>
     let terminal_session_reconnect = running
         && compatible
         && client_protocol == server_protocol
-        && client_protocol.is_some_and(|protocol| protocol >= 21)
+        && client_protocol.is_some_and(|protocol| protocol >= 22)
         && reconnect_capability;
     let socket = parsed
         .server
@@ -785,11 +785,11 @@ mod tests {
     }
 
     #[test]
-    fn reconnect_capability_requires_compatible_protocol_21_on_both_sides() {
+    fn reconnect_capability_requires_compatible_protocol_22_on_both_sides() {
         let capable = parse_remote_status(
             r#"{
-                "client":{"version":"0.8.1","protocol":21},
-                "server":{"running":true,"version":"0.8.1","protocol":21,
+                "client":{"version":"0.8.2","protocol":22},
+                "server":{"running":true,"version":"0.8.2","protocol":22,
                     "compatible":true,"socket":"/tmp/herdr.sock",
                     "capabilities":{"terminal_session_reconnect_v1":true}}
             }"#,
@@ -800,8 +800,9 @@ mod tests {
 
         for json in [
             r#"{"client":{"version":"0.8.1","protocol":20},"server":{"running":true,"version":"0.8.1","protocol":20,"compatible":true,"capabilities":{"terminal_session_reconnect_v1":true}}}"#,
-            r#"{"client":{"version":"0.8.1","protocol":21},"server":{"running":true,"version":"0.8.1","protocol":20,"compatible":false,"capabilities":{"terminal_session_reconnect_v1":true}}}"#,
-            r#"{"client":{"version":"0.8.1","protocol":21},"server":{"running":true,"version":"0.8.1","protocol":21,"compatible":true,"capabilities":{}}}"#,
+            r#"{"client":{"version":"0.8.1","protocol":21},"server":{"running":true,"version":"0.8.1","protocol":21,"compatible":true,"capabilities":{"terminal_session_reconnect_v1":true}}}"#,
+            r#"{"client":{"version":"0.8.2","protocol":22},"server":{"running":true,"version":"0.8.1","protocol":21,"compatible":false,"capabilities":{"terminal_session_reconnect_v1":true}}}"#,
+            r#"{"client":{"version":"0.8.2","protocol":22},"server":{"running":true,"version":"0.8.2","protocol":22,"compatible":true,"capabilities":{}}}"#,
         ] {
             assert!(
                 !parse_remote_status(json, None)

--- a/src/state.rs
+++ b/src/state.rs
@@ -86,6 +86,16 @@ pub struct HostState {
     /// permanent winner and revert the other side's drag.
     #[serde(default)]
     pub ratios: BTreeMap<String, f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_session: Option<RemoteSessionStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemoteSessionStatus {
+    pub client_protocol: Option<u32>,
+    pub server_protocol: Option<u32>,
+    pub compatible: bool,
+    pub reconnect_v1: bool,
 }
 
 pub fn state_path(state_dir: &Path, host: &str) -> PathBuf {

--- a/src/streamer_lock.rs
+++ b/src/streamer_lock.rs
@@ -1,0 +1,172 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone)]
+pub struct StreamerIdentity<'a> {
+    pub transport: &'a str,
+    pub controller_scope: &'a str,
+    pub target: &'a str,
+    pub session: Option<&'a str>,
+    pub pane: &'a str,
+}
+
+impl StreamerIdentity<'_> {
+    pub fn key(&self) -> String {
+        let digest = Sha256::digest(self.metadata().as_bytes());
+        digest.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    pub fn metadata(&self) -> String {
+        let mut out = String::from("herdr-mirror-streamer-v1");
+        for (name, value) in [
+            ("transport", self.transport),
+            ("scope", self.controller_scope),
+            ("target", self.target),
+            ("session", self.session.unwrap_or("<default>")),
+            ("pane", self.pane),
+        ] {
+            out.push('|');
+            out.push_str(name);
+            out.push(':');
+            out.push_str(&value.len().to_string());
+            out.push(':');
+            out.push_str(value);
+        }
+        out
+    }
+}
+
+pub struct StreamerLock {
+    file: File,
+}
+
+impl StreamerLock {
+    pub fn acquire(state_dir: &Path, identity: &StreamerIdentity<'_>) -> crate::util::Result<Self> {
+        let dir = state_dir.join("streamer-pids");
+        fs::create_dir_all(&dir)?;
+        let path = lock_path(state_dir, &identity.key());
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .mode(0o600)
+            .open(&path)?;
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc != 0 {
+            return Err(crate::util::err(format!(
+                "streamer already running for {} ({})",
+                identity.pane,
+                path.display()
+            )));
+        }
+        let metadata = identity.metadata();
+        file.set_len(0)?;
+        writeln!(file, "pid={}", std::process::id())?;
+        writeln!(file, "{metadata}")?;
+        file.flush()?;
+        let recorded = fs::read_to_string(&path)?;
+        if recorded.lines().nth(1) != Some(metadata.as_str()) {
+            return Err(crate::util::err(format!(
+                "streamer lock metadata verification failed ({})",
+                path.display()
+            )));
+        }
+        Ok(Self { file })
+    }
+}
+
+impl Drop for StreamerLock {
+    fn drop(&mut self) {
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+pub fn lock_path(state_dir: &Path, key: &str) -> PathBuf {
+    state_dir
+        .join("streamer-pids")
+        .join(format!("v1-{key}.lock"))
+}
+
+pub fn is_held(state_dir: &Path, key: &str) -> bool {
+    let Ok(file) = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(lock_path(state_dir, key))
+    else {
+        return false;
+    };
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        return std::io::Error::last_os_error().kind() == std::io::ErrorKind::WouldBlock;
+    }
+    unsafe {
+        libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn identity<'a>(
+        scope: &'a str,
+        target: &'a str,
+        session: Option<&'a str>,
+    ) -> StreamerIdentity<'a> {
+        StreamerIdentity {
+            transport: "ssh",
+            controller_scope: scope,
+            target,
+            session,
+            pane: "w1:p1",
+        }
+    }
+
+    #[test]
+    fn key_distinguishes_scope_target_session_and_pane_without_lossy_sanitizing() {
+        let base = identity("work", "user@host:a", None);
+        let keys = [
+            base.key(),
+            identity("other", "user@host:a", None).key(),
+            identity("work", "user@host/a", None).key(),
+            identity("work", "user@host:a", Some("named")).key(),
+            StreamerIdentity {
+                pane: "w1:p2",
+                ..base
+            }
+            .key(),
+        ];
+        let unique: std::collections::HashSet<_> = keys.iter().collect();
+        assert_eq!(unique.len(), keys.len());
+        assert!(keys.iter().all(|key| key.len() == 64));
+    }
+
+    #[test]
+    fn held_lock_refuses_duplicate_and_drop_releases_it() {
+        let dir = std::env::temp_dir().join(format!(
+            "herdr-mirror-streamer-lock-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let id = identity("work", "work", None);
+        let first = StreamerLock::acquire(&dir, &id).unwrap();
+        assert!(is_held(&dir, &id.key()));
+        assert!(StreamerLock::acquire(&dir, &id).is_err());
+        drop(first);
+        assert!(!is_held(&dir, &id.key()));
+        assert!(StreamerLock::acquire(&dir, &id).is_ok());
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/src/streamer_lock.rs
+++ b/src/streamer_lock.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
@@ -43,6 +43,7 @@ impl StreamerIdentity<'_> {
 
 pub struct StreamerLock {
     file: File,
+    legacy_path: PathBuf,
 }
 
 impl StreamerLock {
@@ -50,6 +51,8 @@ impl StreamerLock {
         let dir = state_dir.join("streamer-pids");
         fs::create_dir_all(&dir)?;
         let path = lock_path(state_dir, &identity.key());
+        let directory_lock = coordination_lock(&dir, libc::LOCK_EX)?;
+        collect_stale_files(&dir, &path)?;
         let mut file = OpenOptions::new()
             .create(true)
             .truncate(false)
@@ -66,27 +69,115 @@ impl StreamerLock {
             )));
         }
         let metadata = identity.metadata();
+        let mut existing = String::new();
+        file.read_to_string(&mut existing)?;
+        if let Some(recorded) = existing.lines().nth(1) {
+            if recorded != metadata {
+                return Err(crate::util::err(format!(
+                    "streamer lock identity collision ({})",
+                    path.display()
+                )));
+            }
+        }
         file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
         writeln!(file, "pid={}", std::process::id())?;
         writeln!(file, "{metadata}")?;
         file.flush()?;
-        let recorded = fs::read_to_string(&path)?;
-        if recorded.lines().nth(1) != Some(metadata.as_str()) {
-            return Err(crate::util::err(format!(
-                "streamer lock metadata verification failed ({})",
-                path.display()
-            )));
-        }
-        Ok(Self { file })
+        let legacy_path = legacy_pid_path(state_dir, identity.target, identity.pane);
+        fs::write(&legacy_path, std::process::id().to_string())?;
+        drop(directory_lock);
+        Ok(Self { file, legacy_path })
     }
 }
 
 impl Drop for StreamerLock {
     fn drop(&mut self) {
+        if fs::read_to_string(&self.legacy_path)
+            .ok()
+            .is_some_and(|pid| pid.trim() == std::process::id().to_string())
+        {
+            let _ = fs::remove_file(&self.legacy_path);
+        }
         unsafe {
             libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
         }
     }
+}
+
+fn coordination_lock(dir: &Path, mode: libc::c_int) -> crate::util::Result<File> {
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .mode(0o600)
+        .open(dir.join(".directory.lock"))?;
+    if unsafe { libc::flock(file.as_raw_fd(), mode) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(file)
+}
+
+fn collect_stale_files(dir: &Path, retained_path: &Path) -> crate::util::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("v1-") && name.ends_with(".lock") {
+            if path == retained_path {
+                continue;
+            }
+            let Ok(file) = OpenOptions::new().read(true).write(true).open(&path) else {
+                continue;
+            };
+            if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0
+                && fs::remove_file(&path).is_ok()
+            {
+                if let Some(key) = name
+                    .strip_prefix("v1-")
+                    .and_then(|name| name.strip_suffix(".lock"))
+                {
+                    if let Some(state_dir) = dir.parent() {
+                        let _ = fs::remove_file(
+                            state_dir
+                                .join("claim-tokens")
+                                .join(format!("v1-{key}.token")),
+                        );
+                        let _ = fs::remove_file(
+                            state_dir
+                                .join("claim-tokens")
+                                .join(format!("v1-{key}.generation")),
+                        );
+                    }
+                }
+            }
+        } else if name.ends_with(".pid") {
+            let alive = fs::read_to_string(&path)
+                .ok()
+                .and_then(|pid| pid.trim().parse::<i32>().ok())
+                .is_some_and(crate::util::pid_alive);
+            if !alive {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn legacy_pid_path(state_dir: &Path, target: &str, pane: &str) -> PathBuf {
+    let sanitized = |value: &str| {
+        value
+            .chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+            .collect::<String>()
+    };
+    state_dir.join("streamer-pids").join(format!(
+        "{}--{}.pid",
+        sanitized(target),
+        sanitized(pane)
+    ))
 }
 
 pub fn lock_path(state_dir: &Path, key: &str) -> PathBuf {
@@ -96,6 +187,10 @@ pub fn lock_path(state_dir: &Path, key: &str) -> PathBuf {
 }
 
 pub fn is_held(state_dir: &Path, key: &str) -> bool {
+    let dir = state_dir.join("streamer-pids");
+    let Ok(_directory_lock) = coordination_lock(&dir, libc::LOCK_SH) else {
+        return false;
+    };
     let Ok(file) = OpenOptions::new()
         .read(true)
         .write(true)
@@ -103,7 +198,7 @@ pub fn is_held(state_dir: &Path, key: &str) -> bool {
     else {
         return false;
     };
-    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_SH | libc::LOCK_NB) };
     if rc != 0 {
         return std::io::Error::last_os_error().kind() == std::io::ErrorKind::WouldBlock;
     }
@@ -168,5 +263,54 @@ mod tests {
         assert!(!is_held(&dir, &id.key()));
         assert!(StreamerLock::acquire(&dir, &id).is_ok());
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn acquire_collects_unlocked_artifacts_but_keeps_active_locks() {
+        let dir = std::env::temp_dir().join(format!(
+            "herdr-mirror-streamer-gc-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let active_id = identity("active", "host", None);
+        let active = StreamerLock::acquire(&dir, &active_id).unwrap();
+        let stale_lock = lock_path(&dir, &"a".repeat(64));
+        fs::write(&stale_lock, "stale").unwrap();
+        let stale_pid = dir.join("streamer-pids/dead--pane.pid");
+        fs::write(&stale_pid, "999999999").unwrap();
+
+        let other = StreamerLock::acquire(&dir, &identity("other", "host", None)).unwrap();
+        assert!(!stale_lock.exists());
+        assert!(!stale_pid.exists());
+        assert!(is_held(&dir, &active_id.key()));
+
+        drop(other);
+        drop(active);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn existing_lock_metadata_is_validated_before_replacement() {
+        let dir = std::env::temp_dir().join(format!(
+            "herdr-mirror-streamer-metadata-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let id = identity("work", "host", None);
+        let path = lock_path(&dir, &id.key());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "pid=1\nwrong identity\n").unwrap();
+        let error = StreamerLock::acquire(&dir, &id)
+            .err()
+            .expect("metadata collision must fail")
+            .to_string();
+        assert!(error.contains("identity collision"), "{error}");
+        fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -220,26 +220,8 @@ pub fn pid_alive(pid: i32) -> bool {
     pid > 0 && unsafe { libc::kill(pid, 0) } == 0
 }
 
-/// Pidfile a pane streamer writes at startup. The daemon starts streamers by
-/// TYPING `exec ...` into a fresh shell pane, and interactive shell startup
-/// can eat keystrokes (oh-my-zsh's update prompt swallows the leading `e` —
-/// and re-prompts in every new shell until answered, so it fails every spawn,
-/// not one in a fortnight). The pidfile is how the daemon can tell the exec
-/// took, and retype it when it didn't.
-pub fn streamer_pid_path(state_dir: &Path, ssh_target: &str, pane_target: &str) -> PathBuf {
-    let sane = |s: &str| {
-        s.chars()
-            .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-            .collect::<String>()
-    };
-    state_dir.join("streamer-pids").join(format!("{}--{}.pid", sane(ssh_target), sane(pane_target)))
-}
-
-pub fn streamer_alive(state_dir: &Path, ssh_target: &str, pane_target: &str) -> bool {
-    fs::read_to_string(streamer_pid_path(state_dir, ssh_target, pane_target))
-        .ok()
-        .and_then(|s| s.trim().parse::<i32>().ok())
-        .is_some_and(pid_alive)
+pub fn streamer_alive(state_dir: &Path, key: &str) -> bool {
+    crate::streamer_lock::is_held(state_dir, key)
 }
 
 /// Sleep until the earliest deadline; pend forever when none.

--- a/tests/half_open_reconnect.rs
+++ b/tests/half_open_reconnect.rs
@@ -1,0 +1,171 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader};
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+#[test]
+#[ignore = "process-level failure simulation"]
+fn half_open_child_is_reaped_and_replaced_automatically() {
+    run_scenario(false, 1, Duration::from_millis(9_500));
+}
+
+#[test]
+#[ignore = "process-level failure simulation"]
+fn silent_child_hits_ready_timeout_and_is_replaced_automatically() {
+    run_scenario(true, 1, Duration::from_millis(9_500));
+}
+
+#[test]
+#[ignore = "long process-level resource simulation"]
+fn ten_half_open_cycles_return_to_one_child_then_zero_on_shutdown() {
+    run_scenario(false, 10, Duration::from_secs(50));
+}
+
+fn run_scenario(first_silent: bool, blackhole_count: u32, recovery_limit: Duration) {
+    let dir = std::env::temp_dir().join(format!(
+        "herdr-mirror-half-open-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let fake_ssh = dir.join("ssh");
+    let counter = dir.join("count");
+    std::fs::write(
+        &fake_ssh,
+        r#"#!/usr/bin/env python3
+import base64, json, os, signal, sys
+
+if "terminal session" not in " ".join(sys.argv[1:]):
+    sys.exit(1)
+
+count_path = os.environ["FAKE_SSH_COUNT"]
+try:
+    with open(count_path, "r", encoding="utf-8") as f:
+        count = int(f.read()) + 1
+except Exception:
+    count = 1
+with open(count_path, "w", encoding="utf-8") as f:
+    f.write(str(count))
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+silent = count == 1 and os.environ.get("FAKE_SSH_FIRST_SILENT") == "1"
+if not silent:
+    print(json.dumps({"type":"terminal.ready","mode":"observe","lease_ms":20000}), flush=True)
+healthy = count > int(os.environ["FAKE_SSH_BLACKHOLE_COUNT"])
+if healthy:
+    print(json.dumps({
+        "type":"terminal.frame", "seq":1, "full":True, "width":20, "height":2,
+        "bytes":base64.b64encode(b"RECOVERED\r\n").decode("ascii")
+    }), flush=True)
+
+for line in sys.stdin:
+    try:
+        message = json.loads(line)
+    except Exception:
+        continue
+    if healthy and message.get("type") == "terminal.heartbeat":
+        print(json.dumps({
+            "type":"terminal.heartbeat_ack", "nonce":message["nonce"]
+        }), flush=True)
+"#,
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_ssh, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+    let path = format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-mirror"))
+        .args([
+            "pane",
+            "fake-host",
+            "w1:p1",
+            "--dump",
+            "--terminal-reconnect",
+            "--controller-id",
+            "test-controller",
+        ])
+        .env("PATH", path)
+        .env("FAKE_SSH_COUNT", &counter)
+        .env(
+            "FAKE_SSH_FIRST_SILENT",
+            if first_silent { "1" } else { "0" },
+        )
+        .env("FAKE_SSH_BLACKHOLE_COUNT", blackhole_count.to_string())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let (line_tx, line_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            let _ = line_tx.send(line);
+        }
+    });
+
+    let started = Instant::now();
+    let recovered = loop {
+        let remaining = recovery_limit.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            break false;
+        }
+        match line_rx.recv_timeout(remaining) {
+            Ok(line) if line.contains("RECOVERED") => break true,
+            Ok(_) => {}
+            Err(_) => break false,
+        }
+    };
+    let elapsed = started.elapsed();
+    let direct_children = child_process_count(child.id(), None);
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let _ = child.wait();
+
+    assert!(recovered, "mirror did not recover within {recovery_limit:?}");
+    assert!(elapsed <= recovery_limit, "elapsed={elapsed:?}");
+    assert_eq!(direct_children, 1, "steady state must own one SSH child");
+    assert_eq!(child_process_count(0, Some(&fake_ssh)), 0, "no fake SSH child may remain");
+    println!(
+        "first_silent={first_silent} recovered_ms={}",
+        elapsed.as_millis()
+    );
+    assert!(
+        std::fs::read_to_string(&counter)
+            .unwrap()
+            .trim()
+            .parse::<u32>()
+            .unwrap()
+            > blackhole_count
+    );
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+fn child_process_count(parent: u32, command_path: Option<&std::path::Path>) -> usize {
+    let output = Command::new("ps")
+        .args(["-ax", "-o", "ppid=,command="])
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| {
+            let Some((ppid, command)) = line.trim().split_once(' ') else {
+                return false;
+            };
+            match command_path {
+                Some(path) => command.contains(path.to_string_lossy().as_ref()),
+                None => ppid.parse::<u32>().ok() == Some(parent),
+            }
+        })
+        .count()
+}

--- a/tests/half_open_reconnect.rs
+++ b/tests/half_open_reconnect.rs
@@ -90,10 +90,9 @@ for line in sys.stdin:
             "w1:p1",
             "--dump",
             "--terminal-reconnect",
-            "--controller-id",
-            "test-controller",
         ])
         .env("PATH", path)
+        .env("HOME", &dir)
         .env("FAKE_SSH_COUNT", &counter)
         .env(
             "FAKE_SSH_FIRST_SILENT",
@@ -131,6 +130,10 @@ for line in sys.stdin:
         libc::kill(child.id() as i32, libc::SIGTERM);
     }
     let _ = child.wait();
+    let cleanup_deadline = Instant::now() + Duration::from_secs(1);
+    while child_process_count(0, Some(&fake_ssh)) != 0 && Instant::now() < cleanup_deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
 
     assert!(recovered, "mirror did not recover within {recovery_limit:?}");
     assert!(elapsed <= recovery_limit, "elapsed={elapsed:?}");

--- a/tests/real_ssh_reconnect.rs
+++ b/tests/real_ssh_reconnect.rs
@@ -1,0 +1,504 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{mpsc, Arc};
+use std::time::{Duration, Instant};
+
+#[test]
+#[ignore = "requires HERDR_MIRROR_E2E_SSH_TARGET, _PANE, and _REMOTE_BIN"]
+fn real_ssh_blackhole_recovers_without_releasing_the_old_connection() {
+    let target = required("HERDR_MIRROR_E2E_SSH_TARGET");
+    let pane = required("HERDR_MIRROR_E2E_PANE");
+    let remote_bin = required("HERDR_MIRROR_E2E_REMOTE_BIN");
+    let cycles = std::env::var("HERDR_MIRROR_E2E_CYCLES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1);
+
+    let pane_info: serde_json::Value = serde_json::from_slice(&direct_ssh(
+        &target,
+        &format!("{} pane get {}", shell_quote(&remote_bin), shell_quote(&pane)),
+    ))
+    .expect("remote pane info json");
+    let terminal_id = pane_info["result"]["pane"]["terminal_id"]
+        .as_str()
+        .expect("remote terminal id")
+        .to_owned();
+
+    let ssh = SshTarget::resolve(&target);
+    let proxy = BlackholeProxy::start(ssh.address);
+    let home = TempHome::new("real-ssh");
+    ssh.write_alias(&home.path, proxy.address());
+    let probe = Command::new(home.path.join("bin/ssh"))
+        .args(["-o", "BatchMode=yes", "herdr-reconnect-e2e", "true"])
+        .status()
+        .expect("ssh proxy probe");
+    assert!(probe.success(), "ssh proxy probe failed");
+    let mut mirror = MirrorProcess::start(&home.path, &pane, &remote_bin);
+
+    mirror.wait_for("--- frame", Duration::from_secs(10));
+    mirror.write_and_wait("INITIAL_OK", Duration::from_secs(10));
+    let streams_before_stress = stream_attempts(&home.path);
+    proxy.set_downstream_rate(32 * 1024);
+    mirror.write_command_and_wait(
+        "i=0; while [ $i -lt 4000 ]; do echo SUSTAINED_$i; i=$((i+1)); done; echo SUSTAINED_DONE",
+        "SUSTAINED_DONE",
+        Duration::from_secs(20),
+    );
+    proxy.set_downstream_rate(0);
+    assert!(
+        stream_attempts(&home.path) == streams_before_stress,
+        "healthy slow output triggered a reconnect"
+    );
+    for cycle in 0..cycles {
+        let blocked = proxy.blackhole_existing();
+        let started = Instant::now();
+        proxy.wait_for_new_connection(blocked, Duration::from_secs(9));
+        mirror.write_and_wait(&format!("RECOVERED_{cycle}"), Duration::from_secs(10));
+        assert!(
+            started.elapsed() <= Duration::from_secs(10),
+            "cycle {cycle} exceeded recovery budget: {:?}",
+            started.elapsed()
+        );
+    }
+
+    mirror.stop();
+    proxy.stop();
+
+    std::thread::sleep(Duration::from_secs(21));
+    let sessions: serde_json::Value = serde_json::from_slice(&direct_ssh(
+        &target,
+        &format!(
+            "{} server terminal-sessions --json",
+            shell_quote(&remote_bin)
+        ),
+    ))
+    .expect("terminal session list json");
+    let retained = sessions["result"]["sessions"]
+        .as_array()
+        .expect("terminal sessions")
+        .iter()
+        .any(|session| session["terminal_id"].as_str() == Some(terminal_id.as_str()));
+    assert!(!retained, "remote client/claim/lease survived cleanup");
+
+    let processes = String::from_utf8(direct_ssh(&target, "ps -eo ppid=,args="))
+        .expect("remote process list utf8");
+    assert!(
+        !processes
+            .lines()
+            .any(|line| line.contains("terminal session") && line.contains(&pane)),
+        "remote helper survived cleanup:\n{processes}"
+    );
+}
+
+#[test]
+#[ignore = "requires HERDR_MIRROR_E2E_SSH_TARGET, _PANE, and _REMOTE_BIN"]
+fn different_installation_cannot_displace_the_live_controller() {
+    let target = required("HERDR_MIRROR_E2E_SSH_TARGET");
+    let pane = required("HERDR_MIRROR_E2E_PANE");
+    let remote_bin = required("HERDR_MIRROR_E2E_REMOTE_BIN");
+    let ssh = SshTarget::resolve(&target);
+    let proxy = BlackholeProxy::start(ssh.address);
+    let home_a = TempHome::new("controller-a");
+    let home_b = TempHome::new("controller-b");
+    ssh.write_alias(&home_a.path, proxy.address());
+    ssh.write_alias(&home_b.path, proxy.address());
+
+    let mut owner = MirrorProcess::start(&home_a.path, &pane, &remote_bin);
+    owner.wait_for("--- frame", Duration::from_secs(10));
+    owner.write_and_wait("OWNER_READY", Duration::from_secs(10));
+
+    let mut contender = MirrorProcess::start(&home_b.path, &pane, &remote_bin);
+    contender.wait_for("--- frame", Duration::from_secs(10));
+    contender.write("printf 'MUST_NOT_RUN\\n'\r");
+    std::thread::sleep(Duration::from_secs(3));
+    owner.write_and_wait("OWNER_STILL_WRITABLE", Duration::from_secs(10));
+
+    let screen = String::from_utf8(direct_ssh(
+        &target,
+        &format!(
+            "{} pane read {} --lines 200",
+            shell_quote(&remote_bin),
+            shell_quote(&pane)
+        ),
+    ))
+    .expect("remote pane text");
+    assert!(!screen.contains("MUST_NOT_RUN"), "contender input reached owner pane");
+
+    contender.stop();
+    owner.stop();
+    proxy.stop();
+}
+
+fn required(name: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| panic!("{name} must be set"))
+}
+
+fn direct_ssh(target: &str, command: &str) -> Vec<u8> {
+    let output = Command::new("ssh")
+        .args(["-o", "BatchMode=yes", target, command])
+        .output()
+        .expect("direct ssh command");
+    assert!(
+        output.status.success(),
+        "direct ssh failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn stream_attempts(home: &Path) -> usize {
+    std::fs::read_to_string(home.join("ssh-invocations.log"))
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| line.contains("terminal session"))
+        .count()
+}
+
+struct SshTarget {
+    address: SocketAddr,
+    user: String,
+    identities: Vec<PathBuf>,
+    ssh_program: PathBuf,
+}
+
+impl SshTarget {
+    fn resolve(target: &str) -> Self {
+        let which = Command::new("which").arg("ssh").output().expect("which ssh");
+        assert!(which.status.success(), "ssh executable not found");
+        let ssh_program = PathBuf::from(
+            String::from_utf8(which.stdout)
+                .expect("ssh path utf8")
+                .trim(),
+        );
+        let output = Command::new(&ssh_program)
+            .args(["-G", target])
+            .output()
+            .expect("ssh -G");
+        assert!(output.status.success(), "ssh -G failed");
+        let mut hostname = None;
+        let mut port = 22_u16;
+        let mut user = None;
+        let mut identities = Vec::new();
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            let Some((key, value)) = line.split_once(' ') else {
+                continue;
+            };
+            match key {
+                "hostname" => hostname = Some(value.to_owned()),
+                "port" => port = value.parse().expect("ssh port"),
+                "user" => user = Some(value.to_owned()),
+                "identityfile" => {
+                    let path = expand_home(value);
+                    if path.exists() {
+                        identities.push(path);
+                    }
+                }
+                "proxycommand" if value != "none" => {
+                    panic!("proxycommand targets are not supported by this harness")
+                }
+                _ => {}
+            }
+        }
+        let hostname = hostname.expect("ssh hostname");
+        let address = (hostname.as_str(), port)
+            .to_socket_addrs()
+            .expect("resolve ssh host")
+            .next()
+            .expect("ssh address");
+        Self {
+            address,
+            user: user.expect("ssh user"),
+            identities,
+            ssh_program,
+        }
+    }
+
+    fn write_alias(&self, home: &Path, proxy: SocketAddr) {
+        let ssh_dir = home.join(".ssh");
+        std::fs::create_dir_all(&ssh_dir).unwrap();
+        let mut config = format!(
+            "Host herdr-reconnect-e2e\n  HostName {}\n  Port {}\n  User {}\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null\n",
+            proxy.ip(),
+            proxy.port(),
+            self.user
+        );
+        for identity in &self.identities {
+            config.push_str(&format!("  IdentityFile {}\n", identity.display()));
+        }
+        std::fs::write(ssh_dir.join("config"), config).unwrap();
+        let bin_dir = home.join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let wrapper = bin_dir.join("ssh");
+        std::fs::write(
+            &wrapper,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}/ssh-invocations.log'\nexec '{}' -F '{}/.ssh/config' \"$@\"\n",
+                home.display(),
+                self.ssh_program.display(),
+                home.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&wrapper, std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+}
+
+fn expand_home(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        PathBuf::from(std::env::var("HOME").unwrap()).join(rest)
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+struct BlackholeProxy {
+    listener_address: SocketAddr,
+    accepted: Arc<AtomicU64>,
+    blackhole_through: Arc<AtomicU64>,
+    stop: Arc<AtomicBool>,
+    downstream_bytes_per_second: Arc<AtomicU64>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl BlackholeProxy {
+    fn start(remote: SocketAddr) -> Self {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let listener_address = listener.local_addr().unwrap();
+        let accepted = Arc::new(AtomicU64::new(0));
+        let blackhole_through = Arc::new(AtomicU64::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let downstream_bytes_per_second = Arc::new(AtomicU64::new(0));
+        let thread = {
+            let accepted = Arc::clone(&accepted);
+            let blackhole_through = Arc::clone(&blackhole_through);
+            let stop = Arc::clone(&stop);
+            let downstream_bytes_per_second = Arc::clone(&downstream_bytes_per_second);
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::Acquire) {
+                    match listener.accept() {
+                        Ok((client, _)) => {
+                            let id = accepted.fetch_add(1, Ordering::AcqRel) + 1;
+                            let server = TcpStream::connect(remote).expect("proxy connects remote");
+                            client.set_nonblocking(false).unwrap();
+                            server.set_nonblocking(false).unwrap();
+                            spawn_pump(
+                                client.try_clone().unwrap(),
+                                server.try_clone().unwrap(),
+                                id,
+                                Arc::clone(&blackhole_through),
+                                Arc::new(AtomicU64::new(0)),
+                            );
+                            spawn_pump(
+                                server,
+                                client,
+                                id,
+                                Arc::clone(&blackhole_through),
+                                Arc::clone(&downstream_bytes_per_second),
+                            );
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(error) => panic!("proxy accept: {error}"),
+                    }
+                }
+            })
+        };
+        Self {
+            listener_address,
+            accepted,
+            blackhole_through,
+            stop,
+            downstream_bytes_per_second,
+            thread: Some(thread),
+        }
+    }
+
+    fn address(&self) -> SocketAddr {
+        self.listener_address
+    }
+
+    fn set_downstream_rate(&self, bytes_per_second: u64) {
+        self.downstream_bytes_per_second
+            .store(bytes_per_second, Ordering::Release);
+    }
+
+    fn blackhole_existing(&self) -> u64 {
+        let mut through = self.accepted.load(Ordering::Acquire);
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            std::thread::sleep(Duration::from_millis(250));
+            let current = self.accepted.load(Ordering::Acquire);
+            if current == through || Instant::now() >= deadline {
+                break;
+            }
+            through = current;
+        }
+        assert!(through > 0, "no established SSH connection to blackhole");
+        self.blackhole_through.store(through, Ordering::Release);
+        through
+    }
+
+    fn wait_for_new_connection(&self, previous: u64, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while self.accepted.load(Ordering::Acquire) <= previous {
+            assert!(Instant::now() < deadline, "mirror did not dial replacement SSH");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn stop(mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            thread.join().unwrap();
+        }
+    }
+}
+
+fn spawn_pump(
+    mut source: TcpStream,
+    mut destination: TcpStream,
+    id: u64,
+    blackhole_through: Arc<AtomicU64>,
+    bytes_per_second: Arc<AtomicU64>,
+) {
+    std::thread::spawn(move || {
+        let mut bytes = [0_u8; 16 * 1024];
+        loop {
+            let count = match source.read(&mut bytes) {
+                Ok(0) | Err(_) => return,
+                Ok(count) => count,
+            };
+            if id <= blackhole_through.load(Ordering::Acquire) {
+                continue;
+            }
+            let bytes_per_second = bytes_per_second.load(Ordering::Acquire);
+            if bytes_per_second > 0 {
+                std::thread::sleep(Duration::from_secs_f64(
+                    count as f64 / bytes_per_second as f64,
+                ));
+            }
+            if destination.write_all(&bytes[..count]).is_err() {
+                return;
+            }
+        }
+    });
+}
+
+struct MirrorProcess {
+    child: Child,
+    stdin: std::process::ChildStdin,
+    lines: mpsc::Receiver<String>,
+}
+
+impl MirrorProcess {
+    fn start(home: &Path, pane: &str, remote_bin: &str) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_herdr-mirror"))
+            .args([
+                "pane",
+                "herdr-reconnect-e2e",
+                pane,
+                "--dump",
+                "--always-control",
+                "--terminal-reconnect",
+                "--remote-bin",
+                remote_bin,
+            ])
+            .env("HOME", home)
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    home.join("bin").display(),
+                    std::env::var("PATH").unwrap_or_default()
+                ),
+            )
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let (line_tx, lines) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                let _ = line_tx.send(line);
+            }
+        });
+        Self {
+            child,
+            stdin,
+            lines,
+        }
+    }
+
+    fn write_and_wait(&mut self, marker: &str, timeout: Duration) {
+        self.write_command_and_wait(&format!("printf '{marker}\\n'"), marker, timeout);
+    }
+
+    fn write_command_and_wait(&mut self, command: &str, marker: &str, timeout: Duration) {
+        self.write(&format!("{command}\r"));
+        self.wait_for(marker, timeout);
+    }
+
+    fn write(&mut self, input: &str) {
+        self.stdin.write_all(input.as_bytes()).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    fn wait_for(&mut self, marker: &str, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            assert!(!remaining.is_zero(), "did not observe marker {marker}");
+            let line = self.lines.recv_timeout(remaining).expect("mirror output closed");
+            if line.contains(marker) {
+                return;
+            }
+        }
+    }
+
+    fn stop(&mut self) {
+        unsafe {
+            libc::kill(self.child.id() as i32, libc::SIGTERM);
+        }
+        let _ = self.child.wait();
+    }
+}
+
+struct TempHome {
+    path: PathBuf,
+}
+
+impl TempHome {
+    fn new(label: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "herdr-mirror-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}


### PR DESCRIPTION
## Why

Laptop sleep and abrupt network transitions can leave an SSH process alive but unable to move bytes. A mirrored pane then looks connected while its remote terminal claim is stale: output can freeze, input can disappear, and recovery may require killing processes or blindly taking control from another legitimate client.

This PR makes that failure bounded and automatically recoverable. It also protects the opposite case: another installation or human controller is never silently displaced.

## What changed

- Enable reconnect behavior only when the remote client and running server advertise compatible protocol 22 support and `terminal_session_reconnect_v1`.
- Derive the machine-bound controller identity inside pane mode, keeping the raw ID out of the local pane argv and `pane.process_info`.
- Persist a compare-and-swap claim token plus a monotonic attempt generation per remote pane. Tokens reclaim the exact stale claim; generations reject delayed older dials and recover when a replacement's ready record was lost.
- Add bidirectional heartbeats, exact wake-probe nonce matching, wall/monotonic suspend detection, ready/ack deadlines, a 30-second rapid wake-retry window, and supervised SSH child cancellation/reaping.
- Preserve always-control intent across protocol-22 transport failures. Only real ownership collisions can make a pane sticky read-only.
- Hold all control input until `terminal.ready`, then drain the bounded 64 KiB/10-second buffer once. Child-stdin writes now have deadlines, so a half-open pipe cannot stall the event loop.
- Validate frame sequence continuity and request a full resync on gaps. Herdr's companion helper prioritizes lifecycle/heartbeat envelopes and atomically replaces invalid queued deltas with the forced full frame.
- Replace lossy PID filenames with injective process-lifetime locks, coordinated stale-lock/token collection, pre-truncate metadata validation, and one-release legacy PID compatibility.
- Defer healing when capability probing is unknown instead of permanently creating an unprotected legacy streamer.
- Keep legacy Herdr safe: automatic takeover remains off by default, watch-only never takes over, and opt-in takeover retains cooldown/anti-oscillation guards.

## Compatibility

Older Herdr versions stay on the safe legacy terminal-session path. Protocol 22 is intentionally required because the reconnect claim carries new wire fields. A remote downgrade is detected from rejected reconnect flags and falls back to safe legacy mode instead of looping forever.

The companion server implementation is available on [timsuchanek/herdr `fix/terminal-session-reconnect`](https://github.com/timsuchanek/herdr/tree/fix/terminal-session-reconnect).

## Verification

- `cargo test --locked`: 178 passed, 2 environment-gated relay tests ignored.
- `cargo clippy --all-targets -- -D warnings`: clean.
- Three process-level half-open tests passed, including ten replacements: 4.993s lost-ack recovery, 5.679s ready-timeout recovery, and 43.712s for ten cycles with one steady-state SSH child and zero after shutdown.
- New real-SSH/TCP-proxy harness against Herdr protocol 22 on `timdev3`:
  - ten established connections blackholed permanently without FIN/RST;
  - every automatically spawned replacement became writable within 10 seconds;
  - a 4,000-line burst at 32 KiB/s caused no false reconnect;
  - lease+1 cleanup left zero client/claim/lease state and zero remote helper processes;
  - a different installation was rejected while the original controller remained writable.
- Companion Herdr branch: 3,507/3,507 applicable tests passed under nextest; clippy clean. One process-detection test fails identically at the upstream merge base on this Linux host, and one unrelated deep-scrollback test was excluded after consuming a CPU for more than ten minutes.
- Fleet canary: `timdev2` recovered a stopped live SSH child automatically in 3 seconds; the replacement used the previous claim token and generation 2.

Closes #64
Related: [herdrdev/herdr#2997](https://github.com/herdrdev/herdr/issues/2997)
