### PR TITLE
fix: clear alternate scroll so the wheel stops typing history at a mirrored shell

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1423,7 +1423,17 @@ pub async fn run(args: Args) -> Result<()> {
         // drop otherwise arrives as bare text with no terminator at all. The
         // framing is stripped only to recognise a drop and put back on the way
         // out (`route_paste_body`), so the remote app still sees a paste.
-        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?1002h\x1b[?1006h\x1b[?2004h");
+        // 1007 OFF (alternate scroll). It defaults to ON, and at a shell we
+        // release the grab so herdr can select natively — which leaves this
+        // pane as "alt screen, no mouse reporting, 1007 on", the one state
+        // where herdr's wheel routing types an Up/Down arrow per notch into the
+        // pane app. That app is us, so the arrows are forwarded to the remote
+        // and the shell walks its command history instead of scrolling (#69).
+        // Cleared, routing falls to host scroll, which on the alt screen has
+        // nothing to move: the wheel does nothing rather than the wrong thing.
+        // While the grab IS held this is never consulted — mouse reporting wins
+        // the routing — so nothing about the selection path changes.
+        write_stdout("\x1b[?1049h\x1b[2J\x1b[H\x1b[?1002h\x1b[?1006h\x1b[?2004h\x1b[?1007l");
         RawMode::enable()
     } else {
         None
@@ -1618,7 +1628,10 @@ pub async fn run(args: Args) -> Result<()> {
     if tty {
         // ?1l with the rest: leaving the hosting pane in application cursor mode
         // would misencode arrows for whatever runs there next
-        write_stdout("\x1b[?2004l\x1b[?1002l\x1b[?1006l\x1b[?1l\x1b[?25h\x1b[?1049l");
+        // 1007 back on: it is a default-on mode we turned off, so leaving it
+        // clear would silently change the wheel for whatever runs in this pane
+        // after the streamer exits
+        write_stdout("\x1b[?2004l\x1b[?1002l\x1b[?1006l\x1b[?1l\x1b[?1007h\x1b[?25h\x1b[?1049l");
     }
     if let Some(raw) = raw {
         raw.restore();


### PR DESCRIPTION
Fixes #69.

At a shell foreground the streamer releases the mouse grab so herdr can select
natively. That leaves the mirror pane in the one state herdr routes to
*alternate scroll*: alternate screen on (we set it at startup), no mouse
reporting (we just released it), and DECSET 1007 on (its default, we never
touched it). herdr then types one Up/Down arrow per wheel notch into the pane
app, which is the streamer, which forwards it to the remote. The shell walks its
command history instead of scrolling.

Clearing 1007 drops the routing to host scroll, which on the alternate screen
has nothing to move, so the wheel does nothing rather than the wrong thing. It is
restored on exit, since it is a default-on mode and leaving it clear would change
the wheel for whatever runs in the pane afterwards.

No effect on #67: while the grab is held, mouse reporting wins the routing and
1007 is never consulted.

This does not make the wheel *scroll* at a mirrored shell. Reaching the remote's
real scrollback means holding the grab and sending a semantic scroll, which costs
herdr's native selection in those panes. Left for a separate decision.
