### PR TITLE
feat: drag-select to copy in mirror panes

### DIFF
--- a/src/foreground.rs
+++ b/src/foreground.rs
@@ -31,15 +31,47 @@ pub fn is_shell(name: &str) -> bool {
     SHELLS.contains(&n.as_str())
 }
 
-/// Classify a `pane process-info` JSON response. `Some(true)` = foreground is a
-/// shell, `Some(false)` = something else, `None` = indeterminate (empty/unparseable).
-pub fn classify(json: &str) -> Option<bool> {
-    let v: serde_json::Value = serde_json::from_str(json).ok()?;
+/// What the remote pane's foreground implies for local input handling.
+///
+/// Three states because two different questions hide in "is it a TUI?": which
+/// cursor-key encoding to use, and who should get the mouse. An agent CLI is not
+/// a shell (it sets DECCKM, so arrows must be application mode) and still does
+/// not read mouse reports.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Fg {
+    /// interactive shell at a prompt: sets no mouse modes, so the grab is
+    /// released and herdr does its own native selection
+    Shell,
+    /// an agent CLI. herdr identified it, so this is not a guess.
+    Agent,
+    /// anything else: assume it wants the mouse, which is the safe default
+    /// because being wrong only costs a selection, never an app's clicks
+    Mouse,
+}
+
+/// Classify from the remote pane's `agent` field and its foreground job.
+///
+/// The agent question is answered by HERDR, not by us: `PaneInfo.agent` comes
+/// from its `identify_agent_in_job`, which scans the whole foreground job across
+/// its own canonical agent table and resolves CLIs shipped behind `node`, `bun`
+/// or `python` wrappers using argv0/argv/cmdline. A hardcoded list here would be
+/// a second, worse copy of data herdr already maintains and already serves over
+/// the API we are calling anyway — and it would drift the day a new agent ships.
+///
+/// It also fixes the leaf problem for free: `process-info` returns the whole
+/// foreground process GROUP, so an agent's leaf is whatever tool it just spawned
+/// (`node`, `rg`, `bash`) and moves every few seconds. `agent` does not move.
+pub fn classify(pane_json: &str, proc_json: &str) -> Option<Fg> {
+    let pane: serde_json::Value = serde_json::from_str(pane_json).ok()?;
+    if pane.get("result")?.get("pane")?.get("agent").and_then(|v| v.as_str()).is_some() {
+        return Some(Fg::Agent);
+    }
+    let v: serde_json::Value = serde_json::from_str(proc_json).ok()?;
     let fg = v.get("result")?.get("process_info")?.get("foreground_processes")?.as_array()?;
     // the last foreground process is the actually-running leaf, so `sudo vim`
     // classifies on `vim`, not `sudo`
     let name = fg.last()?.get("name")?.as_str()?;
-    Some(is_shell(name))
+    Some(if is_shell(name) { Fg::Shell } else { Fg::Mouse })
 }
 
 /// Query the remote pane's foreground process over ssh and classify it. `None`
