### PR TITLE
Prevent recovery from writing into active remote panes

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -405,6 +405,10 @@ async fn has_live_streamer(local: &ApiClient, pane_id: &str) -> Option<bool> {
     }))
 }
 
+fn streamer_recovery_needed(process_info_live: Option<bool>, pidfile_live: bool) -> bool {
+    process_info_live == Some(false) && !pidfile_live
+}
+
 /// Is this foreground process one of our pane wrappers?
 ///
 /// argv[0] is the resolved exe path, which varies by install (release build,
@@ -449,7 +453,10 @@ async fn heal_zombie_mirrors(
         // line into the user's live remote session instead.
         let mut dead: Vec<(String, String)> = Vec::new();
         for (remote_pane_id, local_pane_id) in panes {
-            if has_live_streamer(local, &local_pane_id).await == Some(false) {
+            let process_info_live = has_live_streamer(local, &local_pane_id).await;
+            let pidfile_live = crate::util::streamer_alive(state_dir, &h.target, &remote_pane_id)
+                || crate::util::pane_streamer_alive(state_dir, &local_pane_id);
+            if streamer_recovery_needed(process_info_live, pidfile_live) {
                 dead.push((remote_pane_id, local_pane_id));
             }
         }
@@ -985,5 +992,15 @@ mod tests {
     fn other_subcommands_are_not_streamers() {
         assert!(!is_streamer_argv(&argv(&["/usr/local/bin/herdr-mirror", "status"])));
         assert!(!is_streamer_argv(&argv(&["/usr/local/bin/herdr-mirror"])));
+    }
+
+    /// The live failure reported no foreground streamer while its pidfile
+    /// already named the active wrapper. Recovery must trust either signal.
+    #[test]
+    fn a_live_pidfile_blocks_false_recovery() {
+        assert!(!streamer_recovery_needed(Some(false), true));
+        assert!(!streamer_recovery_needed(Some(true), false));
+        assert!(!streamer_recovery_needed(None, false));
+        assert!(streamer_recovery_needed(Some(false), false));
     }
 }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -732,6 +732,7 @@ pub(crate) async fn spawn_streamer_pane(
                 .await
                 .is_err()
             {
+                crate::util::clear_streamer_spawn_pending(&state_dir, &pane_id);
                 return; // pane gone (closed meanwhile) — nothing to heal
             }
         }
@@ -739,6 +740,7 @@ pub(crate) async fn spawn_streamer_pane(
         if !crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target)
             && !crate::util::pane_streamer_alive(&state_dir, &pane_id)
         {
+            crate::util::clear_streamer_spawn_pending(&state_dir, &pane_id);
             log.log(&format!(
                 "streamer for {pane_target} still not up in {pane_id} after retries — pane left as a shell"
             ));

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -668,6 +668,32 @@ pub(crate) async fn spawn_streamer_pane(
     argv: &[String],
     log: &Logger,
 ) {
+    let (Some(ssh_target), Some(pane_target)) = (argv.get(2).cloned(), argv.get(3).cloned())
+    else {
+        log.log(&format!("refusing malformed streamer command for {local_pane_id}"));
+        return;
+    };
+    match crate::util::claim_streamer_spawn(
+        state_dir,
+        &ssh_target,
+        &pane_target,
+        local_pane_id,
+    ) {
+        Ok(crate::util::StreamerSpawnClaim::Claimed) => {}
+        Ok(crate::util::StreamerSpawnClaim::Active) => {
+            log.log(&format!("streamer for {pane_target} already active in {local_pane_id}; not retyping"));
+            return;
+        }
+        Ok(crate::util::StreamerSpawnClaim::Pending) => {
+            log.log(&format!("streamer launch for {pane_target} already pending in {local_pane_id}; not retyping"));
+            return;
+        }
+        Err(e) => {
+            log.log(&format!("cannot claim streamer launch for {local_pane_id}: {e}; not retyping"));
+            return;
+        }
+    }
+
     let line = format!(
         "exec {}\n",
         argv.iter().map(|a| sh_quote(a)).collect::<Vec<_>>().join(" ")
@@ -676,6 +702,7 @@ pub(crate) async fn spawn_streamer_pane(
         .request("pane.send_text", json!({ "pane_id": local_pane_id, "text": line }))
         .await
     {
+        crate::util::clear_streamer_spawn_pending(state_dir, local_pane_id);
         log.log(&format!("spawn streamer {local_pane_id}: {e}"));
         return;
     }
@@ -687,16 +714,14 @@ pub(crate) async fn spawn_streamer_pane(
     // alive-check right before each resend keeps a late-starting streamer
     // from getting the line typed into its stdin (which would forward it to
     // the remote pane as text).
-    let (Some(ssh_target), Some(pane_target)) = (argv.get(2).cloned(), argv.get(3).cloned())
-    else {
-        return;
-    };
     let (local, log, state_dir) = (local.clone(), log.clone(), state_dir.to_path_buf());
     let pane_id = local_pane_id.to_string();
     tokio::spawn(async move {
         for wait_ms in [3000u64, 4000] {
             tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
-            if crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target) {
+            if crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target)
+                || crate::util::pane_streamer_alive(&state_dir, &pane_id)
+            {
                 return;
             }
             log.log(&format!(
@@ -711,7 +736,9 @@ pub(crate) async fn spawn_streamer_pane(
             }
         }
         tokio::time::sleep(std::time::Duration::from_millis(4000)).await;
-        if !crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target) {
+        if !crate::util::streamer_alive(&state_dir, &ssh_target, &pane_target)
+            && !crate::util::pane_streamer_alive(&state_dir, &pane_id)
+        {
             log.log(&format!(
                 "streamer for {pane_target} still not up in {pane_id} after retries — pane left as a shell"
             ));

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1405,6 +1405,9 @@ impl Drop for PidfileGuard {
 }
 
 pub async fn run(args: Args) -> Result<()> {
+    let tty = !args.dump && unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1;
+    let local_pane_id = tty.then(|| std::env::var("HERDR_PANE_ID").ok()).flatten();
+
     // announce ourselves so the daemon can tell its typed `exec` took
     // (see util::streamer_pid_path); --dump is a human diagnostic, not a
     // daemon-spawned streamer, so it must not claim the slot
@@ -1416,18 +1419,25 @@ pub async fn run(args: Args) -> Result<()> {
         if let Some(dir) = path.parent() {
             let _ = std::fs::create_dir_all(dir);
         }
-        let _ = std::fs::write(&path, std::process::id().to_string());
-        PidfileGuard(path)
-    });
+        std::fs::write(&path, std::process::id().to_string()).ok().map(|_| PidfileGuard(path))
+    }).flatten();
 
-    let tty = !args.dump && unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1;
+    // Publish the pid before releasing the launch claim. Recovery always sees
+    // at least one guard, even while herdr's process snapshot catches up.
+    if _pidfile.is_some() {
+        if let Some(id) = &local_pane_id {
+            crate::util::clear_streamer_spawn_pending(
+                &crate::util::home_dir().join(".local").join("state").join("herdr-mirror"),
+                id,
+            );
+        }
+    }
 
     // Say which local pane we are drawing, so anything holding only a herdr
     // pane id can find us. herdr hands every event hook the id of the pane it
     // is talking about and no way to write to it; this is how a hook reaches
     // the streamer sitting in that pane. HERDR_PANE_ID comes from herdr itself
     // and is inherited by whatever it starts in a pane, which is us.
-    let local_pane_id = tty.then(|| std::env::var("HERDR_PANE_ID").ok()).flatten();
     let state_dir = crate::util::home_dir().join(".local").join("state").join("herdr-mirror");
     let _pane_pidfile = local_pane_id.as_deref().map(|id| {
         let path = crate::util::pane_pid_path(&state_dir, id);

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1407,13 +1407,12 @@ impl Drop for PidfileGuard {
 pub async fn run(args: Args) -> Result<()> {
     let tty = !args.dump && unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1;
     let local_pane_id = tty.then(|| std::env::var("HERDR_PANE_ID").ok()).flatten();
+    let state_dir = crate::util::home_dir().join(".local").join("state").join("herdr-mirror");
 
     // announce ourselves so the daemon can tell its typed `exec` took
     // (see util::streamer_pid_path); --dump is a human diagnostic, not a
     // daemon-spawned streamer, so it must not claim the slot
     let _pidfile = (!args.dump).then(|| {
-        let state_dir =
-            crate::util::home_dir().join(".local").join("state").join("herdr-mirror");
         let path =
             crate::util::streamer_pid_path(&state_dir, &args.ssh_target, &args.pane_target);
         if let Some(dir) = path.parent() {
@@ -1426,10 +1425,7 @@ pub async fn run(args: Args) -> Result<()> {
     // at least one guard, even while herdr's process snapshot catches up.
     if _pidfile.is_some() {
         if let Some(id) = &local_pane_id {
-            crate::util::clear_streamer_spawn_pending(
-                &crate::util::home_dir().join(".local").join("state").join("herdr-mirror"),
-                id,
-            );
+            crate::util::clear_streamer_spawn_pending(&state_dir, id);
         }
     }
 
@@ -1438,7 +1434,6 @@ pub async fn run(args: Args) -> Result<()> {
     // is talking about and no way to write to it; this is how a hook reaches
     // the streamer sitting in that pane. HERDR_PANE_ID comes from herdr itself
     // and is inherited by whatever it starts in a pane, which is us.
-    let state_dir = crate::util::home_dir().join(".local").join("state").join("herdr-mirror");
     let _pane_pidfile = local_pane_id.as_deref().map(|id| {
         let path = crate::util::pane_pid_path(&state_dir, id);
         if let Some(dir) = path.parent() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;
@@ -245,6 +246,19 @@ pub fn streamer_spawn_pending_path(state_dir: &Path, local_pane_id: &str) -> Pat
     state_dir.join("streamer-spawns").join(format!("{}.pending", sane_component(local_pane_id)))
 }
 
+/// How long a `.pending` claim may block another launch. The retype loop is
+/// 3s+4s+4s; anything older is leftover from a crashed or abandoned attempt
+/// and must not freeze heal forever.
+const SPAWN_PENDING_TTL: Duration = Duration::from_secs(30);
+
+fn pending_is_fresh(path: &Path) -> bool {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.elapsed().ok())
+        .is_some_and(|age| age < SPAWN_PENDING_TTL)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamerSpawnClaim {
     Claimed,
@@ -278,8 +292,9 @@ pub fn pane_streamer_alive(state_dir: &Path, local_pane_id: &str) -> bool {
 /// Claim the right to type one streamer launcher into a local pane.
 ///
 /// The pidfile protects an active streamer. The exclusive pending file closes
-/// the startup interval before the streamer can publish its pid. A stale claim
-/// leaves a visible shell instead of risking input in a live remote terminal.
+/// the startup interval before the streamer can publish its pid. A claim older
+/// than `SPAWN_PENDING_TTL` is treated as abandoned so a later heal can type
+/// again (session-restore after a spawn that never published a pid).
 pub fn claim_streamer_spawn(
     state_dir: &Path,
     ssh_target: &str,
@@ -296,24 +311,32 @@ pub fn claim_streamer_spawn(
     if let Some(dir) = path.parent() {
         fs::create_dir_all(dir)?;
     }
-    let mut claim = match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
-        Ok(file) => file,
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            return Ok(StreamerSpawnClaim::Pending);
-        }
-        Err(e) => return Err(e),
-    };
-    writeln!(claim, "{ssh_target} {pane_target}")?;
+    // one retry: a stale file we just unlinked can lose create_new to a racer
+    for _ in 0..2 {
+        let mut claim = match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if pending_is_fresh(&path) {
+                    return Ok(StreamerSpawnClaim::Pending);
+                }
+                let _ = fs::remove_file(&path);
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+        writeln!(claim, "{ssh_target} {pane_target}")?;
 
-    // A streamer from an earlier launch can publish its pid between the first
-    // check and our claim. Its pid wins, and its startup removes this claim.
-    if streamer_alive(state_dir, ssh_target, pane_target)
-        || pane_streamer_alive(state_dir, local_pane_id)
-    {
-        let _ = fs::remove_file(path);
-        return Ok(StreamerSpawnClaim::Active);
+        // A streamer from an earlier launch can publish its pid between the first
+        // check and our claim. Its pid wins, and its startup removes this claim.
+        if streamer_alive(state_dir, ssh_target, pane_target)
+            || pane_streamer_alive(state_dir, local_pane_id)
+        {
+            let _ = fs::remove_file(&path);
+            return Ok(StreamerSpawnClaim::Active);
+        }
+        return Ok(StreamerSpawnClaim::Claimed);
     }
-    Ok(StreamerSpawnClaim::Claimed)
+    Ok(StreamerSpawnClaim::Pending)
 }
 
 pub fn clear_streamer_spawn_pending(state_dir: &Path, local_pane_id: &str) {
@@ -413,6 +436,29 @@ mod tests {
             StreamerSpawnClaim::Pending
         );
         clear_streamer_spawn_pending(&state_dir, "w2:p2");
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Claimed
+        );
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn a_stale_pending_claim_can_be_replaced() {
+        let state_dir = test_state_dir("stale-pending");
+        let path = streamer_spawn_pending_path(&state_dir, "w2:p2");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "host w1:p1\n").unwrap();
+        let past = std::time::SystemTime::now()
+            .checked_sub(SPAWN_PENDING_TTL + Duration::from_secs(1))
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as libc::time_t;
+        let cpath = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+        let times = libc::utimbuf { actime: past, modtime: past };
+        assert_eq!(unsafe { libc::utime(cpath.as_ptr(), &times) }, 0);
+
         assert_eq!(
             claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
             StreamerSpawnClaim::Claimed

--- a/src/util.rs
+++ b/src/util.rs
@@ -237,6 +237,21 @@ pub fn streamer_pid_path(state_dir: &Path, ssh_target: &str, pane_target: &str) 
         .join(format!("{}--{}.pid", sane_component(ssh_target), sane_component(pane_target)))
 }
 
+/// A launch claim exists from the first local `pane.send_text` until the
+/// streamer writes its pidfile. Recovery must not type another command into
+/// that pane during this interval: the first streamer can already own stdin
+/// even when herdr's process snapshot still reports the shell.
+pub fn streamer_spawn_pending_path(state_dir: &Path, local_pane_id: &str) -> PathBuf {
+    state_dir.join("streamer-spawns").join(format!("{}.pending", sane_component(local_pane_id)))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamerSpawnClaim {
+    Claimed,
+    Active,
+    Pending,
+}
+
 /// Where the streamer of a given LOCAL herdr pane announces its pid.
 ///
 /// `streamer_pid_path` addresses a streamer by what it is showing (host + remote
@@ -251,6 +266,58 @@ pub fn streamer_alive(state_dir: &Path, ssh_target: &str, pane_target: &str) -> 
         .ok()
         .and_then(|s| s.trim().parse::<i32>().ok())
         .is_some_and(pid_alive)
+}
+
+pub fn pane_streamer_alive(state_dir: &Path, local_pane_id: &str) -> bool {
+    fs::read_to_string(pane_pid_path(state_dir, local_pane_id))
+        .ok()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .is_some_and(pid_alive)
+}
+
+/// Claim the right to type one streamer launcher into a local pane.
+///
+/// The pidfile protects an active streamer. The exclusive pending file closes
+/// the startup interval before the streamer can publish its pid. A stale claim
+/// leaves a visible shell instead of risking input in a live remote terminal.
+pub fn claim_streamer_spawn(
+    state_dir: &Path,
+    ssh_target: &str,
+    pane_target: &str,
+    local_pane_id: &str,
+) -> std::io::Result<StreamerSpawnClaim> {
+    if streamer_alive(state_dir, ssh_target, pane_target)
+        || pane_streamer_alive(state_dir, local_pane_id)
+    {
+        return Ok(StreamerSpawnClaim::Active);
+    }
+
+    let path = streamer_spawn_pending_path(state_dir, local_pane_id);
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+    let mut claim = match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Ok(StreamerSpawnClaim::Pending);
+        }
+        Err(e) => return Err(e),
+    };
+    writeln!(claim, "{ssh_target} {pane_target}")?;
+
+    // A streamer from an earlier launch can publish its pid between the first
+    // check and our claim. Its pid wins, and its startup removes this claim.
+    if streamer_alive(state_dir, ssh_target, pane_target)
+        || pane_streamer_alive(state_dir, local_pane_id)
+    {
+        let _ = fs::remove_file(path);
+        return Ok(StreamerSpawnClaim::Active);
+    }
+    Ok(StreamerSpawnClaim::Claimed)
+}
+
+pub fn clear_streamer_spawn_pending(state_dir: &Path, local_pane_id: &str) {
+    let _ = fs::remove_file(streamer_spawn_pending_path(state_dir, local_pane_id));
 }
 
 /// Poke the streamer drawing a given local pane, so it picks up a notice left
@@ -285,5 +352,71 @@ where
     match deadlines.into_iter().flatten().min() {
         Some(d) => tokio::time::sleep_until(d).await,
         None => std::future::pending::<()>().await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "herdr-mirror-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn a_live_pid_claim_blocks_a_recovery_write() {
+        let state_dir = test_state_dir("active-spawn");
+        let pid_path = streamer_pid_path(&state_dir, "host", "w1:p1");
+        fs::create_dir_all(pid_path.parent().unwrap()).unwrap();
+        fs::write(&pid_path, std::process::id().to_string()).unwrap();
+
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Active
+        );
+        assert!(!streamer_spawn_pending_path(&state_dir, "w2:p2").exists());
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn a_live_local_pane_pid_blocks_a_recovery_write() {
+        let state_dir = test_state_dir("active-local-pane");
+        let pid_path = pane_pid_path(&state_dir, "w2:p2");
+        fs::create_dir_all(pid_path.parent().unwrap()).unwrap();
+        fs::write(&pid_path, std::process::id().to_string()).unwrap();
+
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Active
+        );
+        assert!(!streamer_spawn_pending_path(&state_dir, "w2:p2").exists());
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn one_pending_launch_owns_each_local_pane() {
+        let state_dir = test_state_dir("pending-spawn");
+
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Claimed
+        );
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Pending
+        );
+        clear_streamer_spawn_pending(&state_dir, "w2:p2");
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Claimed
+        );
+        let _ = fs::remove_dir_all(state_dir);
     }
 }


### PR DESCRIPTION
## Why this matters

Herdr Mirror puts remote terminals in the local Herdr sidebar. Each local mirror pane forwards keyboard input to its remote terminal.

Herdr process information can briefly lag during startup. The plugin then can mistake a live mirror process for an empty shell.

Before this fix, recovery typed a launcher command into that pane. The live mirror forwarded the command to the remote terminal instead.

In a shell, this altered the prompt and ran an invalid command. In a coding agent, the final newline activated the current prompt.

This change gives each launch an exclusive claim. Recovery also checks both local and remote-target PID files before it writes anything.

If the signals conflict, the plugin leaves the local pane alone. A frozen mirror is visible and recoverable. Unexpected remote input is not acceptable.

## What changed

- Block recovery when either streamer PID guard proves that the wrapper is active.
- Add an exclusive per-pane launch claim before each `pane.send_text` call.
- Release the claim only after the streamer publishes its PID.
- Keep stale claims fail-safe. They leave a local shell instead of altering a remote terminal.

## Reproduction

A fresh sync created two active streamer processes. Three seconds later, the recovery snapshot reported both streamers as absent.

Recovery then sent each local launcher command through the active wrappers. One command reached a remote shell. The other newline activated a Codex login prompt.

## Related open work

[PR #63](https://github.com/nikok6/herdr-mirror/pull/63) adds reconnect ownership and streamer locks. Its recovery path still trusts process information before the first `pane.send_text` call. The startup race remains there.

[PR #72](https://github.com/nikok6/herdr-mirror/pull/72) changes the terminal socket relay. It keeps the existing recovery and retype logic.

[PR #58](https://github.com/nikok6/herdr-mirror/pull/58) notes transient retype logs during its smoke test. It changes workspace filtering, not streamer recovery.

## Verification

- `cargo test --locked --all-targets`: 186 passed, 2 ignored
- `cargo clippy --locked --all-targets -- -D warnings`: passed
- `cargo audit`: no vulnerable dependencies
- Live exe.dev test: two mirrors appeared and remained active
- Live daemon restart: no launcher command reached either remote pane
- Remote round-trip: `HERDR_MIRROR_PATCH_OK` appeared locally and remotely

`cargo fmt --all -- --check` still reports repository-wide existing differences. Applying rustfmt changes unrelated files, so this PR keeps the existing format.
