### PR TITLE
fix: keep pane SSH streams off control sockets

### DIFF
--- a/src/pane.rs
+++ b/src/pane.rs
@@ -221,6 +221,19 @@ pub(crate) fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
+fn ssh_stream_args(ssh_target: &str, cmd: &str) -> Vec<String> {
+    let mut argv: Vec<String> = crate::remote::SSH_COMMON_OPTS
+        .iter()
+        .map(|arg| (*arg).to_string())
+        .collect();
+    // A pane stream is long-lived and interactive. It must not inherit a
+    // ControlPath from ~/.ssh/config: a stale shared master can hang
+    // the stream before the remote command starts. `-S none` disables control
+    // socket use without changing the daemon's intentional multiplexing.
+    argv.extend(["-S".into(), "none".into(), ssh_target.into(), cmd.into()]);
+    argv
+}
+
 fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx: mpsc::Sender<Msg>) -> Result<Session> {
     // Configured paths stay unquoted so remote-shell ~ expands; auto mode is an
     // `sh -c` resolver that takes the trailing words as "$@" (see
@@ -242,7 +255,7 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
     let mut builder = match &args.container {
         None => {
             let mut c = tokio::process::Command::new("ssh");
-            c.args(crate::remote::SSH_COMMON_OPTS).arg(&args.ssh_target).arg(cmd);
+            c.args(ssh_stream_args(&args.ssh_target, &cmd));
             c
         }
         Some(ct) => {
@@ -1684,6 +1697,21 @@ pub async fn run(args: Args) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pane_ssh_stream_disables_configured_control_sockets() {
+        let argv = ssh_stream_args("work", "exec herdr terminal session observe w5:pM");
+
+        assert_eq!(
+            &argv[crate::remote::SSH_COMMON_OPTS.len()..],
+            [
+                "-S",
+                "none",
+                "work",
+                "exec herdr terminal session observe w5:pM",
+            ]
+        );
+    }
 
     /// Uncapped must stay byte-identical to the old `term_size()` call, or
     /// every existing headless-remote config silently changes behaviour.


### PR DESCRIPTION
## What changed

- Add `-S none` to pane-stream SSH arguments so each stream uses the direct connection the streamer already expects.
- Keep the daemon's explicit ControlMaster, foreground polling, paste uploads, and Docker transport unchanged.
- Pin the SSH argument order with a regression test.

## Why

A user-level `ControlMaster` and `ControlPath` can silently move a pane stream onto a stale shared master. The stream then hangs before its remote Herdr command starts, while the same command with `-S none` returns normally. Pane streams are long-lived and already designed to stay separate from the daemon's shared control connection.

## Usage

No usage change.

Closes #79