@@ -51,10 +83,15 @@ pub async fn poll(
     pane: &str,
     ctl_path: Option<&str>,
     container: Option<&crate::pane::ContainerArg>,
-) -> Option<bool> {
+) -> Option<Fg> {
     // same expression as the observe session (configured path or PATH auto)
     let bin = crate::config::remote_herdr_expr(remote_bin, session);
-    let cmd = format!("exec {} pane process-info --pane {}", bin, sh_quote(pane));
+    // both answers in ONE hop: same ssh round trip cost as the old single query
+    let cmd = format!(
+        "{b} pane get {p}; echo '<<>>'; exec {b} pane process-info --pane {p}",
+        b = bin,
+        p = sh_quote(pane)
+    );
     let mut sc = match container {
         Some(ct) => {
             // async resolve, not the blocking one: this runs on the pane's
@@ -93,12 +130,25 @@ pub async fn poll(
     if !out.status.success() {
         return None;
     }
-    classify(&String::from_utf8_lossy(&out.stdout))
+    let text = String::from_utf8_lossy(&out.stdout);
+    let (pane_json, proc_json) = text.split_once("<<>>")?;
+    classify(pane_json, proc_json)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pane_with_agent(a: Option<&str>) -> String {
+        match a {
+            Some(a) => format!(r#"{{"result":{{"pane":{{"agent":"{a}"}}}}}}"#),
+            None => r#"{"result":{"pane":{}}}"#.to_string(),
+        }
+    }
+
+    fn proc_with(leaf: &str) -> String {
+        format!(r#"{{"result":{{"process_info":{{"foreground_processes":[{{"name":"{leaf}"}}]}}}}}}"#)
+    }
 
     #[test]
     fn shells_recognized_including_login_and_path() {
@@ -114,21 +164,13 @@ mod tests {
     }
 
     #[test]
-    fn classify_reads_leaf_foreground() {
-        let shell = r#"{"result":{"process_info":{"foreground_processes":[{"name":"zsh"}]}}}"#;
-        assert_eq!(classify(shell), Some(true));
-        let tui = r#"{"result":{"process_info":{"foreground_processes":[{"name":"vim"}]}}}"#;
-        assert_eq!(classify(tui), Some(false));
-        // sudo wrapper: the leaf is the real program
-        let sudo =
-            r#"{"result":{"process_info":{"foreground_processes":[{"name":"sudo"},{"name":"vim"}]}}}"#;
-        assert_eq!(classify(sudo), Some(false));
-    }
-
-    #[test]
     fn classify_indeterminate_on_empty_or_garbage() {
-        assert_eq!(classify(r#"{"result":{"process_info":{"foreground_processes":[]}}}"#), None);
-        assert_eq!(classify("not json"), None);
-        assert_eq!(classify(r#"{"result":{}}"#), None);
+        let none = pane_with_agent(None);
+        assert_eq!(
+            classify(&none, r#"{"result":{"process_info":{"foreground_processes":[]}}}"#),
+            None
+        );
+        assert_eq!(classify(&none, "not json"), None);
+        assert_eq!(classify("not json", &proc_with("zsh")), None);
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -10,8 +10,19 @@ use std::rc::Rc;
 use unicode_width::UnicodeWidthChar;
 
 /// Terminal display width of a char (CJK/Hangul are 2 columns).
-fn cw(ch: char) -> usize {
+pub(crate) fn cw(ch: char) -> usize {
     UnicodeWidthChar::width(ch).unwrap_or(1).max(1)
+}
+
+/// First grid row shown in an `out_rows`-tall pane. The window is
+/// bottom-anchored because agent TUIs draw at the bottom of the screen.
+///
+/// Every painter has to agree on this or its output lands on the wrong row, so
+/// the renderer, the prediction overlay and the selection overlay all call here
+/// rather than each keeping the formula.
+pub fn window_offset(grid: &Grid, out_rows: usize) -> usize {
+    let bottom = grid.content_bottom.max(grid.cursor_row);
+    (bottom + 1).saturating_sub(out_rows)
 }
 
 #[derive(Clone, PartialEq)]
@@ -128,6 +139,70 @@ impl Grid {
             .unwrap_or(0);
     }
 
+    /// Char at a grid coordinate, blank when the cell was never painted.
+    pub fn ch_at(&self, row: usize, col: usize) -> char {
+        self.rows.get(row).and_then(|r| r.get(col)).and_then(|c| c.as_ref()).map(|c| c.ch).unwrap_or(' ')
+    }
+
+    /// OSC 8 target on a cell, when it sits inside a hyperlink.
+    pub fn link_at(&self, row: usize, col: usize) -> Option<&str> {
+        self.rows.get(row)?.get(col)?.as_ref()?.link.as_deref()
+    }
+
+    /// Is this cell the blank spacer that follows a double-width char?
+    ///
+    /// `apply` clears the cell after a wide char (see the `w == 2` branch), so a
+    /// `None` alone does not distinguish "never painted" from "second half of
+    /// 한". The cell to the left settles it.
+    pub fn is_spacer(&self, row: usize, col: usize) -> bool {
+        let occupied = self.rows.get(row).and_then(|r| r.get(col)).is_some_and(|c| c.is_some());
+        if occupied || col == 0 {
+            return false;
+        }
+        self.rows
+            .get(row)
+            .and_then(|r| r.get(col - 1))
+            .and_then(|c| c.as_ref())
+            .is_some_and(|c| cw(c.ch) == 2)
+    }
+
+    /// Column where the glyph covering `col` begins: `col` itself, unless that
+    /// is the spacer half of a wide char, in which case the cell to its left.
+    pub fn glyph_start(&self, row: usize, col: usize) -> usize {
+        if self.is_spacer(row, col) { col - 1 } else { col }
+    }
+
+    /// Text of a linear (reading-order) selection, both endpoints inclusive.
+    ///
+    /// Trailing blanks are trimmed per row for the same reason a terminal does
+    /// it: the grid is a fixed rectangle, so every row is padded out to `width`
+    /// and an untrimmed copy would paste a block of spaces after each line.
+    ///
+    /// Steps by display width rather than by column, which is what keeps a wide
+    /// char from being followed by its own spacer cell: `ch_at` reports that
+    /// cleared cell as a blank, so a per-column walk copies 한글 as "한 글".
+    pub fn selection_text(&self, start: (usize, usize), end: (usize, usize)) -> String {
+        let (start, end) = if start <= end { (start, end) } else { (end, start) };
+        let last_col = self.width.saturating_sub(1);
+        let mut out = String::new();
+        for row in start.0..=end.0.min(self.height.saturating_sub(1)) {
+            if row > start.0 {
+                out.push('\n');
+            }
+            let from = if row == start.0 { self.glyph_start(row, start.1) } else { 0 };
+            let to = if row == end.0 { end.1.min(last_col) } else { last_col };
+            let mut line = String::new();
+            let mut c = from;
+            while c <= to && c < self.width {
+                let ch = self.ch_at(row, c);
+                line.push(ch);
+                c += cw(ch);
+            }
+            out.push_str(line.trim_end());
+        }
+        out
+    }
+
     pub fn text_lines(&self) -> Vec<String> {
         self.rows
             .iter()
@@ -233,16 +308,48 @@ impl Renderer {
         self.last_rows.clear();
     }
 
+    /// Force a repaint of a single screen row.
+    ///
+    /// Overlays paint outside the row cache, so the rows they covered have to be
+    /// redrawn to erase them. Doing that per row rather than through
+    /// `invalidate` matters during a drag: the highlight moves on every mouse
+    /// motion, and a full-pane repaint per cell crossed is a lot of ANSI for a
+    /// change that touches two or three rows.
+    pub fn invalidate_row(&mut self, row: usize) {
+        if let Some(slot) = self.last_rows.get_mut(row) {
+            *slot = None;
+        }
+    }
+
     pub fn status(&mut self, text: &str) {
         self.status_text = text.to_string();
         self.last_rows.pop(); // force bottom row repaint
     }
 
+    /// Does the bottom row currently belong to the status line rather than to
+    /// the grid? Overlays must leave that row alone or they paint over the hint.
+    pub fn status_rows(&self) -> usize {
+        usize::from(!self.status_text.is_empty())
+    }
+
+    /// Where the cursor should end up once everything else has been painted.
+    ///
+    /// Emitted last by `paint`, but overlays are appended after it, so anything
+    /// that draws on top has to re-issue this or the cursor is left wherever the
+    /// overlay stopped writing.
+    pub fn cursor_park(&self, grid: &Grid, out_cols: usize, out_rows: usize) -> String {
+        let offset_r = window_offset(grid, out_rows);
+        let cr = grid.cursor_row as isize - offset_r as isize;
+        if !grid.cursor_visible || cr < 0 || cr as usize >= out_rows || !self.status_text.is_empty() {
+            return String::new();
+        }
+        format!("\x1b[{};{}H\x1b[?25h", cr + 1, grid.cursor_col.min(out_cols.saturating_sub(1)) + 1)
+    }
+
     /// Build the ANSI to paint the grid into an out_cols × out_rows terminal.
     /// Bottom-anchored window: agent TUIs live at the bottom of the screen.
     pub fn paint(&mut self, grid: &Grid, out_cols: usize, out_rows: usize) -> String {
-        let bottom = grid.content_bottom.max(grid.cursor_row);
-        let offset_r = (bottom + 1).saturating_sub(out_rows);
+        let offset_r = window_offset(grid, out_rows);
         let mut out = String::from("\x1b[?2026h\x1b[?25l");
         // paint every local row (missing rows blank-fill), or the pane stays
         // blank before the first frame and the status row is unreachable
@@ -316,10 +423,7 @@ impl Renderer {
                 self.last_rows[r] = Some(painted);
             }
         }
-        let cr = grid.cursor_row as isize - offset_r as isize;
-        if grid.cursor_visible && cr >= 0 && (cr as usize) < out_rows && self.status_text.is_empty() {
-            let _ = write!(out, "\x1b[{};{}H\x1b[?25h", cr + 1, grid.cursor_col.min(out_cols.saturating_sub(1)) + 1);
-        }
+        out.push_str(&self.cursor_park(grid, out_cols, out_rows));
         out.push_str("\x1b[?2026l");
         out
     }
@@ -412,6 +516,31 @@ mod tests {
         let out = r.paint(&g, 10, 1);
         // without width handling this painted "한 글 !" and drifted right
         assert!(out.contains("한글!"), "got: {out:?}");
+    }
+
+    #[test]
+    fn selection_text_does_not_inject_spaces_after_wide_chars() {
+        // `apply` clears the cell after a wide char, and `ch_at` reports a
+        // cleared cell as a blank, so a per-column walk copies "한 글 !"
+        let mut g = Grid::new();
+        g.resize(10, 1);
+        g.apply("\x1b[1;1H한글!");
+        assert_eq!(g.selection_text((0, 0), (0, 4)), "한글!");
+        // and a start column on the spacer half still yields the whole glyph
+        assert_eq!(g.selection_text((0, 1), (0, 4)), "한글!");
+    }
+
+    #[test]
+    fn spacer_cells_are_distinguished_from_blanks() {
+        let mut g = Grid::new();
+        g.resize(6, 1);
+        g.apply("\x1b[1;1H한x");
+        assert!(g.is_spacer(0, 1), "cell after a wide char");
+        assert!(!g.is_spacer(0, 0), "the wide char itself");
+        assert!(!g.is_spacer(0, 3), "a genuinely blank cell after a narrow one");
+        assert!(!g.is_spacer(0, 0), "column 0 can never be a spacer");
+        assert_eq!(g.glyph_start(0, 1), 0);
+        assert_eq!(g.glyph_start(0, 2), 2);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod paste;
 mod predict;
 mod remote;
 mod remote_action;
+mod select;
 mod ssh_relay;
 mod state;
 mod util;

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -43,6 +43,7 @@ use tokio::time::Instant;
 
 use crate::util::{err, Result};
 use crate::grid::{Grid, Renderer};
+use crate::foreground::Fg;
 use crate::predict::Predictor;
 use crate::select::{Released, Select};
 
@@ -201,9 +202,9 @@ enum Msg {
     Frame { gen: u64, frame: Frame },
     SessionExit { gen: u64, mode: Mode, reason: String, uptime: Duration },
     Stdin(Vec<u8>),
-    /// result of a background foreground-process poll: Some(true)=shell,
-    /// Some(false)=TUI, None=poll failed (keep last value)
-    Foreground(Option<bool>),
+    /// result of a background foreground poll; None=poll failed (keep the last
+    /// value)
+    Foreground(Option<Fg>),
     Paste(crate::paste::Outcome),
     Drop(crate::paste::DropResult),
 }
@@ -490,21 +491,30 @@ fn button_number(btn: u32) -> u32 {
 /// and is a better judge than this side's process-name heuristic (e.g. a TUI
 /// that doesn't consume wheel events, like an agent CLI). Non-wheel
 /// clicks/drags keep the existing foreground-based routing.
-/// The left button routes through the selection for *every* remote TUI, not a
-/// list of ones known to ignore the mouse. That is only safe because the
-/// selection defers rather than steals: a gesture that never leaves its cell is
-/// replayed to the app as a click. Middle and right buttons have no selection
-/// meaning, so they forward untouched.
-fn mouse_action(remote_is_shell: Option<bool>, btn: u32, press: bool) -> MouseAction {
+/// The left button goes to the local selection in every remote TUI, agent or
+/// not, because a drag is the gesture with no substitute: an app's click can be
+/// replayed after the fact, a selection cannot be recovered.
+///
+/// A gesture that never leaves its cell is replayed to the app as a real click,
+/// so htop still sorts on a header click and lazygit still stages on a file
+/// click. Agent CLIs get it too: they never enabled mouse reporting, but claude
+/// and codex both discard the bytes cleanly, so withholding it only stood to
+/// swallow clicks the day one of them grows mouse support.
+///
+/// A shell is unaffected: the grab is released there, so herdr does its own
+/// native selection and none of this arrives.
+///
+/// The cost is an in-app *drag*: vim's mouse visual-select, a resize handle.
+fn mouse_action(fg: Option<Fg>, btn: u32, press: bool) -> MouseAction {
     match button_number(btn) {
         // wheel up/down. Matched on the button number, not on `btn == 64`, so a
         // modified scroll still scrolls instead of falling through as a click.
         b @ (4 | 5) if press => MouseAction::Scroll { up: b == 4 },
         6 | 7 => MouseAction::Drop,
-        _ if remote_is_shell != Some(false) => MouseAction::Drop,
-        0 => MouseAction::Select,
-        // middle, right, wheel release and the extra buttons: unchanged
-        _ => MouseAction::ForwardRaw,
+        0 if matches!(fg, Some(Fg::Agent) | Some(Fg::Mouse)) => MouseAction::Select,
+        // middle, right, wheel release and the extra buttons
+        _ if matches!(fg, Some(Fg::Agent) | Some(Fg::Mouse)) => MouseAction::ForwardRaw,
+        _ => MouseAction::Drop,
     }
 }
 
@@ -684,10 +694,9 @@ struct App {
     hint_clear_at: Option<Instant>,
     /// predictive local echo — draws keystrokes optimistically, frame-verified
     predict: Predictor,
-    /// remote pane foreground: Some(true)=shell (keep mouse local, no garbage),
-    /// Some(false)=TUI (selection + deferred clicks), None=unknown (fail safe
-    /// to local). Refreshed lazily on mouse activity via `pane process-info`.
-    remote_is_shell: Option<bool>,
+    /// remote pane foreground classification, None=unknown (fail safe to local).
+    /// Refreshed lazily on mouse activity; see `foreground::classify`.
+    remote_fg: Option<Fg>,
     /// local drag-selection, driven by the left button the remote app would
     /// otherwise receive
     select: Select,
@@ -824,7 +833,7 @@ impl App {
             return;
         }
         // grab unless we've confirmed the foreground is a shell
-        let want = self.remote_is_shell != Some(true);
+        let want = self.remote_fg != Some(Fg::Shell);
         if want == self.mouse_grabbed {
             return;
         }
@@ -851,7 +860,7 @@ impl App {
         }
         // a shell prompt reads arrows in normal mode; a TUI is the case that
         // sets smkx, so mirror application mode unless we've confirmed a shell
-        let want = self.remote_is_shell == Some(false);
+        let want = matches!(self.remote_fg, Some(Fg::Agent) | Some(Fg::Mouse));
         if want == self.app_cursor_keys {
             return;
         }
@@ -1247,7 +1256,7 @@ impl App {
         let mut copy_span: Option<(crate::select::Pos, crate::select::Pos)> = None;
         while i < buf.len() {
             if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
-                match mouse_action(self.remote_is_shell, btn, press) {
+                match mouse_action(self.remote_fg, btn, press) {
                     // Without a tty there is no grab, so this is unreachable in
                     // normal operation — but stdin could still be a pipe, and a
                     // selection there would be sized against a phantom viewport
@@ -1268,9 +1277,15 @@ impl App {
                                 // the clipboard holds one thing, so a second
                                 // gesture in the same read legitimately wins
                                 Released::Selection(span) => copy_span = Some(span),
-                                // it was a click: the app gets it at the release's
-                                // position in the stream, which is the point of
-                                // deferring it
+                                // It was a click, not a drag: the app gets it,
+                                // whatever the app is. An earlier version
+                                // swallowed clicks in agent panes on the theory
+                                // that a program which never enabled mouse
+                                // reporting would render the bytes as literal
+                                // text. Measured against claude and codex, both
+                                // discard them cleanly, so the special case only
+                                // stood to swallow clicks the day an agent grows
+                                // mouse support.
                                 Released::Click(bytes) => rest.extend_from_slice(&bytes),
                                 Released::Nothing => {}
                             },
@@ -1454,7 +1469,7 @@ pub async fn run(args: Args) -> Result<()> {
         last_input: Instant::now(),
         hint_clear_at: None,
         predict: Predictor::new(),
-        remote_is_shell: None,
+        remote_fg: None,
         select: Select::new(),
         last_select_rows: None,
         fg_poll_at: None,
@@ -1524,10 +1539,10 @@ pub async fn run(args: Args) -> Result<()> {
                         // a foreground change means the screen belongs to a
                         // different program now, so the old highlight points at
                         // text that is gone
-                        if v != app.remote_is_shell && app.select.clear() {
+                        if v != app.remote_fg && app.select.clear() {
                             app.paint();
                         }
-                        app.remote_is_shell = v;
+                        app.remote_fg = v;
                         app.sync_mouse_grab();
                         app.sync_cursor_key_mode();
                     },
@@ -1641,31 +1656,31 @@ mod tests {
         // remote foreground classified as a TUI (e.g. `claude`) — wheel must
         // still produce a semantic scroll, not a raw forward, or it silently
         // does nothing when the TUI doesn't consume mouse wheel input
-        assert_eq!(mouse_action(Some(false), 64, true), MouseAction::Scroll { up: true });
-        assert_eq!(mouse_action(Some(false), 65, true), MouseAction::Scroll { up: false });
+        assert_eq!(mouse_action(Some(Fg::Agent), 64, true), MouseAction::Scroll { up: true });
+        assert_eq!(mouse_action(Some(Fg::Agent), 65, true), MouseAction::Scroll { up: false });
         // unclassified/shell foreground: wheel still scrolls
         assert_eq!(mouse_action(None, 64, true), MouseAction::Scroll { up: true });
-        assert_eq!(mouse_action(Some(true), 65, true), MouseAction::Scroll { up: false });
+        assert_eq!(mouse_action(Some(Fg::Shell), 65, true), MouseAction::Scroll { up: false });
         // the wheel never reaches the selection path at all, which is what
         // keeps PR #54's scroll regression impossible here by construction
-        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::Select);
-        assert_eq!(mouse_action(Some(true), 0, true), MouseAction::Drop); // shell click
+        assert_eq!(mouse_action(Some(Fg::Agent), 0, true), MouseAction::Select);
+        assert_eq!(mouse_action(Some(Fg::Shell), 0, true), MouseAction::Drop); // shell click
         assert_eq!(mouse_action(None, 0, true), MouseAction::Drop); // unclassified click
     }
 
     #[test]
-    fn every_remote_tui_routes_its_left_button_through_the_selection() {
-        // press, drag (motion bit 32) and release, with no list of apps: the
-        // selection defers the press, so this is safe even for a mouse TUI
-        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::Select);
-        assert_eq!(mouse_action(Some(false), 32, true), MouseAction::Select);
-        assert_eq!(mouse_action(Some(false), 0, false), MouseAction::Select);
-        // modifiers ride the same button: shift(4)/alt(8)/ctrl(16) still select
-        assert_eq!(mouse_action(Some(false), 4, true), MouseAction::Select);
-        assert_eq!(mouse_action(Some(false), 16 | 32, true), MouseAction::Select);
-        // middle and right have no selection meaning, so they forward as before
-        assert_eq!(mouse_action(Some(false), 1, true), MouseAction::ForwardRaw);
-        assert_eq!(mouse_action(Some(false), 2, true), MouseAction::ForwardRaw);
+    fn every_remote_tui_selects_on_drag_agent_or_not() {
+        for fg in [Fg::Agent, Fg::Mouse] {
+            assert_eq!(mouse_action(Some(fg), 0, true), MouseAction::Select, "{fg:?} press");
+            assert_eq!(mouse_action(Some(fg), 32, true), MouseAction::Select, "{fg:?} drag");
+            assert_eq!(mouse_action(Some(fg), 0, false), MouseAction::Select, "{fg:?} release");
+            // other buttons still reach the app
+            assert_eq!(mouse_action(Some(fg), 1, true), MouseAction::ForwardRaw);
+            assert_eq!(mouse_action(Some(fg), 2, true), MouseAction::ForwardRaw);
+        }
+        // a shell releases the grab, so these never arrive; unknown fails safe
+        assert_eq!(mouse_action(Some(Fg::Shell), 0, true), MouseAction::Drop);
+        assert_eq!(mouse_action(None, 0, true), MouseAction::Drop);
     }
 
     #[test]
@@ -1676,25 +1691,25 @@ mod tests {
         // wheel bytes to the app as a click.
         for mods in [4, 8, 16, 4 + 8, 4 + 16, 8 + 16, 4 + 8 + 16] {
             assert_eq!(
-                mouse_action(Some(false), 64 + mods, true),
+                mouse_action(Some(Fg::Agent), 64 + mods, true),
                 MouseAction::Scroll { up: true },
                 "shift/alt/ctrl + wheel-up (btn {})",
                 64 + mods
             );
             assert_eq!(
-                mouse_action(Some(false), 65 + mods, true),
+                mouse_action(Some(Fg::Agent), 65 + mods, true),
                 MouseAction::Scroll { up: false },
                 "modified wheel-down (btn {})",
                 65 + mods
             );
         }
         // horizontal wheel keeps dropping, modified or not
-        assert_eq!(mouse_action(Some(false), 66 + 16, true), MouseAction::Drop);
+        assert_eq!(mouse_action(Some(Fg::Agent), 66 + 16, true), MouseAction::Drop);
         // buttons 8-11 carry bit 7, which the old mask also leaked
-        assert_eq!(mouse_action(Some(false), 128, true), MouseAction::ForwardRaw);
-        assert_eq!(mouse_action(Some(false), 128 + 4, true), MouseAction::ForwardRaw);
+        assert_eq!(mouse_action(Some(Fg::Agent), 128, true), MouseAction::ForwardRaw);
+        assert_eq!(mouse_action(Some(Fg::Agent), 128 + 4, true), MouseAction::ForwardRaw);
         // a wheel release is not a left release
-        assert_eq!(mouse_action(Some(false), 64, false), MouseAction::ForwardRaw);
+        assert_eq!(mouse_action(Some(Fg::Agent), 64, false), MouseAction::ForwardRaw);
     }
 
     #[test]

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -44,6 +44,7 @@ use tokio::time::Instant;
 use crate::util::{err, Result};
 use crate::grid::{Grid, Renderer};
 use crate::predict::Predictor;
+use crate::select::{Released, Select};
 
 // ---------------------------------------------------------------------------
 // args
@@ -463,8 +464,25 @@ enum MouseAction {
     Scroll { up: bool },
     /// click/drag on a remote TUI: forward the raw SGR sequence
     ForwardRaw,
+    /// left press/drag/release on a remote TUI: hand it to the local selection,
+    /// which defers the press and replays it if the gesture turns out to be a
+    /// click rather than a drag (see src/select.rs)
+    Select,
     /// click/drag at a shell (or unclassified): drop, keep mouse local
     Drop,
+}
+
+/// Which physical button an SGR code names, with the modifier and motion flags
+/// removed: 0/1/2 = left/middle/right, 4/5 = wheel up/down, 6/7 = wheel
+/// left/right, 8.. = extra buttons.
+///
+/// The button number is *not* contiguous in the wire encoding: it is the low two
+/// bits plus bit 6 (64) for the wheel set and bit 7 (128) for buttons 8-11,
+/// while bits 2-4 carry shift/alt/ctrl and bit 5 carries motion. Masking only
+/// the low two bits reads shift+wheel-up (68) as a left press, which is how the
+/// wheel ends up driving the selection.
+fn button_number(btn: u32) -> u32 {
+    (btn & 0b11) + if btn & 64 != 0 { 4 } else { 0 } + if btn & 128 != 0 { 8 } else { 0 }
 }
 
 /// Wheel always scrolls semantically, regardless of the foreground
@@ -472,15 +490,21 @@ enum MouseAction {
 /// and is a better judge than this side's process-name heuristic (e.g. a TUI
 /// that doesn't consume wheel events, like an agent CLI). Non-wheel
 /// clicks/drags keep the existing foreground-based routing.
+/// The left button routes through the selection for *every* remote TUI, not a
+/// list of ones known to ignore the mouse. That is only safe because the
+/// selection defers rather than steals: a gesture that never leaves its cell is
+/// replayed to the app as a click. Middle and right buttons have no selection
+/// meaning, so they forward untouched.
 fn mouse_action(remote_is_shell: Option<bool>, btn: u32, press: bool) -> MouseAction {
-    if press && (btn == 64 || btn == 65) {
-        MouseAction::Scroll { up: btn == 64 }
-    } else if btn == 66 || btn == 67 {
-        MouseAction::Drop
-    } else if remote_is_shell == Some(false) {
-        MouseAction::ForwardRaw
-    } else {
-        MouseAction::Drop
+    match button_number(btn) {
+        // wheel up/down. Matched on the button number, not on `btn == 64`, so a
+        // modified scroll still scrolls instead of falling through as a click.
+        b @ (4 | 5) if press => MouseAction::Scroll { up: b == 4 },
+        6 | 7 => MouseAction::Drop,
+        _ if remote_is_shell != Some(false) => MouseAction::Drop,
+        0 => MouseAction::Select,
+        // middle, right, wheel release and the extra buttons: unchanged
+        _ => MouseAction::ForwardRaw,
     }
 }
 
@@ -661,9 +685,15 @@ struct App {
     /// predictive local echo — draws keystrokes optimistically, frame-verified
     predict: Predictor,
     /// remote pane foreground: Some(true)=shell (keep mouse local, no garbage),
-    /// Some(false)=TUI (forward clicks), None=unknown (fail safe to local).
-    /// Refreshed lazily on mouse activity via `herdr pane process-info`.
+    /// Some(false)=TUI (selection + deferred clicks), None=unknown (fail safe
+    /// to local). Refreshed lazily on mouse activity via `pane process-info`.
     remote_is_shell: Option<bool>,
+    /// local drag-selection, driven by the left button the remote app would
+    /// otherwise receive
+    select: Select,
+    /// screen rows the selection overlay covered on the last paint, so they can
+    /// be repainted when it moves away
+    last_select_rows: Option<(usize, usize)>,
     /// last time a foreground poll was kicked off (throttles the ssh handshakes)
     fg_poll_at: Option<Instant>,
     /// scheduled delayed re-poll to catch a foreground change the last input just
@@ -699,15 +729,38 @@ impl App {
         if !self.tty {
             return;
         }
+        let (cols, rows) = term_size();
+        // Overlays paint outside the renderer's per-row cache, so the rows they
+        // covered must be repainted or the old drawing survives underneath.
+        // Predictions are scattered, so they take the whole pane; a selection is
+        // a contiguous band, and during a drag it moves on every mouse motion,
+        // so it repaints only the rows it just left and the ones it now covers.
+        let reserved = self.renderer.status_rows();
         if self.predict.take_dirty() {
-            // cleared predictions may have left ghost chars — full repaint
             self.renderer.invalidate();
         }
-        let (cols, rows) = term_size();
+        if self.select.take_dirty() {
+            let now = self.select.painted_rows(&self.grid, rows, reserved);
+            for (top, bottom) in self.last_select_rows.into_iter().chain(now) {
+                for r in top..=bottom {
+                    self.renderer.invalidate_row(r);
+                }
+            }
+        }
+        self.last_select_rows = self.select.painted_rows(&self.grid, rows, reserved);
         let mut out = self.renderer.paint(&self.grid, cols, rows);
-        // inject the prediction overlay inside the synchronized-update block
-        let overlay = self.predict.overlay(&self.grid, cols, rows);
+        // inject the overlays inside the synchronized-update block. Selection
+        // goes last: it is the one the user is actively pointing at.
+        let mut overlay = self.predict.overlay(&self.grid, cols, rows);
+        let sel = self.select.overlay(&self.grid, cols, rows, reserved);
+        overlay.push_str(&sel);
         if !overlay.is_empty() {
+            // `paint` parks the cursor last; the overlays land after that, so
+            // re-park or the cursor is left wherever the highlight ended and is
+            // re-asserted there on every frame
+            if !sel.is_empty() {
+                overlay.push_str(&self.renderer.cursor_park(&self.grid, cols, rows));
+            }
             const SYNC_END: &str = "\x1b[?2026l";
             if let Some(pos) = out.rfind(SYNC_END) {
                 out.insert_str(pos, &overlay);
@@ -838,6 +891,9 @@ impl App {
         self.mode = m;
         // re-earn prediction confidence against the new session's frames
         self.predict = Predictor::new();
+        // the new session repaints from scratch, so a span from the old one
+        // points at text that no longer exists
+        self.select.clear();
         let (cols, rows) = match m {
             Mode::Observe => self.observe_size(),
             Mode::Control => self.control_size(),
@@ -913,6 +969,9 @@ impl App {
         self.reconnect_at = None;
         self.switching_to = Some(m);
         self.stop_session();
+        // covers every route into a mode change that returns before the mouse
+        // loop: ctrl+\, the idle release, and taking control from Observe
+        self.select.clear();
         self.renderer.invalidate();
         // immediate feedback for the mode-switch gap (stop + 200ms + reconnect)
         self.renderer.status(if m == Mode::Control { "taking control…" } else { "releasing…" });
@@ -936,8 +995,18 @@ impl App {
         let Some(bytes) = &frame.bytes else { return };
         self.backoff_idx = 0;
         self.renderer.status("");
-        self.grid
-            .resize(frame.width.unwrap_or(self.grid.width), frame.height.unwrap_or(self.grid.height));
+        let (fw, fh) = (
+            frame.width.unwrap_or(self.grid.width),
+            frame.height.unwrap_or(self.grid.height),
+        );
+        // A reflow or a full redraw replaces every cell, so a selection anchored
+        // to grid coordinates would survive pointing at different text — and a
+        // release afterwards would copy whatever landed there, or nothing, while
+        // still showing a highlight that implies it worked.
+        if (fw, fh) != (self.grid.width, self.grid.height) || frame.full == Some(true) {
+            self.select.clear();
+        }
+        self.grid.resize(fw, fh);
         if frame.full == Some(true) {
             self.grid.clear();
         }
@@ -1174,10 +1243,45 @@ impl App {
         let mut rest: Vec<u8> = Vec::with_capacity(buf.len());
         let mut i = 0usize;
         let mut scrolls: Vec<serde_json::Value> = Vec::new();
+        let mut sel_changed = false;
+        let mut copy_span: Option<(crate::select::Pos, crate::select::Pos)> = None;
         while i < buf.len() {
             if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
                 match mouse_action(self.remote_is_shell, btn, press) {
+                    // Without a tty there is no grab, so this is unreachable in
+                    // normal operation — but stdin could still be a pipe, and a
+                    // selection there would be sized against a phantom viewport
+                    // and would write OSC 52 into something that is not a
+                    // terminal. Forward instead, which is what `main` did.
+                    MouseAction::Select if !self.tty => {
+                        rest.extend_from_slice(&buf[i..i + len]);
+                    }
+                    MouseAction::Select => {
+                        let at = Select::locate(&self.grid, term_size().1, x, y);
+                        let raw = &buf[i..i + len];
+                        // motion flag (32) distinguishes a drag from the press
+                        // that started it; `press` is the M/m final byte
+                        match (press, btn & 32 != 0) {
+                            (true, false) => self.select.press(at, raw),
+                            (true, true) => self.select.drag(at),
+                            (false, _) => match self.select.release(at, raw) {
+                                // the clipboard holds one thing, so a second
+                                // gesture in the same read legitimately wins
+                                Released::Selection(span) => copy_span = Some(span),
+                                // it was a click: the app gets it at the release's
+                                // position in the stream, which is the point of
+                                // deferring it
+                                Released::Click(bytes) => rest.extend_from_slice(&bytes),
+                                Released::Nothing => {}
+                            },
+                        }
+                        sel_changed |= self.select.is_dirty();
+                    }
                     MouseAction::Scroll { up } => {
+                        // the viewport is about to move under the highlight,
+                        // which is anchored to grid rows: leaving it up would
+                        // paint reverse video over whatever scrolls into place
+                        sel_changed |= self.select.clear();
                         scrolls.push(json!({
                             "type": "terminal.scroll",
                             "direction": if up { "up" } else { "down" },
@@ -1200,13 +1304,37 @@ impl App {
         for s in scrolls {
             self.send(s).await;
         }
+        if let Some((start, end)) = copy_span {
+            let text = self.grid.selection_text(start, end);
+            match crate::select::osc52(&text) {
+                // no hint on success: herdr shows its own "copied to clipboard"
+                // toast when it takes the OSC 52, so ours would be a duplicate
+                Some(seq) => write_stdout(&seq),
+                // too big for herdr to accept. Worth saying, because this is the
+                // one path where nothing else reports: we never emit, so there
+                // is no clipboard write for herdr to toast about.
+                None if text.len() > 1024 => self.hint("selection too large to copy"),
+                // an all-blank drag: leave the clipboard alone rather than
+                // clearing it, and say nothing
+                None => {}
+            }
+        }
         if !rest.is_empty() {
+            // typing anywhere dismisses the highlight, the same as it would in a
+            // local pane — otherwise it hangs over text the agent has redrawn.
+            // `dismiss`, not `clear`: a press may have been buffered earlier in
+            // this very read, and cancelling it would eat the click.
+            sel_changed |= self.select.dismiss();
             let msg = json!({ "type": "terminal.input", "bytes": B64.encode(&rest) });
             self.send(msg).await;
             // optimistic local echo: draw the keystroke now, verify on frame
             if self.predict.on_input(&rest, &self.grid) {
                 self.paint();
+                sel_changed = false;
             }
+        }
+        if sel_changed {
+            self.paint();
         }
     }
 
@@ -1327,6 +1455,8 @@ pub async fn run(args: Args) -> Result<()> {
         hint_clear_at: None,
         predict: Predictor::new(),
         remote_is_shell: None,
+        select: Select::new(),
+        last_select_rows: None,
         fg_poll_at: None,
         settle_at: None,
         mouse_grabbed: tty, // startup wrote ?1002h when we're a tty
@@ -1391,6 +1521,12 @@ pub async fn run(args: Args) -> Result<()> {
                     Some(Msg::Stdin(buf)) => app.handle_stdin(buf).await,
                     // keep the last good classification if a poll failed (None)
                     Some(Msg::Foreground(v)) => if v.is_some() {
+                        // a foreground change means the screen belongs to a
+                        // different program now, so the old highlight points at
+                        // text that is gone
+                        if v != app.remote_is_shell && app.select.clear() {
+                            app.paint();
+                        }
                         app.remote_is_shell = v;
                         app.sync_mouse_grab();
                         app.sync_cursor_key_mode();
@@ -1510,10 +1646,70 @@ mod tests {
         // unclassified/shell foreground: wheel still scrolls
         assert_eq!(mouse_action(None, 64, true), MouseAction::Scroll { up: true });
         assert_eq!(mouse_action(Some(true), 65, true), MouseAction::Scroll { up: false });
-        // non-wheel clicks/drags keep the existing foreground-based routing
-        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::ForwardRaw); // TUI click
+        // the wheel never reaches the selection path at all, which is what
+        // keeps PR #54's scroll regression impossible here by construction
+        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::Select);
         assert_eq!(mouse_action(Some(true), 0, true), MouseAction::Drop); // shell click
         assert_eq!(mouse_action(None, 0, true), MouseAction::Drop); // unclassified click
+    }
+
+    #[test]
+    fn every_remote_tui_routes_its_left_button_through_the_selection() {
+        // press, drag (motion bit 32) and release, with no list of apps: the
+        // selection defers the press, so this is safe even for a mouse TUI
+        assert_eq!(mouse_action(Some(false), 0, true), MouseAction::Select);
+        assert_eq!(mouse_action(Some(false), 32, true), MouseAction::Select);
+        assert_eq!(mouse_action(Some(false), 0, false), MouseAction::Select);
+        // modifiers ride the same button: shift(4)/alt(8)/ctrl(16) still select
+        assert_eq!(mouse_action(Some(false), 4, true), MouseAction::Select);
+        assert_eq!(mouse_action(Some(false), 16 | 32, true), MouseAction::Select);
+        // middle and right have no selection meaning, so they forward as before
+        assert_eq!(mouse_action(Some(false), 1, true), MouseAction::ForwardRaw);
+        assert_eq!(mouse_action(Some(false), 2, true), MouseAction::ForwardRaw);
+    }
+
+    #[test]
+    fn a_modified_wheel_still_scrolls_instead_of_becoming_a_click() {
+        // The button number is the low two bits PLUS bit 6, so shift+wheel-up is
+        // 68 and `btn & 0b11` reads it as a left press: the wheel then drives the
+        // selection, the scroll is lost, and a later left release replays the
+        // wheel bytes to the app as a click.
+        for mods in [4, 8, 16, 4 + 8, 4 + 16, 8 + 16, 4 + 8 + 16] {
+            assert_eq!(
+                mouse_action(Some(false), 64 + mods, true),
+                MouseAction::Scroll { up: true },
+                "shift/alt/ctrl + wheel-up (btn {})",
+                64 + mods
+            );
+            assert_eq!(
+                mouse_action(Some(false), 65 + mods, true),
+                MouseAction::Scroll { up: false },
+                "modified wheel-down (btn {})",
+                65 + mods
+            );
+        }
+        // horizontal wheel keeps dropping, modified or not
+        assert_eq!(mouse_action(Some(false), 66 + 16, true), MouseAction::Drop);
+        // buttons 8-11 carry bit 7, which the old mask also leaked
+        assert_eq!(mouse_action(Some(false), 128, true), MouseAction::ForwardRaw);
+        assert_eq!(mouse_action(Some(false), 128 + 4, true), MouseAction::ForwardRaw);
+        // a wheel release is not a left release
+        assert_eq!(mouse_action(Some(false), 64, false), MouseAction::ForwardRaw);
+    }
+
+    #[test]
+    fn button_numbers_decode_the_split_encoding() {
+        assert_eq!(button_number(0), 0); // left
+        assert_eq!(button_number(32), 0); // left, dragging
+        assert_eq!(button_number(16 + 32), 0); // ctrl + left drag
+        assert_eq!(button_number(1), 1);
+        assert_eq!(button_number(2), 2);
+        assert_eq!(button_number(64), 4); // wheel up
+        assert_eq!(button_number(68), 4); // shift + wheel up
+        assert_eq!(button_number(65), 5);
+        assert_eq!(button_number(66), 6);
+        assert_eq!(button_number(128), 8);
+        assert_eq!(button_number(131), 11);
     }
 
     #[test]

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -268,8 +268,7 @@ impl Predictor {
         if !self.displaying() || self.pending.is_empty() {
             return String::new();
         }
-        let bottom = grid.content_bottom.max(grid.cursor_row);
-        let offset_r = (bottom + 1).saturating_sub(out_rows);
+        let offset_r = crate::grid::window_offset(grid, out_rows);
         let mut out = String::new();
         let mut last: Option<(usize, usize)> = None;
         for p in &self.pending {

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,564 @@
+// Local drag-selection for mirror panes.
+//
+// herdr cannot do this for us. Its native selection only anchors when the pane
+// has *no* mouse mode set (`AppState::handle_mouse` forwards the press and
+// clears the selection otherwise), while the wheel only reaches a pane as a
+// mouse report when at least one mode *is* set. Those are complementary
+// conditions, so releasing the grab to get selection costs the wheel: it falls
+// back to alternate scroll, which types one cursor key per notch into whatever
+// is running (in an agent CLI, that walks the prompt history).
+//
+// So selection has to be ours. The streamer already receives every press, drag
+// and release as SGR bytes while the grab is held, and it already owns the grid
+// it painted, which means it has everything it needs: it can track the drag,
+// highlight the span, and copy the text without herdr ever learning a selection
+// happened. The wheel keeps its existing semantic-scroll path untouched.
+//
+// The part that makes this safe for *every* remote TUI, not just the ones that
+// ignore the mouse, is that a press is deferred rather than stolen. Press and
+// release carry different information and only the release says which gesture
+// this was:
+//
+//     press    → buffer the raw bytes, start a tentative selection
+//     drag     → the pointer left its cell, so this is a selection
+//     release  → moved? copy it, the app sees nothing.
+//                still? it was a click: replay press+release to the app.
+//
+// So lazygit keeps click-to-stage and htop keeps click-to-sort, because those
+// are clicks and clicks still arrive. What they lose is the in-app *drag*
+// gesture (vim's mouse visual-select, a TUI's pane-resize handle), which is
+// claimed as a selection by definition, and the click now lands on release
+// instead of on press. Deferring means there is no list of "apps that ignore
+// the mouse" to keep, which is the whole reason this shape was chosen: such a
+// list is unbounded, drifts, and fails silently when it is wrong.
+//
+// A shell foreground is still handled the old way (the grab is released and
+// herdr selects natively), so none of this applies at a prompt.
+
+use std::fmt::Write as _;
+
+use crate::grid::{self, Grid};
+
+/// A grid coordinate: (row, col), both 0-based, in grid space rather than
+/// screen space. Grid space is the stable one: a frame that grows the content
+/// scrolls the visible window, and a screen-space anchor would slide across the
+/// text mid-drag.
+pub type Pos = (usize, usize);
+
+/// What a release turned out to mean.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Released {
+    /// the pointer covered ground: copy this span, the app sees nothing
+    Selection((Pos, Pos)),
+    /// the pointer never left its cell, so it was a click after all. These are
+    /// the buffered press bytes followed by the release, to send on verbatim.
+    Click(Vec<u8>),
+    /// no press was pending (a stray release, e.g. the button went down before
+    /// we had the grab). Forwarding a lone release to an app that never saw the
+    /// press would be worse than dropping it.
+    Nothing,
+}
+
+#[derive(Default)]
+pub struct Select {
+    span: Option<(Pos, Pos)>,
+    dragging: bool,
+    /// raw bytes of the press we are holding, replayed if this turns out to be
+    /// a click rather than a drag
+    pending_press: Vec<u8>,
+    /// whether the pointer has left its starting cell since the press. Tracked
+    /// separately from `span` because a drag that wanders and comes back is
+    /// still a drag, not a click.
+    moved: bool,
+    /// set whenever the highlight changed, so the caller can invalidate the
+    /// renderer's row cache — the overlay paints outside it, and without a
+    /// repaint an old highlight survives under the new one
+    dirty: bool,
+}
+
+impl Select {
+    pub fn new() -> Select {
+        Select::default()
+    }
+
+    /// Take the "highlight changed" flag.
+    pub fn take_dirty(&mut self) -> bool {
+        std::mem::take(&mut self.dirty)
+    }
+
+    /// Begin a tentative selection and hold the press bytes. Nothing is sent to
+    /// the app yet: until the release we do not know whether this is a click.
+    pub fn press(&mut self, at: Pos, raw: &[u8]) {
+        self.dirty |= self.span.is_some();
+        self.span = Some((at, at));
+        self.dragging = true;
+        self.moved = false;
+        self.pending_press.clear();
+        self.pending_press.extend_from_slice(raw);
+    }
+
+    pub fn drag(&mut self, at: Pos) {
+        if let Some((_, cursor)) = &mut self.span {
+            if *cursor != at {
+                *cursor = at;
+                self.moved = true;
+                self.dirty = true;
+            }
+        }
+    }
+
+    /// Resolve the gesture. A pointer that never left its starting cell is a
+    /// click, so the held press and this release go to the app untouched;
+    /// anything that moved is a selection and the app sees neither.
+    pub fn release(&mut self, at: Pos, raw: &[u8]) -> Released {
+        self.drag(at);
+        self.dragging = false;
+        if self.span.is_none() {
+            return Released::Nothing;
+        }
+        if !self.moved {
+            let mut click = std::mem::take(&mut self.pending_press);
+            click.extend_from_slice(raw);
+            self.clear();
+            return Released::Click(click);
+        }
+        let (anchor, cursor) = self.span.expect("checked above");
+        self.pending_press.clear();
+        if anchor == cursor {
+            // dragged out and back to the starting cell: the user changed their
+            // mind. Copying the one character under the pointer would be a
+            // surprise, and replaying a click is wrong because this was a drag.
+            self.clear();
+            return Released::Nothing;
+        }
+        Released::Selection(ordered(anchor, cursor))
+    }
+
+    /// Peek at the repaint flag without consuming it.
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Dismiss a finished highlight, e.g. because the user typed.
+    ///
+    /// Deliberately a no-op while the button is still down. `clear` would throw
+    /// away the held press, and the release that follows would then find nothing
+    /// pending and drop the click entirely — so a keystroke landing in the same
+    /// stdin read as a press (typing while clicking, or a focus report coalesced
+    /// with one) would silently eat the click.
+    pub fn dismiss(&mut self) -> bool {
+        if self.dragging {
+            return false;
+        }
+        self.clear()
+    }
+
+    /// Drop the highlight and cancel any gesture in flight. Returns whether
+    /// anything was showing.
+    ///
+    /// A press held at this point is discarded rather than replayed: the app
+    /// never saw it go down, so delivering a click it did not ask for (because
+    /// the foreground changed underneath, or the session restarted) would be
+    /// inventing input.
+    pub fn clear(&mut self) -> bool {
+        self.dragging = false;
+        self.moved = false;
+        self.pending_press.clear();
+        let had = self.span.take().is_some();
+        self.dirty |= had;
+        had
+    }
+
+    /// Map a 1-based SGR mouse coordinate onto the grid. Clamped into the
+    /// painted content: a click in the blank gutter to the right of a narrow
+    /// remote, or below its last row, should extend the selection to the edge
+    /// rather than being ignored.
+    pub fn locate(grid: &Grid, out_rows: usize, x: u32, y: u32) -> Pos {
+        let offset = grid::window_offset(grid, out_rows);
+        let row = (y.max(1) as usize - 1 + offset).min(grid.height.saturating_sub(1));
+        let col = (x.max(1) as usize - 1).min(grid.width.saturating_sub(1));
+        // clicking the right half of a wide char addresses the same glyph as
+        // clicking its left half
+        (row, grid.glyph_start(row, col))
+    }
+
+    /// Screen rows the highlight currently covers, as an inclusive range. The
+    /// caller uses this to repaint exactly those rows rather than the whole
+    /// pane when the selection moves.
+    pub fn painted_rows(
+        &self,
+        grid: &Grid,
+        out_rows: usize,
+        reserved: usize,
+    ) -> Option<(usize, usize)> {
+        let (start, end) = ordered(self.span?.0, self.span?.1);
+        if start == end {
+            return None;
+        }
+        let offset = grid::window_offset(grid, out_rows);
+        let last = out_rows.saturating_sub(reserved).checked_sub(1)?;
+        let top = start.0.saturating_sub(offset).min(last);
+        let bottom = end.0.checked_sub(offset)?.min(last);
+        (start.0 >= offset || end.0 >= offset).then_some((top, bottom))
+    }
+
+    /// ANSI overlay drawing the highlight. Window math matches `Renderer::paint`
+    /// and `Predictor::overlay` via `grid::window_offset`.
+    ///
+    /// `reserved` is the number of rows at the bottom the renderer has taken for
+    /// its status line; painting into those would erase the hint.
+    pub fn overlay(&self, grid: &Grid, out_cols: usize, out_rows: usize, reserved: usize) -> String {
+        let Some((anchor, cursor)) = self.span else {
+            return String::new();
+        };
+        let (start, end) = ordered(anchor, cursor);
+        if start == end {
+            return String::new();
+        }
+        let offset = grid::window_offset(grid, out_rows);
+        let limit = out_cols.min(grid.width);
+        let rows_avail = out_rows.saturating_sub(reserved);
+        if limit == 0 || rows_avail == 0 {
+            return String::new();
+        }
+        let mut out = String::new();
+        for row in start.0..=end.0 {
+            let Some(wr) = row.checked_sub(offset) else { continue };
+            if wr >= rows_avail {
+                break;
+            }
+            // a start column landing on the spacer half of a wide char would
+            // paint a blank over its left half, so snap back to the glyph
+            let from = if row == start.0 { grid.glyph_start(row, start.1) } else { 0 };
+            let to = if row == end.0 { end.1 } else { limit - 1 };
+            if from >= limit || from > to {
+                continue;
+            }
+            let to = to.min(limit - 1);
+            let _ = write!(out, "\x1b[{};{}H", wr + 1, from + 1);
+            // Reverse video over the run, re-emitting each cell's OSC 8 link so
+            // a highlighted URL stays clickable. The cell's own SGR is
+            // deliberately not re-emitted: inverting on top of an existing
+            // inverse would make the selected text look unselected.
+            out.push_str("\x1b[7m");
+            let mut prev_link: Option<&str> = None;
+            let mut c = from;
+            while c <= to {
+                let ch = grid.ch_at(row, c);
+                let w = grid::cw(ch);
+                // Unlike the renderer's identical-looking guard, `to` is the
+                // selection edge, not the screen edge: the cell past it is
+                // visible and owned by someone else, so a wide char that would
+                // straddle it is left unhighlighted rather than blanked.
+                if w == 2 && c + 1 > to {
+                    break;
+                }
+                let link = grid.link_at(row, c);
+                if prev_link != link {
+                    match link {
+                        Some(uri) => {
+                            let _ = write!(out, "\x1b]8;;{uri}\x1b\\");
+                        }
+                        None => out.push_str("\x1b]8;;\x1b\\"),
+                    }
+                    prev_link = link;
+                }
+                out.push(ch);
+                c += w;
+            }
+            // never leave a link open: it would swallow whatever is painted next
+            if prev_link.is_some() {
+                out.push_str("\x1b]8;;\x1b\\");
+            }
+            out.push_str("\x1b[0m");
+        }
+        out
+    }
+}
+
+fn ordered(a: Pos, b: Pos) -> (Pos, Pos) {
+    if a <= b { (a, b) } else { (b, a) }
+}
+
+/// herdr rejects a clipboard write past this, so a selection bigger than it
+/// would be dropped on the floor rather than truncated. A selection can only
+/// ever be one screenful, so this is a guard, not a real limit.
+const MAX_CLIPBOARD_BYTES: usize = 192 * 1024;
+
+/// OSC 52 clipboard write: `ESC ] 52 ; c ; <base64> BEL`.
+///
+/// Written to the streamer's own stdout, which is the mirror pane, so herdr
+/// picks it up as a clipboard write from the pane app and puts it wherever the
+/// user's clipboard actually is. That last part is why this is OSC 52 and not a
+/// `pbcopy` call: the streamer runs beside the herdr *server*, which is not
+/// necessarily the machine the user is sitting at. When the client is attached
+/// over ssh, herdr forwards the sequence on to the real terminal
+/// (`selection::write_osc52_bytes`); when it is local, herdr writes the system
+/// clipboard natively. Shelling out would get the ssh case silently wrong,
+/// setting a clipboard on a machine nobody is looking at.
+///
+/// BEL rather than ST for the terminator, matching what herdr emits: some
+/// terminals still only honour that form.
+pub fn osc52(text: &str) -> Option<String> {
+    use base64::Engine as _;
+    // Whitespace-only, not just empty: a drag across N blank rows yields N-1
+    // newlines, which is non-empty and would replace the user's clipboard with
+    // nothing useful. Dragging through the empty space above an agent's prompt
+    // is an easy way to do that by accident.
+    if text.chars().all(char::is_whitespace) || text.len() > MAX_CLIPBOARD_BYTES {
+        return None;
+    }
+    let b64 = base64::engine::general_purpose::STANDARD.encode(text);
+    Some(format!("\x1b]52;c;{b64}\x07"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid_with(lines: &[&str], width: usize) -> Grid {
+        let mut g = Grid::new();
+        g.resize(width, lines.len());
+        let mut ansi = String::new();
+        for (r, line) in lines.iter().enumerate() {
+            let _ = write!(ansi, "\x1b[{};1H{line}", r + 1);
+        }
+        g.apply(&ansi);
+        g
+    }
+
+    const DOWN: &[u8] = b"\x1b[<0;3;2M";
+    const UP: &[u8] = b"\x1b[<0;7;2m";
+
+    #[test]
+    fn a_drag_is_a_selection_and_the_app_sees_nothing() {
+        let mut s = Select::new();
+        s.press((1, 2), DOWN);
+        s.drag((1, 6));
+        assert_eq!(s.release((1, 6), UP), Released::Selection(((1, 2), (1, 6))));
+    }
+
+    #[test]
+    fn a_click_is_replayed_to_the_app_press_then_release() {
+        // the press was held back, so the app must receive both halves in order
+        // and unaltered — this is what keeps click-to-stage working in lazygit
+        let mut s = Select::new();
+        s.press((3, 4), DOWN);
+        let mut expected = DOWN.to_vec();
+        expected.extend_from_slice(UP);
+        assert_eq!(s.release((3, 4), UP), Released::Click(expected));
+        assert!(s.span.is_none(), "a click must leave no highlight behind");
+    }
+
+    #[test]
+    fn a_drag_that_wanders_back_cancels() {
+        // returning to the starting cell must not become a click (the app would
+        // get one the user never made) nor a one-character copy
+        let mut s = Select::new();
+        s.press((1, 2), DOWN);
+        s.drag((1, 9));
+        s.drag((1, 2));
+        assert_eq!(s.release((1, 2), UP), Released::Nothing);
+        assert!(s.span.is_none());
+    }
+
+    #[test]
+    fn a_stray_release_is_dropped_not_forwarded() {
+        // the button went down before we had the grab: the app never saw the
+        // press, so handing it a lone release would be inventing input
+        let mut s = Select::new();
+        assert_eq!(s.release((1, 1), UP), Released::Nothing);
+    }
+
+    #[test]
+    fn a_held_press_is_discarded_when_the_selection_is_cleared() {
+        // typing, or a foreground change, cancels the gesture. The app never
+        // saw the press, so it must not later receive a click for it.
+        let mut s = Select::new();
+        s.press((1, 2), DOWN);
+        s.clear();
+        assert_eq!(s.release((1, 2), UP), Released::Nothing);
+    }
+
+    #[test]
+    fn a_backwards_drag_normalizes() {
+        let mut s = Select::new();
+        s.press((4, 8), DOWN);
+        s.drag((2, 1));
+        assert_eq!(s.release((2, 1), UP), Released::Selection(((2, 1), (4, 8))));
+    }
+
+    #[test]
+    fn extraction_is_inclusive_and_trims_row_tails() {
+        let g = grid_with(&["hello world", "second line"], 20);
+        // within one row, both endpoints included
+        assert_eq!(g.selection_text((0, 0), (0, 4)), "hello");
+        // across rows: the first row runs to its content end, not to `width`
+        assert_eq!(g.selection_text((0, 6), (1, 5)), "world\nsecond");
+    }
+
+    #[test]
+    fn overlay_covers_the_span_and_nothing_else() {
+        let g = grid_with(&["abcdef"], 6);
+        let mut s = Select::new();
+        s.press((0, 1), DOWN);
+        s.release((0, 3), UP);
+        let out = s.overlay(&g, 6, 1, 0);
+        assert!(out.contains("\x1b[1;2H\x1b[7mbcd\x1b[0m"), "got: {out:?}");
+        assert!(!out.contains('a') && !out.contains('e'), "highlight leaked: {out:?}");
+    }
+
+    #[test]
+    fn overlay_follows_the_bottom_anchored_window() {
+        // content taller than the pane: the window shows the last rows, so a
+        // selection on grid row 9 must paint on screen row 3, not row 10
+        let g = grid_with(&["", "", "", "", "", "", "", "", "", "target"], 10);
+        let mut s = Select::new();
+        s.press((9, 0), DOWN);
+        s.release((9, 5), UP);
+        let out = s.overlay(&g, 10, 3, 0);
+        assert!(out.contains("\x1b[3;1H\x1b[7mtarget"), "got: {out:?}");
+    }
+
+    #[test]
+    fn overlay_skips_rows_scrolled_out_of_view() {
+        let g = grid_with(&["", "", "", "", "", "", "", "", "top", "bottom"], 10);
+        let mut s = Select::new();
+        s.press((0, 0), DOWN);
+        s.release((9, 5), UP);
+        let out = s.overlay(&g, 10, 2, 0);
+        // only grid rows 8 and 9 are on screen
+        assert!(out.contains("top"), "got: {out:?}");
+        assert!(!out.contains("\x1b[0;"), "row 0 must not paint above the pane: {out:?}");
+    }
+
+    #[test]
+    fn wide_chars_do_not_drift_the_highlight() {
+        let g = grid_with(&["\u{d55c}\u{ae00}!"], 6);
+        let mut s = Select::new();
+        s.press((0, 0), DOWN);
+        s.release((0, 4), UP);
+        let out = s.overlay(&g, 6, 1, 0);
+        // without width handling the blank spacer cells print too, pushing the
+        // run two columns wide and painting over the text to the right
+        assert!(out.contains("\u{d55c}\u{ae00}!"), "got: {out:?}");
+    }
+
+    #[test]
+    fn osc52_wraps_base64_and_refuses_the_unsendable() {
+        assert_eq!(osc52("hi").as_deref(), Some("\x1b]52;c;aGk=\x07"));
+        // empty writes clear the clipboard in OSC 52, which a no-op selection
+        // must never do
+        assert_eq!(osc52(""), None);
+        // and neither must a drag across blank rows, which yields bare newlines
+        // — non-empty, but replacing the clipboard with them is pure loss
+        assert_eq!(osc52("\n\n\n"), None);
+        assert_eq!(osc52("   \n  "), None);
+        // herdr drops an oversize write, so don't emit one
+        assert_eq!(osc52(&"x".repeat(MAX_CLIPBOARD_BYTES + 1)), None);
+    }
+
+    #[test]
+    fn a_keystroke_dismisses_a_finished_highlight_but_not_a_gesture_in_flight() {
+        // finished: the highlight goes away, as it would in a local pane
+        let mut s = Select::new();
+        s.press((1, 2), DOWN);
+        s.drag((1, 8));
+        s.release((1, 8), UP);
+        assert!(s.dismiss(), "a released selection should be dismissed");
+
+        // in flight: the button is still down, so the held press must survive or
+        // the release that follows finds nothing and the click is eaten
+        let mut s = Select::new();
+        s.press((1, 2), DOWN);
+        assert!(!s.dismiss(), "must not cancel a press that is still down");
+        let mut expected = DOWN.to_vec();
+        expected.extend_from_slice(UP);
+        assert_eq!(s.release((1, 2), UP), Released::Click(expected));
+    }
+
+    #[test]
+    fn a_wide_char_at_the_selection_edge_is_left_alone_not_blanked() {
+        // `to` is the selection edge, not the screen edge: the cell past it is
+        // visible and belongs to someone else, so blanking a straddling wide
+        // char would erase a glyph the user can see
+        let g = grid_with(&["ab\u{d55c}cd"], 8);
+        let mut s = Select::new();
+        s.press((0, 0), DOWN);
+        s.drag((0, 2)); // ends on the left half of 한
+        let out = s.overlay(&g, 8, 1, 0);
+        assert!(out.contains("ab"), "got: {out:?}");
+        assert!(!out.contains("ab "), "wide char blanked at the edge: {out:?}");
+    }
+
+    #[test]
+    fn clicking_the_right_half_of_a_wide_char_addresses_the_glyph() {
+        let g = grid_with(&["\u{d55c}\u{ae00}"], 4);
+        // column 1 is the spacer of 한, and must resolve to 한 itself
+        assert_eq!(Select::locate(&g, 1, 2, 1), (0, 0));
+        assert_eq!(Select::locate(&g, 1, 1, 1), (0, 0));
+        // 글 starts at column 2
+        assert_eq!(Select::locate(&g, 1, 3, 1), (0, 2));
+    }
+
+    #[test]
+    fn the_overlay_keeps_a_hyperlink_clickable() {
+        let mut g = Grid::new();
+        g.resize(8, 1);
+        g.apply("\x1b[1;1H\x1b]8;;https://e.com/x\x1b\\PR\x1b[1;3H\x1b]8;;\x1b\\ ok");
+        let mut s = Select::new();
+        s.press((0, 0), DOWN);
+        s.drag((0, 4));
+        let out = s.overlay(&g, 8, 1, 0);
+        assert!(out.contains("\x1b]8;;https://e.com/x\x1b\\"), "link dropped: {out:?}");
+        assert!(out.contains("\x1b]8;;\x1b\\"), "link never closed: {out:?}");
+    }
+
+    #[test]
+    fn the_overlay_leaves_the_status_row_alone() {
+        // the window is bottom-anchored, so a downward drag ends exactly where
+        // the renderer puts its hint
+        let g = grid_with(&["one", "two", "three"], 6);
+        let mut s = Select::new();
+        s.press((0, 0), DOWN);
+        s.drag((2, 4));
+        assert!(s.overlay(&g, 6, 3, 0).contains("\x1b[3;"), "row 3 should paint with no status");
+        assert!(!s.overlay(&g, 6, 3, 1).contains("\x1b[3;"), "row 3 belongs to the status line");
+    }
+
+    #[test]
+    fn painted_rows_reports_the_band_actually_drawn() {
+        let g = grid_with(&["a", "b", "c", "d"], 4);
+        let mut s = Select::new();
+        s.press((1, 0), DOWN);
+        s.drag((2, 0));
+        assert_eq!(s.painted_rows(&g, 4, 0), Some((1, 2)));
+        // a status row shrinks the band rather than letting it spill
+        assert_eq!(s.painted_rows(&g, 4, 1), Some((1, 2)));
+        // nothing to repaint when there is no span
+        s.clear();
+        assert_eq!(s.painted_rows(&g, 4, 0), None);
+    }
+
+    #[test]
+    fn locate_clamps_into_the_grid() {
+        let g = grid_with(&["ab", "cd"], 2);
+        // past the right edge and below the last row
+        assert_eq!(Select::locate(&g, 2, 99, 99), (1, 1));
+        // 1-based input, 0-based output
+        assert_eq!(Select::locate(&g, 2, 1, 1), (0, 0));
+    }
+
+    #[test]
+    fn dirty_tracks_visible_changes() {
+        let mut s = Select::new();
+        s.press((0, 0), DOWN);
+        s.take_dirty();
+        s.drag((0, 0)); // no movement
+        assert!(!s.take_dirty(), "an unmoved drag should not force a repaint");
+        s.drag((0, 3));
+        assert!(s.take_dirty());
+        s.clear();
+        assert!(s.take_dirty(), "clearing must repaint away the old highlight");
+    }
+}


### PR DESCRIPTION
Drag to select text in a mirror pane, and it lands on your clipboard.

herdr can't do this itself: its native selection only anchors when a pane has no
mouse mode set, while the wheel only arrives as a mouse report when one is. So
the streamer keeps the mouse grab and does the selection over its own cell grid,
painting the highlight and copying via OSC 52, which herdr routes to the right
clipboard whether the client is local or attached over ssh.

A press is deferred rather than stolen. A gesture that leaves its starting cell
is a selection and the app sees nothing; one that doesn't is replayed as a real
click, so htop still sorts on a header click and lazygit still stages on a file
click. The cost is in-app drag gestures, notably vim's mouse visual-select.

The foreground classifier now answers two questions instead of one, and takes
the agent answer from herdr's own `PaneInfo.agent` rather than a list of our own.
That scans the whole foreground job, so an agent stays classified as an agent
while it runs a `bash` tool call, instead of flapping to "shell" and dropping the
grab mid-session.

Supersedes #54, which diagnosed the problem and worked out the classifier shape.

Not fixed here: the wheel still sends `terminal.scroll`, which is right for a
shell or an inline-renderer agent and types arrow keys into a fullscreen one.
Fixing it properly needs herdr to expose a pane's wheel routing.
