### PR TITLE
fix: a click in the host picker can never select "this machine"

### DIFF
--- a/src/pick.rs
+++ b/src/pick.rs
@@ -709,11 +709,31 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
             }
             // a click on an option row picks it outright; anywhere else ignores
             Key::Click { y } => {
-                if let Some(idx) = (y as usize).checked_sub(FIRST_ROW_Y) {
-                    if idx < rows.len() {
+                let idx = (y as usize).checked_sub(FIRST_ROW_Y).filter(|i| *i < rows.len());
+                match idx {
+                    // NEVER let a CLICK resolve to row 0, "this machine".
+                    //
+                    // FIRST_ROW_Y counts draw()'s preamble assuming this pane's own
+                    // row 1 is what the mouse reports as row 1. The popup is a
+                    // floating BORDERED pane (open_popup sends placement = "popup")
+                    // placed anywhere on the screen, so that assumption is unverified
+                    // -- and its failure is NOT symmetric. Row 0 is the only entry
+                    // that runs create_local(), which passes the local CWD_ENV: a
+                    // misaimed click there silently opens a new LOCAL workspace in
+                    // the local directory while the user believes they picked a
+                    // remote host. That is the reported bug -- click "macbook", get a
+                    // new local path. Every other misaim picks a different remote
+                    // host, which is visible and harmless, or falls outside the list
+                    // and is already ignored.
+                    //
+                    // "this machine" stays one keypress away: it is the default
+                    // selection so Enter takes it, and so does `1`.
+                    Some(0) => {}
+                    Some(i) => {
                         finish(&mut out);
-                        return Ok(Some(idx));
+                        return Ok(Some(i));
                     }
+                    None => {}
                 }
             }
             Key::Enter => {
@@ -735,6 +755,7 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
 /// positions each row absolutely from this, and the click handler subtracts it,
 /// so the two can no longer disagree about where the list actually is.
 const FIRST_ROW_Y: usize = 6;
+
 
 fn draw(out: &mut impl Write, rows: &[Row], sel: usize, note: Option<&str>) {
     // full redraw each keypress: the popup is tiny and this keeps it stateless

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -710,6 +710,7 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
             // a click on an option row picks it outright; anywhere else ignores
             Key::Click { y } => {
                 let idx = (y as usize).checked_sub(FIRST_ROW_Y).filter(|i| *i < rows.len());
+                log_click(y, idx, rows.len());
                 match idx {
                     // NEVER let a CLICK resolve to row 0, "this machine".
                     //
@@ -756,6 +757,16 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
 /// so the two can no longer disagree about where the list actually is.
 const FIRST_ROW_Y: usize = 6;
 
+/// Record every click so the row mapping above can be CALIBRATED against a real
+/// event instead of assumed. Appends one line to
+/// ~/.local/state/herdr-mirror/click-debug.log; best-effort, never fails a pick.
+fn log_click(y: u32, idx: Option<usize>, n_rows: usize) {
+    let Ok(home) = std::env::var("HOME") else { return };
+    let path = std::path::Path::new(&home).join(".local/state/herdr-mirror/click-debug.log");
+    if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(f, "click y={y} -> idx={idx:?} (FIRST_ROW_Y={FIRST_ROW_Y}, rows={n_rows})");
+    }
+}
 
 fn draw(out: &mut impl Write, rows: &[Row], sel: usize, note: Option<&str>) {
     // full redraw each keypress: the popup is tiny and this keeps it stateless


### PR DESCRIPTION
## The bug

Clicking a remote host in the New-workspace popup can silently create a **local** workspace, in the local directory, instead of the host you clicked.

Keyboard picking (arrows/wheel + Enter, or the digit keys) is unaffected — that is both the workaround and the tell, since only the click path uses the mouse row.

## Why

`run_menu` maps a click to a row with a hardcoded constant:

```rust
const FIRST_ROW_Y: usize = 6;
Key::Click { y } => { if let Some(idx) = (y as usize).checked_sub(FIRST_ROW_Y) { ... } }
```

`6` is counted off `draw()`'s preamble assuming this pane's own row 1 is what the mouse reports as row 1. But `open_popup` sends `placement = "popup"` — a floating, **bordered** pane placed anywhere on the screen — so that assumption is unverified.

The failure is **not symmetric**, which is what makes it worth guarding rather than merely correcting:

- Row 0 (`this machine`) is the only entry that calls `create_local()`, and `create_local` passes the local cwd (`CWD_ENV`).
- `create_remote()` deliberately passes no cwd at all.

So a misaimed click landing on row 0 produces a local workspace in the local directory while the user believes they picked a remote host — silently, because that is a perfectly plausible thing for the picker to have done. Every other misaim picks a *different remote host*, which is immediately visible and harmless, or falls outside the list and was already ignored.

## What this does

**1. A click may never resolve to index 0.**

The constant is deliberately left alone. I could not determine the correct value locally — it depends on whether herdr reports mouse rows screen-absolute or relative to the pane, and on whether the popup's border is counted — and shipping a second unproven constant helps nobody. Removing the one outcome that is silently wrong does.

`this machine` stays one keypress away: it is the default selection, so <kbd>Enter</kbd> takes it, and so does <kbd>1</kbd>.

**2. Temporary click logging** so the mapping can be calibrated from a real event:

```
click y=12 -> idx=Some(6) (FIRST_ROW_Y=6, rows=3)
```

Appended to `~/.local/state/herdr-mirror/click-debug.log`, best-effort — a failed write never fails a pick. **Happy to drop this commit** if you'd rather not carry it; it exists only so the constant can be fixed against data instead of guessed a second time. Once that lands, both this and the guard's rationale can be simplified.

## Testing

- `cargo build --release`, `cargo clippy --release --all-targets` clean, `cargo test` 187 passed / 0 failed.
- Deployed and running on a WSL host with two configured remotes; mirrors intact across the daemon restart.

## Not ruled out

My `daemon.log` also shows `streamer for <pane> not up in <pane> — shell startup likely ate the exec; retyping` fairly often. A failed streamer leaves a plain local shell inside a mirror pane, which looks *identical* to this symptom from the user's side. The guard here is correct regardless, but if someone reports this and the guard doesn't help them, that's the other candidate.
