### PR TITLE
fix: a replaced binary made every streamer argv unrunnable

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -684,6 +684,16 @@ pub fn cmd_start(env: &Env) -> Result<()> {
         println!("mirror daemon already running");
         return Ok(());
     }
+    // A stale pidfile is not proof that nothing is running. Starting beside an
+    // orphan gives every remote workspace two mirrors, and the second one comes
+    // from a daemon no command here can see.
+    let others = other_daemon_pids(None);
+    if !others.is_empty() {
+        let list = others.iter().map(i32::to_string).collect::<Vec<_>>().join(", ");
+        println!("not starting: a mirror daemon is already running (pid {list}) that the pidfile does not track");
+        println!("run `herdr-mirror pause` first — it stops untracked daemons too — then start again");
+        return Ok(());
+    }
     let exe = crate::util::self_exe_path()
         .ok_or_else(|| err("cannot locate the herdr-mirror binary to respawn"))?;
     let log = fs::OpenOptions::new()
@@ -705,15 +715,56 @@ pub fn cmd_start(env: &Env) -> Result<()> {
     Ok(())
 }
 
+/// Live `herdr-mirror daemon` processes other than this one, skipping `skip`.
+///
+/// The pidfile alone is not enough. If it goes stale -- an orphan that was
+/// never written to it, or a shutdown that removed the file while another
+/// daemon was still up -- a second daemon starts happily beside the first.
+/// Both then mirror every remote workspace, so every create lands twice and
+/// the only outward sign is doubled log lines. Uses `ps` rather than /proc so
+/// it works on macOS as well as Linux.
+fn other_daemon_pids(skip: Option<i32>) -> Vec<i32> {
+    let me = std::process::id() as i32;
+    let Ok(out) = std::process::Command::new("ps").args(["-eo", "pid=,args="]).output() else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (pid, args) = line.trim().split_once(' ')?;
+            let pid: i32 = pid.trim().parse().ok()?;
+            if pid == me || Some(pid) == skip {
+                return None;
+            }
+            let mut words = args.split_whitespace();
+            let bin = words.next()?;
+            // argv[0] is our binary and argv[1] is exactly `daemon`, so a
+            // `pane` streamer or someone's grep never matches
+            let is_ours = std::path::Path::new(bin)
+                .file_name()
+                .is_some_and(|f| f.to_string_lossy().starts_with("herdr-mirror"));
+            (is_ours && words.next() == Some("daemon")).then_some(pid)
+        })
+        .collect()
+}
+
 pub fn cmd_pause(env: &Env) {
     // sticky: mirrors stay, only the sync loop halts; resume with start
     set_paused(env, true);
-    match running_pid(env) {
+    let tracked = running_pid(env);
+    match tracked {
         None => println!("mirror daemon already stopped; paused (won't autostart until you run start)"),
         Some(pid) => {
             unsafe { libc::kill(pid, libc::SIGTERM) };
             println!("paused mirror daemon (pid {pid}); mirrors stay, resume with start");
         }
+    }
+    // Stop the ones the pidfile never knew about too. Leaving one behind is the
+    // whole failure this guards against: it keeps mirroring while status says
+    // stopped, and the next start puts a second daemon beside it.
+    for pid in other_daemon_pids(tracked) {
+        unsafe { libc::kill(pid, libc::SIGTERM) };
+        println!("also stopped untracked mirror daemon (pid {pid})");
     }
 }
 
@@ -732,7 +783,13 @@ pub fn cmd_ensure(env: &Env) {
 
 pub fn cmd_status(env: &Env) -> Result<()> {
     match running_pid(env) {
-        Some(pid) => println!("daemon: running (pid {pid})"),
+        Some(pid) => {
+            println!("daemon: running (pid {pid})");
+            for other in other_daemon_pids(Some(pid)) {
+                println!("  WARNING: a second, untracked mirror daemon is running (pid {other})");
+                println!("  every remote workspace is being mirrored twice; `herdr-mirror pause` stops both");
+            }
+        }
         None => println!(
             "daemon: not running{}",
             if is_paused(env) { " (paused — resume with start)" } else { "" }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -15,6 +15,8 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::io::{Read, Seek, Write};
+use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -38,9 +40,100 @@ fn pid_path(env: &Env) -> PathBuf {
     env.state_dir.join("daemon.pid")
 }
 
-pub fn running_pid(env: &Env) -> Option<i32> {
+fn daemon_lock_path(env: &Env) -> PathBuf {
+    env.state_dir.join("daemon.lock")
+}
+
+fn open_daemon_lock(env: &Env) -> Result<fs::File> {
+    Ok(fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(daemon_lock_path(env))?)
+}
+
+fn try_lock(file: &fs::File) -> Result<bool> {
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(true);
+    }
+    let e = std::io::Error::last_os_error();
+    if e.kind() == std::io::ErrorKind::WouldBlock {
+        Ok(false)
+    } else {
+        Err(e.into())
+    }
+}
+
+enum DaemonLockState {
+    Unlocked,
+    Locked(Option<i32>),
+}
+
+/// The lifetime lock is authoritative for daemons from this release onward.
+/// Its contents identify the owner so commands can still signal the right
+/// process if daemon.pid is deleted. An unlocked file may contain a stale PID;
+/// the lock state, rather than the file's contents, decides whether it is live.
+fn daemon_lock_state(env: &Env) -> Result<DaemonLockState> {
+    let mut file = open_daemon_lock(env)?;
+    if try_lock(&file)? {
+        let _ = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+        return Ok(DaemonLockState::Unlocked);
+    }
+    let mut contents = String::new();
+    file.rewind()?;
+    file.read_to_string(&mut contents)?;
+    let pid = contents.trim().parse().ok().filter(|pid| pid_alive(*pid));
+    Ok(DaemonLockState::Locked(pid))
+}
+
+struct DaemonLifetime {
+    _lock: fs::File,
+    pid_file: PathBuf,
+    pid: i32,
+}
+
+impl Drop for DaemonLifetime {
+    fn drop(&mut self) {
+        // Never erase a newer owner's record if shutdowns overlap.
+        let ours = fs::read_to_string(&self.pid_file)
+            .ok()
+            .and_then(|s| s.trim().parse::<i32>().ok())
+            == Some(self.pid);
+        if ours {
+            let _ = fs::remove_file(&self.pid_file);
+        }
+        let _ = unsafe { libc::flock(self._lock.as_raw_fd(), libc::LOCK_UN) };
+    }
+}
+
+fn acquire_daemon_lifetime(env: &Env) -> Result<DaemonLifetime> {
+    let mut lock = open_daemon_lock(env)?;
+    if !try_lock(&lock)? {
+        return Err(err("mirror daemon already running for this state directory"));
+    }
+    let pid = std::process::id() as i32;
+    lock.set_len(0)?;
+    lock.rewind()?;
+    writeln!(lock, "{pid}")?;
+    lock.flush()?;
+    let guard = DaemonLifetime { _lock: lock, pid_file: pid_path(env), pid };
+    fs::write(&guard.pid_file, pid.to_string())?;
+    Ok(guard)
+}
+
+fn legacy_running_pid(env: &Env) -> Option<i32> {
     let pid: i32 = fs::read_to_string(pid_path(env)).ok()?.trim().parse().ok()?;
     pid_alive(pid).then_some(pid)
+}
+
+pub fn running_pid(env: &Env) -> Option<i32> {
+    match daemon_lock_state(env) {
+        Ok(DaemonLockState::Locked(pid)) => pid,
+        // Compatibility with a daemon started by an older binary, which wrote
+        // daemon.pid but did not hold daemon.lock for its lifetime.
+        Ok(DaemonLockState::Unlocked) | Err(_) => legacy_running_pid(env),
+    }
 }
 
 // Sticky pause marker: blocks the focus-hook autostart until an explicit
@@ -558,10 +651,10 @@ async fn local_events_task(
 // --- commands ---
 
 pub async fn cmd_run(env: Env) -> Result<()> {
+    let _daemon_lifetime = acquire_daemon_lifetime(&env)?;
     let detached = std::env::var("HERDR_MIRROR_DETACHED").is_ok();
     let log = Logger::new(&env.state_dir, !detached);
     let config = load_config(&env.config_search)?;
-    fs::write(pid_path(&env), std::process::id().to_string())?;
     log.log(&format!(
         "daemon starting (pid {}, hosts: {}, config: {})",
         std::process::id(),
@@ -664,34 +757,23 @@ pub async fn cmd_run(env: Env) -> Result<()> {
                 .await;
         }
     }
-    let _ = fs::remove_file(pid_path(&env));
     Ok(())
 }
 
 pub fn cmd_start(env: &Env) -> Result<()> {
-    // flock + parent-written pidfile: two racing starts (focus hook) must not
-    // both see "not running" and spawn duplicate daemons
-    use std::os::fd::AsRawFd;
+    // Serialize launch attempts. The child separately owns daemon.lock for its
+    // full lifetime; this short lock only keeps two `start` calls from both
+    // spawning candidates before either child publishes readiness.
     let lock = fs::OpenOptions::new()
         .create(true)
         .truncate(false)
         .write(true)
-        .open(env.state_dir.join("daemon.lock"))?;
+        .open(env.state_dir.join("daemon.start.lock"))?;
     if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX) } != 0 {
-        return Err(err("cannot lock daemon.lock"));
+        return Err(err("cannot lock daemon.start.lock"));
     }
     if running_pid(env).is_some() {
         println!("mirror daemon already running");
-        return Ok(());
-    }
-    // A stale pidfile is not proof that nothing is running. Starting beside an
-    // orphan gives every remote workspace two mirrors, and the second one comes
-    // from a daemon no command here can see.
-    let others = other_daemon_pids(None);
-    if !others.is_empty() {
-        let list = others.iter().map(i32::to_string).collect::<Vec<_>>().join(", ");
-        println!("not starting: a mirror daemon is already running (pid {list}) that the pidfile does not track");
-        println!("run `herdr-mirror pause` first — it stops untracked daemons too — then start again");
         return Ok(());
     }
     let exe = crate::util::self_exe_path()
@@ -702,7 +784,7 @@ pub fn cmd_start(env: &Env) -> Result<()> {
         .open(env.state_dir.join("daemon.log"))?;
     let log2 = log.try_clone()?;
     use std::os::unix::process::CommandExt;
-    let child = std::process::Command::new(exe)
+    let mut child = std::process::Command::new(exe)
         .arg("daemon")
         .stdin(std::process::Stdio::null())
         .stdout(log)
@@ -710,61 +792,29 @@ pub fn cmd_start(env: &Env) -> Result<()> {
         .env("HERDR_MIRROR_DETACHED", "1")
         .process_group(0)
         .spawn()?;
-    fs::write(pid_path(env), child.id().to_string())?;
-    println!("mirror daemon started (pid {})", child.id());
-    Ok(())
-}
-
-/// Live `herdr-mirror daemon` processes other than this one, skipping `skip`.
-///
-/// The pidfile alone is not enough. If it goes stale -- an orphan that was
-/// never written to it, or a shutdown that removed the file while another
-/// daemon was still up -- a second daemon starts happily beside the first.
-/// Both then mirror every remote workspace, so every create lands twice and
-/// the only outward sign is doubled log lines. Uses `ps` rather than /proc so
-/// it works on macOS as well as Linux.
-fn other_daemon_pids(skip: Option<i32>) -> Vec<i32> {
-    let me = std::process::id() as i32;
-    let Ok(out) = std::process::Command::new("ps").args(["-eo", "pid=,args="]).output() else {
-        return Vec::new();
-    };
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|line| {
-            let (pid, args) = line.trim().split_once(' ')?;
-            let pid: i32 = pid.trim().parse().ok()?;
-            if pid == me || Some(pid) == skip {
-                return None;
-            }
-            let mut words = args.split_whitespace();
-            let bin = words.next()?;
-            // argv[0] is our binary and argv[1] is exactly `daemon`, so a
-            // `pane` streamer or someone's grep never matches
-            let is_ours = std::path::Path::new(bin)
-                .file_name()
-                .is_some_and(|f| f.to_string_lossy().starts_with("herdr-mirror"));
-            (is_ours && words.next() == Some("daemon")).then_some(pid)
-        })
-        .collect()
+    let expected = child.id() as i32;
+    for _ in 0..100 {
+        if running_pid(env) == Some(expected) {
+            println!("mirror daemon started (pid {expected})");
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait()? {
+            return Err(err(format!("mirror daemon exited during startup ({status})")));
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    Err(err(format!("mirror daemon did not become ready (pid {expected})")))
 }
 
 pub fn cmd_pause(env: &Env) {
     // sticky: mirrors stay, only the sync loop halts; resume with start
     set_paused(env, true);
-    let tracked = running_pid(env);
-    match tracked {
+    match running_pid(env) {
         None => println!("mirror daemon already stopped; paused (won't autostart until you run start)"),
         Some(pid) => {
             unsafe { libc::kill(pid, libc::SIGTERM) };
             println!("paused mirror daemon (pid {pid}); mirrors stay, resume with start");
         }
-    }
-    // Stop the ones the pidfile never knew about too. Leaving one behind is the
-    // whole failure this guards against: it keeps mirroring while status says
-    // stopped, and the next start puts a second daemon beside it.
-    for pid in other_daemon_pids(tracked) {
-        unsafe { libc::kill(pid, libc::SIGTERM) };
-        println!("also stopped untracked mirror daemon (pid {pid})");
     }
 }
 
@@ -783,13 +833,7 @@ pub fn cmd_ensure(env: &Env) {
 
 pub fn cmd_status(env: &Env) -> Result<()> {
     match running_pid(env) {
-        Some(pid) => {
-            println!("daemon: running (pid {pid})");
-            for other in other_daemon_pids(Some(pid)) {
-                println!("  WARNING: a second, untracked mirror daemon is running (pid {other})");
-                println!("  every remote workspace is being mirrored twice; `herdr-mirror pause` stops both");
-            }
-        }
+        Some(pid) => println!("daemon: running (pid {pid})"),
         None => println!(
             "daemon: not running{}",
             if is_paused(env) { " (paused — resume with start)" } else { "" }
@@ -983,6 +1027,50 @@ mod tests {
             "type": "pane.agent_status_changed",
             "pane_id": "w1:p1",
         })));
+    }
+
+    fn lock_test_env(tag: &str) -> Env {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let state_dir = std::env::temp_dir().join(format!(
+            "herdr-mirror-daemon-lock-{tag}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&state_dir).unwrap();
+        Env { config_search: Vec::new(), state_dir, local_socket: PathBuf::new() }
+    }
+
+    #[test]
+    fn daemon_lifetime_lock_excludes_a_second_owner() {
+        let env = lock_test_env("exclusive");
+        let owner = acquire_daemon_lifetime(&env).unwrap();
+        assert_eq!(running_pid(&env), Some(std::process::id() as i32));
+        assert!(acquire_daemon_lifetime(&env).is_err());
+        drop(owner);
+        assert_eq!(running_pid(&env), None);
+        let _ = fs::remove_dir_all(&env.state_dir);
+    }
+
+    #[test]
+    fn locked_owner_is_recovered_when_pidfile_disappears() {
+        let env = lock_test_env("missing-pidfile");
+        let owner = acquire_daemon_lifetime(&env).unwrap();
+        fs::remove_file(pid_path(&env)).unwrap();
+        assert_eq!(running_pid(&env), Some(std::process::id() as i32));
+        drop(owner);
+        let _ = fs::remove_dir_all(&env.state_dir);
+    }
+
+    #[test]
+    fn lifetime_guard_does_not_remove_a_newer_pidfile() {
+        let env = lock_test_env("new-owner");
+        let owner = acquire_daemon_lifetime(&env).unwrap();
+        fs::write(pid_path(&env), "123456").unwrap();
+        drop(owner);
+        assert_eq!(fs::read_to_string(pid_path(&env)).unwrap(), "123456");
+        let _ = fs::remove_dir_all(&env.state_dir);
     }
 
     /// One fallback is not evidence: the probe also fails when the remote herdr

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -684,7 +684,8 @@ pub fn cmd_start(env: &Env) -> Result<()> {
         println!("mirror daemon already running");
         return Ok(());
     }
-    let exe = std::env::current_exe()?;
+    let exe = crate::util::self_exe_path()
+        .ok_or_else(|| err("cannot locate the herdr-mirror binary to respawn"))?;
     let log = fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -442,9 +442,7 @@ pub(crate) fn cmd_for_pane(
     state_dir: &std::path::Path,
     sizes: &HashMap<String, LayoutRect>,
 ) -> impl Fn(&str) -> Vec<String> {
-    let exe = std::env::current_exe()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| "herdr-mirror".into());
+    let exe = crate::util::self_exe();
     let target = host.target.clone();
     let remote_bin = host.remote_bin.clone();
     let session = host.session.clone();

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,9 @@
 
 use std::fs;
 use std::io::Write;
+use std::ffi::OsString;
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -76,13 +79,30 @@ pub fn default_config_dir() -> PathBuf {
     home_dir().join(".config").join("herdr-mirror")
 }
 
-const DELETED_MARKER: &str = " (deleted)";
+const DELETED_MARKER: &[u8] = b" (deleted)";
 
 /// `/proc/self/exe` gains a literal " (deleted)" suffix once the file behind it
 /// is replaced or unlinked. Returns the path without it, or None when there is
 /// no marker to strip. Pure, so the rule is testable without unlinking a binary.
 fn strip_deleted_marker(p: &Path) -> Option<PathBuf> {
-    p.to_str().and_then(|s| s.strip_suffix(DELETED_MARKER)).map(PathBuf::from)
+    let stripped = p.as_os_str().as_bytes().strip_suffix(DELETED_MARKER)?;
+    Some(PathBuf::from(OsString::from_vec(stripped.to_vec())))
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+/// Resolve the path a future child should execute from a path reported for the
+/// current process. The replacement must already exist and be executable: a
+/// path that merely happens to look right is not safe to put into pane argv.
+fn resolve_reported_exe(reported: &Path) -> Option<PathBuf> {
+    if is_executable_file(reported) {
+        return Some(reported.to_path_buf());
+    }
+    let stripped = strip_deleted_marker(reported)?;
+    is_executable_file(&stripped).then_some(stripped)
 }
 
 /// A path to THIS binary that can still be RUN.
@@ -96,21 +116,13 @@ fn strip_deleted_marker(p: &Path) -> Option<PathBuf> {
 /// `Command::new` when respawning the daemon, and symlinked into the CLI link by
 /// `repair_cli_link`, which would have made the breakage outlive the process.
 ///
-/// Order: the reported path if it is really there; the same path with the marker
-/// stripped (a rebuild in place -- the common case); then the stable CLI link,
-/// which by definition points at whatever is current.
+/// Order: the reported path if it is executable, then the same path with the
+/// Linux marker stripped (a rebuild in place -- the common case). The CLI link
+/// is deliberately not a fallback: this project permits that link to point at
+/// another installation and reports it as `CliLink::Other` below.
 pub fn self_exe_path() -> Option<PathBuf> {
     let reported = std::env::current_exe().ok()?;
-    if reported.is_file() {
-        return Some(reported);
-    }
-    if let Some(stripped) = strip_deleted_marker(&reported) {
-        if stripped.is_file() {
-            return Some(stripped);
-        }
-    }
-    let link = cli_link_path();
-    link.is_file().then_some(link)
+    resolve_reported_exe(&reported)
 }
 
 /// `self_exe_path` as a command string, falling back to a bare name so PATH
@@ -524,7 +536,7 @@ mod tests {
 
     #[test]
     fn deleted_marker_is_stripped_only_when_it_is_a_real_suffix() {
-        use super::strip_deleted_marker;
+        use super::{resolve_reported_exe, strip_deleted_marker};
         assert_eq!(
             strip_deleted_marker(Path::new("/usr/bin/herdr-mirror (deleted)")),
             Some(PathBuf::from("/usr/bin/herdr-mirror"))
@@ -532,5 +544,27 @@ mod tests {
         assert_eq!(strip_deleted_marker(Path::new("/usr/bin/herdr-mirror")), None);
         // the words appearing mid-path are a directory name, not the kernel marker
         assert_eq!(strip_deleted_marker(Path::new("/tmp/x (deleted)/herdr-mirror")), None);
+
+        // Model the real replacement case without unlinking the test runner:
+        // the reported path is gone, while the original path names the new,
+        // executable inode installed in its place.
+        let executable = std::env::current_exe().unwrap();
+        let mut reported = executable.as_os_str().as_bytes().to_vec();
+        reported.extend_from_slice(DELETED_MARKER);
+        assert_eq!(
+            resolve_reported_exe(Path::new(&OsString::from_vec(reported))),
+            Some(executable)
+        );
+    }
+
+    #[test]
+    fn replacement_path_must_exist_and_be_executable() {
+        let root = test_state_dir("replacement-exe");
+        fs::create_dir_all(&root).unwrap();
+        let candidate = root.join("herdr-mirror");
+        fs::write(&candidate, "not executable").unwrap();
+        let reported = PathBuf::from(format!("{} (deleted)", candidate.display()));
+        assert_eq!(resolve_reported_exe(&reported), None);
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -76,6 +76,49 @@ pub fn default_config_dir() -> PathBuf {
     home_dir().join(".config").join("herdr-mirror")
 }
 
+const DELETED_MARKER: &str = " (deleted)";
+
+/// `/proc/self/exe` gains a literal " (deleted)" suffix once the file behind it
+/// is replaced or unlinked. Returns the path without it, or None when there is
+/// no marker to strip. Pure, so the rule is testable without unlinking a binary.
+fn strip_deleted_marker(p: &Path) -> Option<PathBuf> {
+    p.to_str().and_then(|s| s.strip_suffix(DELETED_MARKER)).map(PathBuf::from)
+}
+
+/// A path to THIS binary that can still be RUN.
+///
+/// `current_exe()` reads /proc/self/exe, and Linux appends " (deleted)" to that
+/// link the moment the file behind it is replaced -- which every rebuild does to
+/// a running daemon. Rust passes the suffix straight through, so the value went
+/// into the streamer argv and produced `exec '/path/herdr-mirror (deleted)'`: a
+/// command that cannot run, leaving a bare shell parked in the `.mirror-pane`
+/// placeholder where a mirror should be. The same value was also handed to
+/// `Command::new` when respawning the daemon, and symlinked into the CLI link by
+/// `repair_cli_link`, which would have made the breakage outlive the process.
+///
+/// Order: the reported path if it is really there; the same path with the marker
+/// stripped (a rebuild in place -- the common case); then the stable CLI link,
+/// which by definition points at whatever is current.
+pub fn self_exe_path() -> Option<PathBuf> {
+    let reported = std::env::current_exe().ok()?;
+    if reported.is_file() {
+        return Some(reported);
+    }
+    if let Some(stripped) = strip_deleted_marker(&reported) {
+        if stripped.is_file() {
+            return Some(stripped);
+        }
+    }
+    let link = cli_link_path();
+    link.is_file().then_some(link)
+}
+
+/// `self_exe_path` as a command string, falling back to a bare name so PATH
+/// lookup still gives a streamer something to try.
+pub fn self_exe() -> String {
+    self_exe_path().map(|p| p.display().to_string()).unwrap_or_else(|| "herdr-mirror".into())
+}
+
 /// The stable CLI path install.sh links and the README's keybindings use.
 pub fn cli_link_path() -> PathBuf {
     home_dir().join(".local").join("bin").join("herdr-mirror")
@@ -102,7 +145,7 @@ pub fn cli_link_state() -> CliLink {
         Err(_) => CliLink::File,
         Ok(target) => {
             let resolved = fs::canonicalize(&link).ok();
-            let exe = std::env::current_exe().ok().and_then(|e| fs::canonicalize(e).ok());
+            let exe = self_exe_path().and_then(|e| fs::canonicalize(e).ok());
             match resolved {
                 None => CliLink::Dangling(target),
                 Some(r) if exe.as_ref() == Some(&r) => CliLink::Ok(target),
@@ -132,7 +175,7 @@ pub fn cli_link_problem() -> Option<String> {
 pub fn repair_cli_link() -> Option<String> {
     cli_link_problem()?;
     let link = cli_link_path();
-    let exe = std::env::current_exe().ok()?;
+    let exe = self_exe_path()?;
     let _ = fs::create_dir_all(link.parent()?);
     let _ = fs::remove_file(&link);
     Some(match std::os::unix::fs::symlink(&exe, &link) {
@@ -477,5 +520,17 @@ mod tests {
             StreamerSpawnClaim::Claimed
         );
         let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn deleted_marker_is_stripped_only_when_it_is_a_real_suffix() {
+        use super::strip_deleted_marker;
+        assert_eq!(
+            strip_deleted_marker(Path::new("/usr/bin/herdr-mirror (deleted)")),
+            Some(PathBuf::from("/usr/bin/herdr-mirror"))
+        );
+        assert_eq!(strip_deleted_marker(Path::new("/usr/bin/herdr-mirror")), None);
+        // the words appearing mid-path are a directory name, not the kernel marker
+        assert_eq!(strip_deleted_marker(Path::new("/tmp/x (deleted)/herdr-mirror")), None);
     }
 }


### PR DESCRIPTION
## The bug

After any rebuild, new mirror panes come up as a bare shell parked in the `.mirror-pane` placeholder instead of a mirror. The prompt shows why:

```
exec '/path/to/herdr-mirror (deleted)'
```

## Cause

`std::env::current_exe()` reads `/proc/self/exe`, and Linux appends a literal `" (deleted)"` to that link the moment the file behind it is replaced or unlinked — which **every `cargo build` does to a running daemon**. Rust passes the suffix straight through.

Measured with a standalone probe that replaces its own binary underneath itself:

```
BEFORE delete: current_exe() = /tmp/probe_bin
AFTER  replace: current_exe() = /tmp/probe_bin (deleted)
  is_file()? false
```

Four call sites consumed that value without checking it:

| site | consequence |
| --- | --- |
| `mirror.rs::cmd_for_pane` | the value is **argv[0] of every streamer** → `exec '<path> (deleted)'` cannot resolve → bare shell in the placeholder. The visible bug. |
| `daemon.rs::cmd_start` | `Command::new(exe)` when respawning the daemon |
| `util.rs::cli_link_state` | `canonicalize` fails on the deleted path, so a healthy CLI link is reported as someone else's |
| `util.rs::repair_cli_link` | would **symlink the CLI link at the `(deleted)` path** — making the breakage outlive the process that caused it |

That last one is the reason this is worth fixing rather than working around: the failure can be made permanent by the very command meant to repair it.

## Fix

`util::self_exe_path()` resolves in the order that's actually safe:

1. the reported path, if it really exists;
2. the same path with the marker stripped — a rebuild in place, the common case;
3. the stable CLI link, which by definition points at whatever is current.

`self_exe()` wraps it for argv and falls back to a bare `herdr-mirror` so PATH lookup still gives a streamer something to try. All four sites use it.

`strip_deleted_marker` is kept pure so the rule is unit-testable without unlinking a binary — including the case that must **not** strip, where the words appear mid-path as an ordinary directory name.

## Testing

`cargo build --release` clean, `cargo clippy --release --all-targets` clean, `cargo test` **188 passed / 0 failed** including the new `deleted_marker_is_stripped_only_when_it_is_a_real_suffix`.

Deployed and exercised on a WSL host with two configured remotes.

## Note

This is also the mechanism behind the folklore "after any rebuild, restart the mirror daemon or new streamers exec a `(deleted)` path and die". That was a workaround for this bug, not a property of the system.

---

**Second commit: duplicate daemon detection.**

Same area, found while testing the first fix. `start`, `pause` and `status` look at nothing but the pidfile, so a daemon missing from it is invisible to all three — which is exactly what an orphan from an earlier build is. Two daemons then mirror every remote workspace: every create lands twice, `pause` reports success while mirroring continues, and the only sign is doubled lines in `daemon.log`.

`start` now refuses when it finds an untracked daemon, `pause` stops those too, and `status` warns instead of reporting one healthy daemon. Verified with a decoy process whose argv is exactly `<path>/herdr-mirror daemon`: `status` warns while it lives, goes quiet when it dies, and never fires on the real single-daemon case.

Uses `ps` rather than `/proc` so it works on macOS, and matches argv[0] being the binary plus argv[1] being exactly `daemon`, so a `pane` streamer never counts.
