### PR TITLE
fix: relay mirror panes through herdr's client socket

### DIFF
--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -458,6 +458,9 @@ pub(crate) fn cmd_for_pane(
     let ctl_path = crate::remote::control_path(state_dir, &host.name)
         .display()
         .to_string();
+    let client_socket = crate::remote::client_relay_path(state_dir, &host.name)
+        .display()
+        .to_string();
     let sizes = sizes.clone();
     move |pane_id: &str| {
         let mut argv = vec![
@@ -488,10 +491,14 @@ pub(crate) fn cmd_for_pane(
         // foreground polls. Docker has no ControlMaster, and healing no longer
         // needs a host-identity token in the argv at all — it asks herdr what
         // is running in each pane instead (see daemon::has_live_streamer).
+        if matches!(kind, crate::config::HostKind::Ssh) {
+            argv.extend(["--ctl-path".into(), ctl_path.clone()]);
+        }
+        // Terminal sessions use Herdr's separate client-protocol socket. The
+        // daemon owns this stable local relay for both SSH API transports and
+        // Docker; the pane passes it explicitly to Herdr.
+        argv.extend(["--client-socket".into(), client_socket.clone()]);
         match &kind {
-            crate::config::HostKind::Ssh => {
-                argv.extend(["--ctl-path".into(), ctl_path.clone()]);
-            }
             crate::config::HostKind::DockerContainer(name) => {
                 argv.extend(["--container".into(), name.clone()]);
                 argv.extend(["--docker-bin".into(), docker_bin.clone()]);
@@ -500,6 +507,7 @@ pub(crate) fn cmd_for_pane(
                 argv.extend(["--container-folder".into(), folder.clone()]);
                 argv.extend(["--docker-bin".into(), docker_bin.clone()]);
             }
+            crate::config::HostKind::Ssh => {}
         }
         if let Some(rect) = sizes.get(pane_id) {
             argv.extend([
@@ -1767,11 +1775,8 @@ mod tests {
     /// Characterization test: the ssh pane argv is a cross-process contract.
     ///
     /// The daemon spawns `herdr-mirror pane ...` as a separate process, and
-    /// `count_streamers` (daemon.rs) identifies a host's live streamers by
-    /// string-matching `--ctl-path` in that argv. Nothing else pins the shape,
-    /// so a change here silently breaks mirror healing on upgrade: streamers
-    /// started by the old binary carry the old argv, the new daemon fails to
-    /// match them, concludes they died, and re-execs over live panes.
+    /// The daemon spawns this argv in another process, so options added here
+    /// must remain parseable by `pane::parse_args` and be pinned explicitly.
     ///
     /// If this test fails, that is the question to answer — not a prompt to
     /// update the expected value.
@@ -1790,6 +1795,8 @@ mod tests {
                 "--always-control",
                 "--ctl-path",
                 "/state/vps.ctl",
+                "--client-socket",
+                "/state/vps-api-client.sock",
             ]
         );
         // argv[0] is the resolved exe path, which varies by install
@@ -1815,6 +1822,8 @@ mod tests {
                 "--always-control",
                 "--ctl-path",
                 "/state/vps.ctl",
+                "--client-socket",
+                "/state/vps-api-client.sock",
             ]
         );
     }
@@ -1836,10 +1845,16 @@ mod tests {
                 "--always-control",
                 "--ctl-path",
                 "/state/vps.ctl",
+                "--client-socket",
+                "/state/vps-api-client.sock",
             ]
         );
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
         assert_eq!(parsed.session.as_deref(), Some("work"));
+        assert_eq!(
+            parsed.client_socket.as_deref(),
+            Some(std::path::Path::new("/state/vps-api-client.sock"))
+        );
     }
 
     /// Docker hosts append their flags *after* the ssh-shaped prefix, so the
@@ -1860,6 +1875,8 @@ mod tests {
                 "/Users/n/proj",
                 "w1:p1",
                 "--always-control",
+                "--client-socket",
+                "/state/token-api-client.sock",
                 // no identity token at all: healing asks herdr per pane
                 "--container-folder",
                 "/Users/n/proj",
@@ -1886,6 +1903,10 @@ mod tests {
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
         assert_eq!(parsed.pane_target, "w1:p1");
         assert_eq!(parsed.ctl_path, None, "docker panes carry no ctl path");
+        assert_eq!(
+            parsed.client_socket.as_deref(),
+            Some(std::path::Path::new("/state/vps-api-client.sock"))
+        );
         let ct = parsed.container.expect("container must survive the argv round trip");
         assert_eq!(ct.kind, crate::config::HostKind::DockerContainer("crazy_ride".into()));
         assert_eq!(ct.docker_bin, "/usr/local/bin/docker", "--docker-bin must round-trip");
@@ -1901,7 +1922,15 @@ mod tests {
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
-            ["pane", "vps", "w1:p1", "--ctl-path", "/state/vps.ctl"]
+            [
+                "pane",
+                "vps",
+                "w1:p1",
+                "--ctl-path",
+                "/state/vps.ctl",
+                "--client-socket",
+                "/state/vps-api-client.sock",
+            ]
         );
     }
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -19,9 +19,11 @@
 //   --max-rows N        uncapped — control fills the local pane). Set for a
 //                       remote with its own display: the remote keeps its own
 //                       geometry and the rest of the local pane stays blank.
+//   --client-socket PATH daemon-owned relay to the remote Herdr terminal socket
 //
-// Every stream gets its own direct ssh connection (no shared ControlMaster):
-// isolated, and nothing persists to go stale on a flaky network.
+// Streams prefer the daemon-owned local relay to Herdr's terminal-protocol
+// socket. A missing or failed relay falls back once to the original direct
+// ssh/docker process, so stale daemon state cannot strand a pane blank.
 //
 // One owner of all state, message-driven: frames, keystrokes, timers, and
 // ssh-child exits arrive on one channel; a session generation number tags
@@ -75,6 +77,8 @@ pub struct Args {
     /// (`ssh -S <path>`) to skip a handshake. None → polls connect directly.
     ///
     pub ctl_path: Option<String>,
+    /// daemon-owned local relay to the remote Herdr terminal client socket.
+    pub client_socket: Option<std::path::PathBuf>,
     /// container to exec into instead of ssh. `None` = ssh host.
     pub container: Option<ContainerArg>,
 }
@@ -102,6 +106,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
         max_cols: None,
         max_rows: None,
         ctl_path: None,
+        client_socket: None,
         container: None,
     };
     let mut container_name: Option<String> = None;
@@ -140,6 +145,9 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                     .filter(|&n| n > 0)
             }
             "--ctl-path" => args.ctl_path = Some(next("--ctl-path")?),
+            "--client-socket" => {
+                args.client_socket = Some(std::path::PathBuf::from(next("--client-socket")?))
+            }
             "--container" => container_name = Some(next("--container")?),
             "--container-folder" => container_folder = Some(next("--container-folder")?),
             "--docker-bin" => docker_bin = next("--docker-bin")?,
@@ -200,7 +208,14 @@ struct Frame {
 
 enum Msg {
     Frame { gen: u64, frame: Frame },
-    SessionExit { gen: u64, mode: Mode, reason: String, uptime: Duration },
+    SessionExit {
+        gen: u64,
+        mode: Mode,
+        transport: Transport,
+        saw_frame: bool,
+        reason: String,
+        uptime: Duration,
+    },
     Stdin(Vec<u8>),
     /// result of a background foreground poll; None=poll failed (keep the last
     /// value)
@@ -208,6 +223,51 @@ enum Msg {
     Paste(crate::paste::Outcome),
     Drop(crate::paste::DropResult),
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Transport {
+    Relayed,
+    DirectSsh,
+    Container,
+}
+
+fn fallback_to_direct(transport: Transport, saw_frame: bool) -> bool {
+    transport == Transport::Relayed && !saw_frame
+}
+
+#[derive(Default)]
+struct RelayFallback {
+    bypass_once: bool,
+}
+
+impl RelayFallback {
+    fn allow_relay(&mut self) -> bool {
+        !std::mem::take(&mut self.bypass_once)
+    }
+
+    fn note_failure(&mut self, transport: Transport, saw_frame: bool) {
+        if fallback_to_direct(transport, saw_frame) {
+            self.bypass_once = true;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SpawnFailure {
+    transport: Transport,
+    reason: String,
+}
+
+impl SpawnFailure {
+    fn new(transport: Transport, error: impl std::fmt::Display) -> Self {
+        Self { transport, reason: error.to_string() }
+    }
+}
+
+#[cfg(not(test))]
+const FIRST_RELAY_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const FIRST_RELAY_FRAME_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct Session {
     gen: u64,
@@ -221,7 +281,54 @@ pub(crate) fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx: mpsc::Sender<Msg>) -> Result<Session> {
+fn forwarded_api_candidates(ctl_path: &str) -> Vec<std::path::PathBuf> {
+    let path = std::path::Path::new(ctl_path);
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return Vec::new();
+    };
+    let Some(stem) = name.strip_suffix(".ctl") else {
+        return Vec::new();
+    };
+    let dir = path.parent().unwrap_or_else(|| std::path::Path::new(""));
+    vec![
+        dir.join(format!("{stem}-api.sock")),
+        dir.join(format!("{stem}-api-exec.sock")),
+    ]
+}
+
+async fn relayed_client_socket(args: &Args) -> Option<std::path::PathBuf> {
+    const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+    let client_socket = args.client_socket.as_ref()?;
+    if !crate::remote::socket_accepts(client_socket).await {
+        return None;
+    }
+    // Docker has no separate local API signal; reaching the client listener is
+    // enough to try it, and a failed Herdr handshake falls back to docker exec.
+    if args.container.is_some() {
+        return Some(client_socket.clone());
+    }
+    let ctl_path = args.ctl_path.as_deref()?;
+    for socket in forwarded_api_candidates(ctl_path) {
+        if matches!(
+            tokio::time::timeout(PROBE_TIMEOUT, crate::api::ApiClient::connect(&socket)).await,
+            Ok(Ok(_))
+        ) {
+            return Some(client_socket.clone());
+        }
+    }
+    None
+}
+
+async fn spawn_session(
+    args: &Args,
+    mode: Mode,
+    cols: usize,
+    rows: usize,
+    gen: u64,
+    tx: mpsc::Sender<Msg>,
+    allow_relay: bool,
+) -> std::result::Result<Session, SpawnFailure> {
     // Configured paths stay unquoted so remote-shell ~ expands; auto mode is an
     // `sh -c` resolver that takes the trailing words as "$@" (see
     // config::remote_herdr_expr).
@@ -237,15 +344,41 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         cols,
         rows
     );
-    // ssh and docker differ only in how the command is carried; the streaming
-    // contract (piped stdio, herdr's frames on stdout) is identical
-    let mut builder = match &args.container {
-        None => {
-            let mut c = tokio::process::Command::new("ssh");
-            c.args(crate::remote::SSH_COMMON_OPTS).arg(&args.ssh_target).arg(cmd);
-            c
+    let relayed = if allow_relay {
+        relayed_client_socket(args).await
+    } else {
+        None
+    };
+    // ssh, the daemon's forwarded socket, and docker differ only in how the
+    // command is carried; the streaming contract is identical.
+    let (mut builder, transport) = match (&args.container, relayed) {
+        // The daemon already owns a relay to the remote Herdr terminal socket.
+        // Prefer it for the long-lived stream: besides avoiding one transport
+        // child per pane, this works when a supervised macOS pane cannot
+        // resolve its own uid during OpenSSH startup (#60). Standalone `pane`
+        // invocations have no relay and retain the direct fallback below.
+        (_, Some(client_socket)) => {
+            let bin = std::env::var_os("HERDR_BIN_PATH")
+                .filter(|p| !p.is_empty())
+                .unwrap_or_else(|| "herdr".into());
+            let mut c = tokio::process::Command::new(bin);
+            c.args(["terminal", "session", mode.as_str()])
+                .arg(&args.pane_target)
+                .arg("--cols")
+                .arg(cols.to_string())
+                .arg("--rows")
+                .arg(rows.to_string())
+                .env_remove("HERDR_SOCKET_PATH")
+                .env("HERDR_CLIENT_SOCKET_PATH", client_socket)
+                .env_remove("HERDR_SESSION");
+            (c, Transport::Relayed)
         }
-        Some(ct) => {
+        (None, None) => {
+            let mut c = tokio::process::Command::new(crate::remote::ssh_bin());
+            c.args(crate::remote::SSH_COMMON_OPTS).arg(&args.ssh_target).arg(cmd);
+            (c, Transport::DirectSsh)
+        }
+        (Some(ct), _) => {
             // resolve per spawn so a rebuilt container is picked up on
             // reconnect. Bounded: this runs on the pane's single-threaded
             // runtime, so a wedged Docker daemon must not be able to freeze
@@ -254,22 +387,33 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
                 &ct.docker_bin,
                 &ct.kind,
                 Duration::from_secs(5),
-            )?;
+            )
+            .map_err(|e| SpawnFailure::new(Transport::Container, e))?;
             let mut c = tokio::process::Command::new(&ct.docker_bin);
             // `sh -c` not `-lc`: match ssh's non-login remote shell
             c.args(["exec", "-i", &id, "sh", "-c", &cmd]);
-            c
+            (c, Transport::Container)
         }
     };
     let mut child = builder
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()?;
+        .spawn()
+        .map_err(|e| SpawnFailure::new(transport, e))?;
     let pid = child.id().map(|p| p as i32).unwrap_or(0);
-    let stdin = child.stdin.take().ok_or_else(|| err("no child stdin"))?;
-    let stdout = child.stdout.take().ok_or_else(|| err("no child stdout"))?;
-    let stderr = child.stderr.take().ok_or_else(|| err("no child stderr"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| SpawnFailure::new(transport, "no child stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| SpawnFailure::new(transport, "no child stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| SpawnFailure::new(transport, "no child stderr"))?;
     let started = Instant::now();
 
     tokio::spawn(async move {
@@ -290,9 +434,27 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
             }
         });
         let mut close_reason = String::new();
+        let mut saw_frame = false;
+        let first_frame_deadline = started + FIRST_RELAY_FRAME_TIMEOUT;
         let mut lines = BufReader::new(stdout).lines();
-        while let Ok(Some(line)) = lines.next_line().await {
+        loop {
+            let next = if transport == Transport::Relayed && !saw_frame {
+                match tokio::time::timeout_at(first_frame_deadline, lines.next_line()).await {
+                    Ok(next) => next,
+                    Err(_) => {
+                        close_reason = "terminal relay timed out before its first frame".into();
+                        let _ = child.start_kill();
+                        break;
+                    }
+                }
+            } else {
+                lines.next_line().await
+            };
+            let Ok(Some(line)) = next else { break };
             let Ok(frame) = serde_json::from_str::<Frame>(&line) else { continue };
+            if frame.kind == "terminal.frame" {
+                saw_frame = true;
+            }
             if frame.kind == "terminal.closed" {
                 if let Some(r) = &frame.reason {
                     close_reason = r.clone();
@@ -306,7 +468,16 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         stderr_task.abort();
         let tail = err_tail.lock().unwrap().trim().to_string();
         let reason = if close_reason.is_empty() { tail } else { close_reason };
-        let _ = tx.send(Msg::SessionExit { gen, mode, reason, uptime: started.elapsed() }).await;
+        let _ = tx
+            .send(Msg::SessionExit {
+                gen,
+                mode,
+                transport,
+                saw_frame,
+                reason,
+                uptime: started.elapsed(),
+            })
+            .await;
     });
 
     Ok(Session { gen, mode, pid, stdin })
@@ -683,6 +854,10 @@ struct App {
     switch_at: Option<Instant>,
     session: Option<Session>,
     next_gen: u64,
+    /// A relayed Herdr process that exits before its first frame may have a
+    /// locally live but remotely broken client socket. Bypass it once so the
+    /// existing direct SSH/docker transport gets a chance to recover the pane.
+    relay_fallback: RelayFallback,
 
     backoff_idx: usize,
     reconnect_at: Option<(Instant, Mode)>,
@@ -911,7 +1086,18 @@ impl App {
             unsafe { libc::kill(s.pid, libc::SIGTERM) };
         }
         self.next_gen += 1;
-        match spawn_session(&self.args, m, cols, rows, self.next_gen, self.tx.clone()) {
+        let allow_relay = self.relay_fallback.allow_relay();
+        match spawn_session(
+            &self.args,
+            m,
+            cols,
+            rows,
+            self.next_gen,
+            self.tx.clone(),
+            allow_relay,
+        )
+        .await
+        {
             Ok(mut s) => {
                 if m == Mode::Control {
                     self.last_input = Instant::now();
@@ -935,7 +1121,10 @@ impl App {
                     },
                 );
             }
-            Err(e) => self.schedule_reconnect(m, &e.to_string()),
+            Err(failure) => {
+                self.relay_fallback.note_failure(failure.transport, false);
+                self.schedule_reconnect(m, &failure.reason);
+            }
         }
     }
 
@@ -1039,11 +1228,20 @@ impl App {
         }
     }
 
-    fn handle_exit(&mut self, gen: u64, exited_mode: Mode, reason: String, uptime: Duration) {
+    fn handle_exit(
+        &mut self,
+        gen: u64,
+        exited_mode: Mode,
+        transport: Transport,
+        saw_frame: bool,
+        reason: String,
+        uptime: Duration,
+    ) {
         if self.session.as_ref().map(|s| s.gen) != Some(gen) {
             return; // an old child we already replaced/killed
         }
         self.session = None;
+        self.relay_fallback.note_failure(transport, saw_frame);
         let reason_line =
             reason.lines().map(str::trim).rfind(|l| !l.is_empty()).unwrap_or("").to_string();
         // control that dies quickly twice is failing (refused/dropped): fall
@@ -1471,6 +1669,7 @@ pub async fn run(args: Args) -> Result<()> {
         switch_at: None,
         session: None,
         next_gen: 0,
+        relay_fallback: RelayFallback::default(),
         backoff_idx: 0,
         reconnect_at: None,
         control_failures: 0,
@@ -1542,7 +1741,14 @@ pub async fn run(args: Args) -> Result<()> {
                 match msg {
                     None => break,
                     Some(Msg::Frame { gen, frame }) => app.handle_frame(gen, frame),
-                    Some(Msg::SessionExit { gen, mode, reason, uptime }) => app.handle_exit(gen, mode, reason, uptime),
+                    Some(Msg::SessionExit {
+                        gen,
+                        mode,
+                        transport,
+                        saw_frame,
+                        reason,
+                        uptime,
+                    }) => app.handle_exit(gen, mode, transport, saw_frame, reason, uptime),
                     Some(Msg::Stdin(buf)) => app.handle_stdin(buf).await,
                     // keep the last good classification if a poll failed (None)
                     Some(Msg::Foreground(v)) => if v.is_some() {
@@ -1642,6 +1848,69 @@ pub async fn run(args: Args) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    struct EnvVarGuard {
+        name: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let original = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.original.take() {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
+
+    struct TempDirGuard(PathBuf);
+
+    impl TempDirGuard {
+        fn new(prefix: &str) -> Self {
+            let nonce = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "herdr-mirror-{prefix}-{}-{nonce}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    struct PidGuard(i32);
+
+    impl Drop for PidGuard {
+        fn drop(&mut self) {
+            if self.0 > 0 {
+                unsafe { libc::kill(self.0, libc::SIGTERM) };
+            }
+        }
+    }
 
     /// Uncapped must stay byte-identical to the old `term_size()` call, or
     /// every existing headless-remote config silently changes behaviour.
@@ -1760,6 +2029,699 @@ mod tests {
         // overflow-proof mouse params: 11 digits saturate instead of panicking
         let (_, x, _, _, _) = parse_mouse(b"\x1b[<64;99999999999;1M", 0).unwrap();
         assert_eq!(x, u32::MAX);
+    }
+
+    #[test]
+    fn relayed_exit_without_a_frame_forces_one_direct_attempt() {
+        let mut fallback = RelayFallback::default();
+        assert!(fallback.allow_relay(), "first attempt should use the relay");
+        fallback.note_failure(Transport::Relayed, false);
+        assert!(!fallback.allow_relay(), "the next attempt must bypass it");
+        assert!(fallback.allow_relay(), "the bypass is exactly one attempt");
+        assert!(!fallback_to_direct(Transport::Relayed, true));
+        assert!(!fallback_to_direct(Transport::DirectSsh, false));
+        assert!(!fallback_to_direct(Transport::Container, false));
+    }
+
+    #[tokio::test]
+    async fn ssh_pane_streams_through_the_daemon_forward_without_launching_ssh() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = ENV_LOCK.lock().await;
+        let temp = TempDirGuard::new("forwarded-pane");
+        let dir = temp.path();
+        let ctl = dir.join("work.ctl");
+        let api = dir.join("work-api.sock");
+        let client = crate::remote::client_socket_path(&api);
+        let listener = tokio::net::UnixListener::bind(&api).unwrap();
+        let _client_listener = tokio::net::UnixListener::bind(&client).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = tokio::io::BufReader::new(read).lines();
+            let request = lines.next_line().await.unwrap().unwrap();
+            let request: serde_json::Value = serde_json::from_str(&request).unwrap();
+            let id = request["id"].as_str().unwrap();
+            write
+                .write_all(format!("{{\"id\":\"{id}\",\"result\":{{}}}}\n").as_bytes())
+                .await
+                .unwrap();
+        });
+
+        let fake_herdr = dir.join("herdr");
+        std::fs::write(
+            &fake_herdr,
+            format!(
+                "#!/bin/sh\n[ -z \"$HERDR_SOCKET_PATH\" ] || exit 90\n[ \"$HERDR_CLIENT_SOCKET_PATH\" = '{}' ] || exit 91\nprintf '%s\\n' '{{\"type\":\"terminal.frame\"}}'\n",
+                client.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_herdr, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let _bin = EnvVarGuard::set("HERDR_BIN_PATH", &fake_herdr);
+        let args = Args {
+            ssh_target: "127.0.0.1".into(),
+            pane_target: "w1:p1".into(),
+            remote_bin: Some("/remote/herdr".into()),
+            cols: 120,
+            rows: 40,
+            dump: true,
+            session: None,
+            control_idle_secs: 3600,
+            always_control: false,
+            max_cols: None,
+            max_rows: None,
+            ctl_path: Some(ctl.display().to_string()),
+            client_socket: Some(client.clone()),
+            container: None,
+        };
+        let (tx, mut rx) = mpsc::channel(8);
+        let session = spawn_session(&args, Mode::Observe, 120, 40, 1, tx, true)
+            .await
+            .unwrap();
+        let _session = PidGuard(session.pid);
+        let got_frame = tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(msg) = rx.recv().await {
+                if matches!(msg, Msg::Frame { frame: Frame { ref kind, .. }, .. } if kind == "terminal.frame") {
+                    return true;
+                }
+                if matches!(msg, Msg::SessionExit { .. }) {
+                    return false;
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+
+        server.abort();
+        let _ = server.await;
+        assert!(got_frame, "daemon-spawned panes must not need a fresh ssh client");
+    }
+
+    #[tokio::test]
+    async fn api_only_forward_is_not_selected_for_terminal_streaming() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = ENV_LOCK.lock().await;
+        let temp = TempDirGuard::new("api-only-forward");
+        let dir = temp.path();
+        let ctl = dir.join("work.ctl");
+        let api = dir.join("work-api.sock");
+        let listener = tokio::net::UnixListener::bind(&api).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = tokio::io::BufReader::new(read).lines();
+            let request = lines.next_line().await.unwrap().unwrap();
+            let request: serde_json::Value = serde_json::from_str(&request).unwrap();
+            let id = request["id"].as_str().unwrap();
+            write
+                .write_all(format!("{{\"id\":\"{id}\",\"result\":{{}}}}\n").as_bytes())
+                .await
+                .unwrap();
+        });
+        let fake_ssh = dir.join("ssh");
+        std::fs::write(
+            &fake_ssh,
+            "#!/bin/sh\nprintf '%s\\n' '{\"type\":\"terminal.frame\"}'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_ssh, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let _ssh = EnvVarGuard::set("HERDR_MIRROR_TEST_SSH_BIN", &fake_ssh);
+        let args = Args {
+            ssh_target: "work".into(),
+            pane_target: "w1:p1".into(),
+            remote_bin: None,
+            cols: 80,
+            rows: 24,
+            dump: true,
+            session: None,
+            control_idle_secs: 3600,
+            always_control: false,
+            max_cols: None,
+            max_rows: None,
+            ctl_path: Some(ctl.display().to_string()),
+            client_socket: Some(crate::remote::client_socket_path(&api)),
+            container: None,
+        };
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let session = spawn_session(&args, Mode::Observe, 80, 24, 1, tx, true)
+            .await
+            .unwrap();
+        let _session = PidGuard(session.pid);
+        let got_direct_frame = tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Frame {
+                        frame: Frame { kind, .. },
+                        ..
+                    } if kind == "terminal.frame" => return true,
+                    Msg::SessionExit { .. } => return false,
+                    _ => {}
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+
+        server.abort();
+        let _ = server.await;
+        assert!(
+            got_direct_frame,
+            "an old daemon's API-only forward must launch the direct SSH transport"
+        );
+    }
+
+    #[tokio::test]
+    async fn relayed_spawn_failure_is_followed_by_a_direct_attempt() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = ENV_LOCK.lock().await;
+        let temp = TempDirGuard::new("relay-spawn-failure");
+        let dir = temp.path();
+        let ctl = dir.join("work.ctl");
+        let api = dir.join("work-api.sock");
+        let client = crate::remote::client_socket_path(&api);
+        let listener = tokio::net::UnixListener::bind(&api).unwrap();
+        let _client_listener = tokio::net::UnixListener::bind(&client).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = tokio::io::BufReader::new(read).lines();
+            let request: serde_json::Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            let id = request["id"].as_str().unwrap();
+            write
+                .write_all(
+                    format!("{{\"id\":\"{id}\",\"result\":{{}}}}\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+        let fake_ssh = dir.join("ssh");
+        std::fs::write(
+            &fake_ssh,
+            "#!/bin/sh\nprintf '%s\\n' '{\"type\":\"terminal.frame\"}'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_ssh, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let _ssh = EnvVarGuard::set("HERDR_MIRROR_TEST_SSH_BIN", &fake_ssh);
+        let _bin = EnvVarGuard::set("HERDR_BIN_PATH", dir.join("missing-herdr"));
+        let args = Args {
+            ssh_target: "work".into(),
+            pane_target: "w1:p1".into(),
+            remote_bin: None,
+            cols: 80,
+            rows: 24,
+            dump: true,
+            session: None,
+            control_idle_secs: 3600,
+            always_control: false,
+            max_cols: None,
+            max_rows: None,
+            ctl_path: Some(ctl.display().to_string()),
+            client_socket: Some(client),
+            container: None,
+        };
+        let mut fallback = RelayFallback::default();
+        let (tx, _rx) = mpsc::channel(8);
+        let allow_relay = fallback.allow_relay();
+        let failure = match spawn_session(&args, Mode::Observe, 80, 24, 1, tx, allow_relay).await {
+            Ok(session) => {
+                let _session = PidGuard(session.pid);
+                panic!("missing local Herdr unexpectedly spawned")
+            }
+            Err(failure) => failure,
+        };
+        fallback.note_failure(failure.transport, false);
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let allow_relay = fallback.allow_relay();
+        assert!(!allow_relay, "spawn failure must consume one direct attempt");
+        let direct = spawn_session(&args, Mode::Observe, 80, 24, 2, tx, allow_relay)
+            .await
+            .unwrap();
+        let _direct = PidGuard(direct.pid);
+        let got_frame = tokio::time::timeout(Duration::from_secs(2), async {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Frame {
+                        frame: Frame { kind, .. },
+                        ..
+                    } if kind == "terminal.frame" => return true,
+                    Msg::SessionExit { .. } => return false,
+                    _ => {}
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+        server.await.unwrap();
+        assert!(got_frame, "relay spawn failure must fall back to direct SSH");
+        assert!(fallback.allow_relay(), "relay bypass must be one-shot");
+    }
+
+    #[tokio::test]
+    async fn relayed_first_frame_timeout_is_followed_by_a_direct_attempt() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = ENV_LOCK.lock().await;
+        let temp = TempDirGuard::new("relay-first-frame-timeout");
+        let dir = temp.path();
+        let ctl = dir.join("work.ctl");
+        let api = dir.join("work-api.sock");
+        let client = crate::remote::client_socket_path(&api);
+        let listener = tokio::net::UnixListener::bind(&api).unwrap();
+        let _client_listener = tokio::net::UnixListener::bind(&client).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (read, mut write) = stream.into_split();
+            let mut lines = tokio::io::BufReader::new(read).lines();
+            let request: serde_json::Value =
+                serde_json::from_str(&lines.next_line().await.unwrap().unwrap()).unwrap();
+            let id = request["id"].as_str().unwrap();
+            write
+                .write_all(
+                    format!("{{\"id\":\"{id}\",\"result\":{{}}}}\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+        let fake_herdr = dir.join("herdr");
+        std::fs::write(&fake_herdr, "#!/bin/sh\nread ignored\n").unwrap();
+        std::fs::set_permissions(&fake_herdr, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let fake_ssh = dir.join("ssh");
+        std::fs::write(
+            &fake_ssh,
+            "#!/bin/sh\nprintf '%s\\n' '{\"type\":\"terminal.frame\"}'\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_ssh, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let _bin = EnvVarGuard::set("HERDR_BIN_PATH", &fake_herdr);
+        let _ssh = EnvVarGuard::set("HERDR_MIRROR_TEST_SSH_BIN", &fake_ssh);
+        let args = Args {
+            ssh_target: "work".into(),
+            pane_target: "w1:p1".into(),
+            remote_bin: None,
+            cols: 80,
+            rows: 24,
+            dump: true,
+            session: None,
+            control_idle_secs: 3600,
+            always_control: false,
+            max_cols: None,
+            max_rows: None,
+            ctl_path: Some(ctl.display().to_string()),
+            client_socket: Some(client),
+            container: None,
+        };
+        let mut fallback = RelayFallback::default();
+        let (tx, mut rx) = mpsc::channel(8);
+        let allow_relay = fallback.allow_relay();
+        let relayed = spawn_session(&args, Mode::Observe, 80, 24, 1, tx, allow_relay)
+            .await
+            .unwrap();
+        let _relayed = PidGuard(relayed.pid);
+        let exit = tokio::time::timeout(Duration::from_secs(4), async {
+            while let Some(msg) = rx.recv().await {
+                if let Msg::SessionExit {
+                    transport,
+                    saw_frame,
+                    reason,
+                    ..
+                } = msg
+                {
+                    return (transport, saw_frame, reason);
+                }
+            }
+            panic!("relayed child ended without SessionExit")
+        })
+        .await
+        .expect("relayed first-frame deadline did not fire");
+        assert_eq!(exit.0, Transport::Relayed);
+        assert!(!exit.1);
+        assert!(exit.2.contains("timed out before its first frame"), "{}", exit.2);
+        fallback.note_failure(exit.0, exit.1);
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let allow_relay = fallback.allow_relay();
+        assert!(!allow_relay, "timeout must consume one direct attempt");
+        let direct = spawn_session(&args, Mode::Observe, 80, 24, 2, tx, allow_relay)
+            .await
+            .unwrap();
+        let _direct = PidGuard(direct.pid);
+        let got_frame = tokio::time::timeout(Duration::from_secs(2), async {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Frame {
+                        frame: Frame { kind, .. },
+                        ..
+                    } if kind == "terminal.frame" => return true,
+                    Msg::SessionExit { .. } => return false,
+                    _ => {}
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+        server.await.unwrap();
+        assert!(got_frame, "hung relay must fall back to direct SSH");
+        assert!(fallback.allow_relay(), "relay bypass must be one-shot");
+    }
+
+    /// The fast test above deliberately fakes the Herdr executable. This one
+    /// runs a real isolated Herdr server and terminal client through Mirror's
+    /// client relay. Its ssh program is a local transport surrogate: this
+    /// proves path derivation and the Herdr protocol, not a live ssh channel.
+    #[tokio::test]
+    #[ignore = "requires herdr 0.7.2+ on PATH"]
+    async fn client_relay_reaches_a_real_herdr_terminal_stream() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = ENV_LOCK.lock().await;
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp = TempDirGuard::new("real-stream");
+        let dir = temp.path();
+
+        let herdr_bin = std::env::var_os("HERDR_BIN_PATH").unwrap_or_else(|| "herdr".into());
+        let real_api = dir.join("server.sock");
+        let real_client = crate::remote::client_socket_path(&real_api);
+        let xdg_config = dir.join("xdg-config");
+        let xdg_state = dir.join("xdg-state");
+        std::fs::create_dir_all(&xdg_config).unwrap();
+        std::fs::create_dir_all(&xdg_state).unwrap();
+        let session_name = format!("mirror-it-{}-{nonce}", std::process::id());
+
+        let mut server_cmd = tokio::process::Command::new(&herdr_bin);
+        server_cmd
+            .arg("server")
+            .current_dir(dir)
+            .env("HERDR_CONFIG_PATH", "/dev/null")
+            .env("HERDR_SOCKET_PATH", &real_api)
+            .env("HERDR_CLIENT_SOCKET_PATH", &real_client)
+            .env("HERDR_SESSION", &session_name)
+            .env("XDG_CONFIG_HOME", &xdg_config)
+            .env("XDG_STATE_HOME", &xdg_state)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut server = server_cmd.spawn().unwrap();
+
+        for _ in 0..100 {
+            if real_api.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            real_api.exists(),
+            "isolated Herdr server did not create its API socket"
+        );
+
+        let created = tokio::process::Command::new(&herdr_bin)
+            .args(["workspace", "create", "--cwd"])
+            .arg(dir)
+            .args(["--label", "mirror-it", "--no-focus"])
+            .env("HERDR_CONFIG_PATH", "/dev/null")
+            .env("HERDR_SOCKET_PATH", &real_api)
+            .env("HERDR_CLIENT_SOCKET_PATH", &real_client)
+            .env("HERDR_SESSION", &session_name)
+            .env("XDG_CONFIG_HOME", &xdg_config)
+            .env("XDG_STATE_HOME", &xdg_state)
+            .output()
+            .await
+            .unwrap();
+        assert!(created.status.success(), "workspace create failed");
+        let created: serde_json::Value = serde_json::from_slice(&created.stdout).unwrap();
+        let pane_id = created
+            .pointer("/result/root_pane/pane_id")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .to_string();
+        for _ in 0..100 {
+            if real_client.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            real_client.exists(),
+            "isolated Herdr server did not create its client socket"
+        );
+
+        // The fake ControlMaster materializes the API streamlocal mapping and
+        // runs relay exec commands locally. The real client handshake still
+        // crosses Mirror's Unix listener and byte pump.
+        let fake_ssh = dir.join("ssh");
+        std::fs::write(
+            &fake_ssh,
+            "#!/bin/sh\nop=\nlast=\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    -O) op=$2; shift 2 ;;\n    -L) spec=$2; local=${spec%%:*}; remote=${spec#*:}; shift 2\n        if [ \"$op\" = forward ]; then ln -sf \"$remote\" \"$local\"; else rm -f \"$local\"; fi ;;\n    *) last=$1; shift ;;\n  esac\ndone\n[ -n \"$op\" ] && exit 0\nexec sh -c \"$last\"\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&fake_ssh, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let _ssh = EnvVarGuard::set("HERDR_MIRROR_TEST_SSH_BIN", &fake_ssh);
+        let _bin = EnvVarGuard::set("HERDR_BIN_PATH", &herdr_bin);
+
+        let host = crate::config::HostConfig {
+            name: "work".into(),
+            target: "127.0.0.1".into(),
+            kind: crate::config::HostKind::Ssh,
+            docker_bin: "docker".into(),
+            prefix: "work".into(),
+            remote_bin: None,
+            session: None,
+            max_cols: None,
+            max_rows: None,
+            api_transport: crate::config::ApiTransport::Socket,
+            always_control: true,
+        };
+        let mut remote = crate::remote::RemoteHost::new(&host, dir);
+        let forwarded_api = remote
+            .forward_api(real_api.to_str().unwrap())
+            .await
+            .expect("API forward registration");
+        let expected_client = crate::remote::client_relay_path(dir, "work");
+        std::fs::write(&expected_client, b"stale").unwrap();
+        let client_relay = remote
+            .client_relay_transport(real_api.to_str().unwrap())
+            .await
+            .expect("terminal client relay registration");
+        assert!(forwarded_api.exists());
+        assert!(client_relay.exists());
+        assert_eq!(
+            std::fs::metadata(&client_relay)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+
+        let args = Args {
+            ssh_target: host.target,
+            pane_target: pane_id,
+            remote_bin: None,
+            cols: 80,
+            rows: 24,
+            dump: true,
+            session: None,
+            control_idle_secs: 3600,
+            always_control: false,
+            max_cols: None,
+            max_rows: None,
+            ctl_path: Some(
+                crate::remote::control_path(dir, "work")
+                    .display()
+                    .to_string(),
+            ),
+            client_socket: Some(crate::remote::client_relay_path(dir, "work")),
+            container: None,
+        };
+        let (tx, mut rx) = mpsc::channel(8);
+        let mut stream = spawn_session(&args, Mode::Control, 80, 24, 1, tx, true)
+            .await
+            .unwrap();
+        let _stream = PidGuard(stream.pid);
+        let got_socket_frame = tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Frame {
+                        frame: Frame { kind, .. },
+                        ..
+                    } if kind == "terminal.frame" => {
+                        return true;
+                    }
+                    Msg::SessionExit { .. } => return false,
+                    _ => {}
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+        let marker = "HERDR_MIRROR_RELAY_INPUT_OK";
+        let input = json!({
+            "type": "terminal.input",
+            "bytes": B64.encode(format!("printf '{marker}\\n'\n")),
+        })
+        .to_string()
+            + "\n";
+        stream.stdin.write_all(input.as_bytes()).await.unwrap();
+        let got_control_echo = tokio::time::timeout(Duration::from_secs(5), async {
+            let mut output = String::new();
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Frame {
+                        frame: Frame { kind, bytes, .. },
+                        ..
+                    } if kind == "terminal.frame" => {
+                        if let Some(bytes) = bytes.and_then(|bytes| B64.decode(bytes).ok()) {
+                            output.push_str(&String::from_utf8_lossy(&bytes));
+                            if output.contains(marker) {
+                                return true;
+                            }
+                        }
+                    }
+                    Msg::SessionExit { .. } => return false,
+                    _ => {}
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+
+        drop(remote);
+        assert!(!client_relay.exists(), "dropping the host must unlink its client relay");
+        let _ = std::fs::remove_file(&forwarded_api);
+
+        let exec_host = crate::config::HostConfig {
+            name: "exec".into(),
+            target: "127.0.0.1".into(),
+            api_transport: crate::config::ApiTransport::Exec,
+            ..host
+        };
+        let mut exec_remote = crate::remote::RemoteHost::new(&exec_host, dir);
+        let exec_api = exec_remote
+            .exec_relay_transport(real_api.to_str().unwrap())
+            .await
+            .expect("API exec relay registration");
+        let exec_client = exec_remote
+            .client_relay_transport(real_api.to_str().unwrap())
+            .await
+            .expect("terminal client exec relay registration");
+        assert!(exec_api.exists());
+        assert!(exec_client.exists());
+        assert_eq!(
+            std::fs::metadata(&exec_client)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let exec_args = Args {
+            ssh_target: exec_host.target,
+            pane_target: args.pane_target,
+            ctl_path: Some(
+                crate::remote::control_path(dir, "exec")
+                    .display()
+                    .to_string(),
+            ),
+            client_socket: Some(crate::remote::client_relay_path(dir, "exec")),
+            ..args
+        };
+        let (tx, mut rx) = mpsc::channel(8);
+        let exec_stream = spawn_session(&exec_args, Mode::Observe, 80, 24, 2, tx, true)
+            .await
+            .unwrap();
+        let _exec_stream = PidGuard(exec_stream.pid);
+        let got_exec_frame = tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(msg) = rx.recv().await {
+                match msg {
+                    Msg::Frame {
+                        frame: Frame { kind, .. },
+                        ..
+                    } if kind == "terminal.frame" => return true,
+                    Msg::SessionExit { .. } => return false,
+                    _ => {}
+                }
+            }
+            false
+        })
+        .await
+        .unwrap();
+
+        let _ = server.kill().await;
+        let _ = server.wait().await;
+        drop(exec_remote);
+        assert!(!exec_client.exists(), "dropping the host must unlink its client relay");
+        assert!(
+            got_socket_frame,
+            "the real Herdr client must reach the client relay beside a socket API"
+        );
+        assert!(got_control_echo, "control input must round-trip through the client relay");
+        assert!(
+            got_exec_frame,
+            "the real Herdr client must reach the exec-relay client socket"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_blackholed_forward_cannot_freeze_the_pane_reconnect_loop() {
+        let dir = std::env::temp_dir().join(format!(
+            "herdr-mirror-blackholed-forward-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let ctl = dir.join("work.ctl");
+        let api = dir.join("work-api.sock");
+        let client = crate::remote::client_socket_path(&api);
+        let listener = tokio::net::UnixListener::bind(&api).unwrap();
+        let _client_listener = tokio::net::UnixListener::bind(&client).unwrap();
+        let blackhole = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        });
+        let args = Args {
+            ssh_target: "work".into(),
+            pane_target: "w1:p1".into(),
+            remote_bin: None,
+            cols: 120,
+            rows: 40,
+            dump: true,
+            session: None,
+            control_idle_secs: 3600,
+            always_control: false,
+            max_cols: None,
+            max_rows: None,
+            ctl_path: Some(ctl.display().to_string()),
+            client_socket: Some(client.clone()),
+            container: None,
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(1500),
+            relayed_client_socket(&args),
+        )
+        .await;
+
+        blackhole.abort();
+        let _ = blackhole.await;
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(result.unwrap(), None, "a dead forward must fall back promptly");
     }
 
     #[test]

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,9 +1,10 @@
-// ssh transport for the DAEMON's own traffic (remote CLI execs + API-socket
-// forward) over one ControlMaster per host. Pane streams deliberately use
-// their own direct connections instead (see pane.rs).
+// SSH transport for the daemon's control traffic over one ControlMaster per
+// host. The JSON API uses streamlocal or an exec relay; the separate Herdr
+// terminal protocol always uses an exec relay that pane.rs consumes locally.
 
 use std::fs;
 use std::os::unix::fs::FileTypeExt;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
@@ -47,8 +48,19 @@ struct SshOutput {
     err: String,
 }
 
+pub(crate) fn ssh_bin() -> std::ffi::OsString {
+    #[cfg(test)]
+    {
+        std::env::var_os("HERDR_MIRROR_TEST_SSH_BIN").unwrap_or_else(|| "ssh".into())
+    }
+    #[cfg(not(test))]
+    {
+        "ssh".into()
+    }
+}
+
 async fn ssh(args: &[String], timeout_ms: u64) -> SshOutput {
-    let fut = Command::new("ssh")
+    let fut = Command::new(ssh_bin())
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -94,16 +106,21 @@ pub struct RemoteHost {
     pub cfg: HostConfig,
     ctl_path: PathBuf,
     pub fwd_sock: PathBuf,
+    client_sock: PathBuf,
     forwarded: bool,
     /// docker hosts only: resolved container + chosen stdio bridge
     container: Option<crate::docker::Container>,
     /// docker hosts only: owns the relay listener. Dropping it stops serving
     /// and unlinks the socket, so a reconnect never inherits a dead one.
     relay: Option<crate::docker::RelayHandle>,
+    /// docker hosts only: companion relay for Herdr's terminal protocol.
+    client_relay: Option<crate::docker::RelayHandle>,
     /// ssh hosts only: owns the exec-relay listener when the exec transport
     /// is in use. Same lifecycle reasoning as `relay` above, one level up
     /// the transport stack (ssh exec instead of `docker exec`).
     exec_relay: Option<crate::ssh_relay::RelayHandle>,
+    /// ssh hosts only: companion exec relay for Herdr's terminal protocol.
+    ssh_client_relay: Option<crate::ssh_relay::RelayHandle>,
     /// ssh hosts only: where the exec relay listens. Deliberately NOT
     /// `fwd_sock`: sharing one path with the streamlocal forward makes the
     /// relay's "is a healthy relay already serving this?" check answerable by
@@ -144,7 +161,7 @@ fn short_hash(s: &str) -> String {
     format!("{:08x}", hasher.finish() as u32)
 }
 
-/// Filename stem shared by a host's three sockets, bounded so the longest one
+/// Filename stem shared by a host's sockets, bounded so the longest one
 /// still fits sockaddr_un.
 ///
 /// Truncation alone is not enough: two hosts sharing a long prefix (exactly the
@@ -164,9 +181,9 @@ fn socket_stem(state_dir: &std::path::Path, host_name: &str) -> String {
 
     // macOS reserves one byte of sockaddr_un's 104-byte path for NUL; Linux
     // allows 108, and we deliberately apply the tighter bound on both so a
-    // hosts.toml is portable. Overhead is the worst case across the three
-    // suffixes (`-api-exec.sock`, 14) plus OpenSSH's mux temp suffix on the
-    // ControlPath (a dot and 11 chars); 21 keeps a little slack.
+    // hosts.toml is portable. The existing 21-byte overhead covers the longest
+    // relay suffix (`-api-client.sock`) and leaves room for OpenSSH's mux temp
+    // suffix on the shorter ControlPath.
     const MAX_SOCKET_PATH_BYTES: usize = 103;
     const CONTROL_SOCKET_OVERHEAD: usize = 21;
 
@@ -194,23 +211,54 @@ fn socket_stem(state_dir: &std::path::Path, host_name: &str) -> String {
     format!("{prefix}-{hash}")
 }
 
+/// Match Herdr's API → terminal-client socket derivation exactly: remove one
+/// trailing `.sock` when present, then append `-client.sock`. Work bytewise so
+/// a non-UTF-8 Unix path stays lossless.
+pub(crate) fn client_socket_path(api_socket: &Path) -> PathBuf {
+    let raw = api_socket.as_os_str().as_bytes();
+    let stem = raw.strip_suffix(b".sock").unwrap_or(raw);
+    let mut client = stem.to_vec();
+    client.extend_from_slice(b"-client.sock");
+    PathBuf::from(std::ffi::OsString::from_vec(client))
+}
+
+pub(crate) async fn socket_accepts(path: &Path) -> bool {
+    matches!(
+        timeout(
+            Duration::from_millis(500),
+            tokio::net::UnixStream::connect(path)
+        )
+        .await,
+        Ok(Ok(_))
+    )
+}
+
 pub(crate) fn control_path(state_dir: &std::path::Path, host_name: &str) -> PathBuf {
     state_dir.join(format!("{}.ctl", socket_stem(state_dir, host_name)))
+}
+
+pub(crate) fn client_relay_path(state_dir: &std::path::Path, host_name: &str) -> PathBuf {
+    state_dir.join(format!("{}-api-client.sock", socket_stem(state_dir, host_name)))
 }
 
 impl RemoteHost {
     pub fn new(cfg: &HostConfig, state_dir: &std::path::Path) -> RemoteHost {
         let stem = socket_stem(state_dir, &cfg.name);
+        let fwd_sock = state_dir.join(format!("{stem}-api.sock"));
+        let exec_sock = state_dir.join(format!("{stem}-api-exec.sock"));
         RemoteHost {
             ctl_path: state_dir.join(format!("{stem}.ctl")),
-            fwd_sock: state_dir.join(format!("{stem}-api.sock")),
+            client_sock: client_socket_path(&fwd_sock),
+            fwd_sock,
             transport_hint: cfg.api_transport,
             cfg: cfg.clone(),
             forwarded: false,
             container: None,
             relay: None,
+            client_relay: None,
             exec_relay: None,
-            exec_sock: state_dir.join(format!("{stem}-api-exec.sock")),
+            ssh_client_relay: None,
+            exec_sock,
             last_api_transport: None,
             log: Logger::new(state_dir, false),
         }
@@ -265,6 +313,18 @@ impl RemoteHost {
             "-o".into(),
             "BatchMode=yes".into(),
         ]
+    }
+
+    fn forward_command(&self, operation: &str, remote_socket: &str) -> Vec<String> {
+        let mut args = self.base_args();
+        args.extend([
+            "-O".into(),
+            operation.into(),
+            "-L".into(),
+            format!("{}:{remote_socket}", self.fwd_sock.display()),
+            self.cfg.target.clone(),
+        ]);
+        args
     }
 
     pub async fn ensure_master(&mut self) -> Result<()> {
@@ -384,23 +444,23 @@ impl RemoteHost {
         if self.forwarded && self.fwd_sock.exists() {
             return Ok(self.fwd_sock.clone());
         }
-        // NEVER cancel a healthy forward — other processes may be using it
+        // NEVER cancel a healthy forward — other processes may be using it.
         if self.fwd_sock.exists() && ApiClient::connect(&self.fwd_sock).await.is_ok() {
             self.forwarded = true;
             return Ok(self.fwd_sock.clone());
         }
-        let spec = format!("{}:{}", self.fwd_sock.display(), remote_socket);
-        // a dead process can leave the forward registered on the master with
-        // its socket file unlinked — cancel before re-adding
-        let mut cancel = self.base_args();
-        cancel.extend(["-O".into(), "cancel".into(), "-L".into(), spec.clone(), self.cfg.target.clone()]);
+        // A dead process can leave the forward registered on the master with
+        // its socket file unlinked — cancel before re-adding.
+        let cancel = self.forward_command("cancel", remote_socket);
         let _ = ssh(&cancel, 15000).await;
         let _ = std::fs::remove_file(&self.fwd_sock);
-        let mut fwd = self.base_args();
-        fwd.extend(["-O".into(), "forward".into(), "-L".into(), spec, self.cfg.target.clone()]);
-        let res = ssh(&fwd, 15000).await;
+        let forward = self.forward_command("forward", remote_socket);
+        let res = ssh(&forward, 15000).await;
         if res.code != 0 {
-            return Err(err(format!("ssh socket forward failed: {}", nonempty(&res.err, res.code))));
+            return Err(err(format!(
+                "ssh socket forward failed: {}",
+                nonempty(&res.err, res.code)
+            )));
         }
         self.forwarded = true;
         Ok(self.fwd_sock.clone())
@@ -430,9 +490,7 @@ impl RemoteHost {
     /// socket file unlinked. Unlike `forward_api`'s guard this cannot steal a
     /// healthy forward: it only runs after a real ping failed.
     async fn cancel_forward(&mut self, remote_socket: &str) {
-        let spec = format!("{}:{}", self.fwd_sock.display(), remote_socket);
-        let mut args = self.base_args();
-        args.extend(["-O".into(), "cancel".into(), "-L".into(), spec, self.cfg.target.clone()]);
+        let args = self.forward_command("cancel", remote_socket);
         let _ = ssh(&args, 15000).await;
         let _ = std::fs::remove_file(&self.fwd_sock);
         self.forwarded = false;
@@ -442,7 +500,7 @@ impl RemoteHost {
     /// streamlocal forward. See `ssh_relay` for the transport itself; this
     /// only resolves the relay command once and (re)starts the listener,
     /// mirroring the docker branch below one function down.
-    async fn exec_relay_transport(&mut self, remote_socket: &str) -> Result<PathBuf> {
+    pub(crate) async fn exec_relay_transport(&mut self, remote_socket: &str) -> Result<PathBuf> {
         // NEVER steal a healthy relay — same reasoning as the docker guard:
         // the socket path is per-host but shared across processes (daemon,
         // `remote-*` actions, `once`), and state_dir is a single fixed path.
@@ -470,6 +528,68 @@ impl RemoteHost {
         Ok(path)
     }
 
+    pub(crate) async fn client_relay_transport(
+        &mut self,
+        remote_socket: &str,
+    ) -> Result<PathBuf> {
+        if self.ssh_client_relay.as_ref().is_some_and(|relay| relay.path.exists()) {
+            return Ok(self.client_sock.clone());
+        }
+        // A second daemon or a one-shot command may own the stable path. Do
+        // not unlink a listener that is accepting connections for live panes.
+        if self.ssh_client_relay.is_none() && socket_accepts(&self.client_sock).await {
+            return Ok(self.client_sock.clone());
+        }
+        self.ssh_client_relay = None;
+        let remote_client = client_socket_path(Path::new(remote_socket));
+        let remote_client = remote_client
+            .to_str()
+            .ok_or_else(|| err("remote Herdr client socket is not valid UTF-8"))?;
+        let relay_cmd = crate::ssh_relay::detect_relay_command(self, remote_client).await?;
+        self.log.log(&format!(
+            "[{}] terminal client relay via {} → {remote_client}",
+            self.cfg.name,
+            relay_cmd.tool()
+        ));
+        let handle = crate::ssh_relay::serve_relay(
+            self.ctl_path.clone(),
+            self.cfg.target.clone(),
+            relay_cmd,
+            self.client_sock.clone(),
+            self.log.clone(),
+        )?;
+        let path = handle.path.clone();
+        self.ssh_client_relay = Some(handle);
+        Ok(path)
+    }
+
+    async fn ensure_docker_client_relay(
+        &mut self,
+        container: &crate::docker::Container,
+        remote_socket: &str,
+    ) -> Result<PathBuf> {
+        if self.client_relay.as_ref().is_some_and(|relay| relay.path.exists()) {
+            return Ok(self.client_sock.clone());
+        }
+        if self.client_relay.is_none() && socket_accepts(&self.client_sock).await {
+            return Ok(self.client_sock.clone());
+        }
+        self.client_relay = None;
+        let remote_client = client_socket_path(Path::new(remote_socket));
+        let remote_client = remote_client
+            .to_str()
+            .ok_or_else(|| err("remote Herdr client socket is not valid UTF-8"))?;
+        let handle = crate::docker::serve_relay(
+            container.clone(),
+            remote_client.to_string(),
+            self.client_sock.clone(),
+            self.log.clone(),
+        )?;
+        let path = handle.path.clone();
+        self.client_relay = Some(handle);
+        Ok(path)
+    }
+
     /// Choose and reach the ssh API transport: streamlocal socket forward, or
     /// an exec relay. `api_transport = "socket"` / `"exec"` pin one and never
     /// try the other; the default `"auto"` tries the socket transport first
@@ -489,6 +609,12 @@ impl RemoteHost {
         if start_with_socket {
             match self.try_socket_transport(remote_socket).await {
                 Ok(api) => {
+                    if let Err(e) = self.client_relay_transport(remote_socket).await {
+                        self.log.log(&format!(
+                            "[{}] terminal client relay unavailable ({e}) — panes will use direct ssh",
+                            self.cfg.name
+                        ));
+                    }
                     self.last_api_transport = Some(ApiTransport::Socket);
                     return Ok(api);
                 }
@@ -509,6 +635,12 @@ impl RemoteHost {
 
         let sock = self.exec_relay_transport(remote_socket).await?;
         let api = ApiClient::connect(&sock).await?;
+        if let Err(e) = self.client_relay_transport(remote_socket).await {
+            self.log.log(&format!(
+                "[{}] terminal client relay unavailable ({e}) — panes will use direct ssh",
+                self.cfg.name
+            ));
+        }
         self.last_api_transport = Some(ApiTransport::Exec);
         Ok(api)
     }
@@ -556,6 +688,15 @@ impl RemoteHost {
             }
         };
         let api = ApiClient::connect(&sock).await?;
+        if let Err(e) = self
+            .ensure_docker_client_relay(container.as_ref().unwrap(), &status.socket)
+            .await
+        {
+            self.log.log(&format!(
+                "[{}] terminal client relay unavailable ({e}) — panes will use direct docker",
+                self.cfg.name
+            ));
+        }
         Ok((api, status))
     }
 
@@ -618,6 +759,110 @@ mod tests {
     }
 
     #[test]
+    fn herdr_client_socket_path_matches_the_real_cli() {
+        assert_eq!(
+            client_socket_path(Path::new("/tmp/host-api.sock")),
+            PathBuf::from("/tmp/host-api-client.sock")
+        );
+        assert_eq!(
+            client_socket_path(Path::new("/tmp/host-api-exec.sock")),
+            PathBuf::from("/tmp/host-api-exec-client.sock")
+        );
+        assert_eq!(
+            client_socket_path(Path::new("/tmp/custom")),
+            PathBuf::from("/tmp/custom-client.sock")
+        );
+    }
+
+    #[test]
+    fn streamlocal_forward_carries_only_the_api_socket() {
+        let state_dir = PathBuf::from("/tmp/herdr-mirror");
+        let remote = RemoteHost::new(&ssh_host("work"), &state_dir);
+
+        assert_eq!(
+            remote.forward_command("forward", "/run/user/501/herdr.sock"),
+            vec![
+                "-S",
+                "/tmp/herdr-mirror/work.ctl",
+                "-o",
+                "BatchMode=yes",
+                "-O",
+                "forward",
+                "-L",
+                "/tmp/herdr-mirror/work-api.sock:/run/user/501/herdr.sock",
+                "work.example.com",
+            ]
+        );
+        assert_eq!(
+            client_relay_path(&state_dir, "work"),
+            PathBuf::from("/tmp/herdr-mirror/work-api-client.sock")
+        );
+    }
+
+    #[tokio::test]
+    async fn socket_accept_probe_distinguishes_live_and_missing_listeners() {
+        let path = test_path("socket-accepts");
+        let listener = tokio::net::UnixListener::bind(&path).unwrap();
+
+        assert!(socket_accepts(&path).await);
+        drop(listener);
+        let _ = fs::remove_file(&path);
+        assert!(!socket_accepts(&path).await);
+    }
+
+    #[tokio::test]
+    async fn docker_client_relay_replaces_stale_socket_and_pumps_bytes() {
+        use std::os::unix::fs::PermissionsExt;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let dir = test_path("docker-client-relay");
+        fs::create_dir_all(&dir).unwrap();
+        let remote_api = dir.join("remote.sock");
+        let remote_client = client_socket_path(&remote_api);
+        let listener = tokio::net::UnixListener::bind(&remote_client).unwrap();
+        let endpoint = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4];
+            stream.read_exact(&mut request).await.unwrap();
+            assert_eq!(&request, b"ping");
+            stream.write_all(b"pong").await.unwrap();
+        });
+
+        let docker = dir.join("docker");
+        fs::write(
+            &docker,
+            "#!/bin/sh\nremote=${6#UNIX-CONNECT:}\nexec python3 -c 'import socket,sys;s=socket.socket(socket.AF_UNIX);s.connect(sys.argv[1]);s.sendall(sys.stdin.buffer.read(4));sys.stdout.buffer.write(s.recv(4));sys.stdout.buffer.flush()' \"$remote\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&docker, fs::Permissions::from_mode(0o755)).unwrap();
+        let container = crate::docker::Container {
+            id: "test".into(),
+            docker_bin: docker.display().to_string(),
+        };
+        let mut cfg = ssh_host("docker");
+        cfg.kind = crate::config::HostKind::DockerContainer("test".into());
+        let mut remote = RemoteHost::new(&cfg, &dir);
+        fs::write(&remote.client_sock, b"stale").unwrap();
+
+        let local = remote
+            .ensure_docker_client_relay(&container, remote_api.to_str().unwrap())
+            .await
+            .unwrap();
+        let mode = fs::metadata(&local).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        let mut client = tokio::net::UnixStream::connect(&local).await.unwrap();
+        client.write_all(b"ping").await.unwrap();
+        let mut response = [0u8; 4];
+        client.read_exact(&mut response).await.unwrap();
+        assert_eq!(&response, b"pong");
+        endpoint.await.unwrap();
+
+        drop(remote);
+        assert!(!local.exists(), "relay owner must unlink its socket on drop");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn long_host_names_use_truncated_socket_paths() {
         let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
         let name = "remote-development-environment-with-a-very-long-name";
@@ -633,6 +878,7 @@ mod tests {
         // the ControlPath must survive OpenSSH's mux temp suffix on top
         assert!(remote.ctl_path.as_os_str().len() + 17 <= 103);
         assert!(remote.fwd_sock.as_os_str().len() <= 103);
+        assert!(remote.client_sock.as_os_str().len() <= 103);
         assert!(remote.exec_sock.as_os_str().len() <= 103);
     }
 

--- a/src/ssh_relay.rs
+++ b/src/ssh_relay.rs
@@ -158,7 +158,7 @@ struct ExecTarget {
 
 impl ExecTarget {
     fn relay_child(&self) -> Result<tokio::process::Child> {
-        let mut cmd = Command::new("ssh");
+        let mut cmd = Command::new(crate::remote::ssh_bin());
         cmd.args([
             "-S",
             &self.ctl_path.display().to_string(),


### PR DESCRIPTION
## What changed

- Keep the daemon's JSON API transport unchanged, and add a separate local relay for Herdr's terminal client-protocol socket.
- Reuse the SSH ControlMaster through exec channels for SSH hosts, with the same client-relay lifecycle for Docker hosts.
- Pass the client socket to local Herdr explicitly, without `HERDR_SOCKET_PATH` or `HERDR_SESSION`, so Herdr does not derive the wrong socket.
- Keep direct SSH/docker as a one-attempt fallback when the relay is absent, cannot spawn, or produces no terminal frame within the startup deadline.

## Why

Herdr uses separate sockets for its JSON API and terminal sessions. The previous PR revision proved the API forward, then launched the terminal client against that API path; Herdr derived a client-socket path nobody served, leaving mirrored panes blank. A second Unix-to-Unix OpenSSH forward is not portable on the affected macOS path, so terminal traffic needs its own exec relay.

## Usage

No usage change.

Refs #60
