### PR TITLE
fix(mouse): make mirror-pane selection reliable

### DIFF
--- a/src/foreground.rs
+++ b/src/foreground.rs
@@ -3,10 +3,11 @@
 // herdr strips the mouse-mode DECSET from the frames the plugin observes, so the
 // streamer can't tell whether the remote pane's app wants the mouse. As a proxy,
 // query the remote pane's foreground process (`herdr pane process-info`) and
-// classify it: a plain shell at a prompt never enables mouse reporting, so mouse
-// events should stay local (no garbage in the prompt); anything else is treated
-// as a possible mouse-aware TUI and clicks are forwarded. This is a heuristic
-// stand-in until herdr exposes the pane's mouse-reporting state through the API.
+// classify it: shells and plain text viewers never enable mouse reporting, so
+// mouse events should stay local (no garbage in the prompt); anything else is
+// treated as a possible mouse-aware TUI and clicks are forwarded. This is a
+// heuristic stand-in until herdr exposes the pane's mouse-reporting state through
+// the API.
 
 use std::process::Stdio;
 
@@ -15,16 +16,16 @@ use tokio::process::Command;
 use crate::pane::sh_quote;
 use crate::remote::SSH_COMMON_OPTS;
 
-/// Interactive shells: at a prompt these don't enable mouse reporting, so mouse
-/// events over them should stay local rather than being forwarded to the pty.
+/// Foregrounds known not to enable mouse reporting, so mouse events over them
+/// should stay local rather than being forwarded to the pty.
 const SHELLS: &[&str] = &[
     "bash", "zsh", "fish", "sh", "dash", "ksh", "ksh93", "mksh", "ash", "tcsh",
     "csh", "nu", "elvish", "xonsh", "osh", "ysh", "oil", "ion", "murex", "ngs",
-    "pwsh", "powershell", "cmd",
+    "pwsh", "powershell", "cmd", "less", "more", "most", "pager", "journalctl",
 ];
 
-/// Is `name` one of the known interactive shells? Normalizes a login-shell dash
-/// (`-bash`), a leading path, and a Windows `.exe` suffix before matching.
+/// Is `name` a known foreground that does not consume mouse reports? Normalizes
+/// a login-shell dash (`-bash`), a leading path, and a Windows `.exe` suffix.
 pub fn is_shell(name: &str) -> bool {
     let base = name.trim_start_matches('-').rsplit(['/', '\\']).next().unwrap_or(name);
     let n = base.trim_end_matches(".exe").to_ascii_lowercase();
@@ -158,6 +159,8 @@ mod tests {
         assert!(is_shell("-bash")); // login shell
         assert!(is_shell("/usr/bin/fish")); // full path
         assert!(is_shell("pwsh.exe")); // windows
+        assert!(is_shell("less")); // journalctl's default pager
+        assert!(is_shell("journalctl")); // follow/no-pager output
         assert!(!is_shell("vim"));
         assert!(!is_shell("htop"));
         assert!(!is_shell("nvim"));

--- a/src/foreground.rs
+++ b/src/foreground.rs
@@ -3,11 +3,10 @@
 // herdr strips the mouse-mode DECSET from the frames the plugin observes, so the
 // streamer can't tell whether the remote pane's app wants the mouse. As a proxy,
 // query the remote pane's foreground process (`herdr pane process-info`) and
-// classify it: shells and plain text viewers never enable mouse reporting, so
-// mouse events should stay local (no garbage in the prompt); anything else is
-// treated as a possible mouse-aware TUI and clicks are forwarded. This is a
-// heuristic stand-in until herdr exposes the pane's mouse-reporting state through
-// the API.
+// classify it: a plain shell at a prompt never enables mouse reporting, so mouse
+// events should stay local (no garbage in the prompt); anything else is treated
+// as a possible mouse-aware TUI and clicks are forwarded. This is a heuristic
+// stand-in until herdr exposes the pane's mouse-reporting state through the API.
 
 use std::process::Stdio;
 
@@ -16,16 +15,16 @@ use tokio::process::Command;
 use crate::pane::sh_quote;
 use crate::remote::SSH_COMMON_OPTS;
 
-/// Foregrounds known not to enable mouse reporting, so mouse events over them
-/// should stay local rather than being forwarded to the pty.
+/// Interactive shells: at a prompt these don't enable mouse reporting, so mouse
+/// events over them should stay local rather than being forwarded to the pty.
 const SHELLS: &[&str] = &[
     "bash", "zsh", "fish", "sh", "dash", "ksh", "ksh93", "mksh", "ash", "tcsh",
     "csh", "nu", "elvish", "xonsh", "osh", "ysh", "oil", "ion", "murex", "ngs",
-    "pwsh", "powershell", "cmd", "less", "more", "most", "pager", "journalctl",
+    "pwsh", "powershell", "cmd",
 ];
 
-/// Is `name` a known foreground that does not consume mouse reports? Normalizes
-/// a login-shell dash (`-bash`), a leading path, and a Windows `.exe` suffix.
+/// Is `name` one of the known interactive shells? Normalizes a login-shell dash
+/// (`-bash`), a leading path, and a Windows `.exe` suffix before matching.
 pub fn is_shell(name: &str) -> bool {
     let base = name.trim_start_matches('-').rsplit(['/', '\\']).next().unwrap_or(name);
     let n = base.trim_end_matches(".exe").to_ascii_lowercase();
@@ -159,8 +158,6 @@ mod tests {
         assert!(is_shell("-bash")); // login shell
         assert!(is_shell("/usr/bin/fish")); // full path
         assert!(is_shell("pwsh.exe")); // windows
-        assert!(is_shell("less")); // journalctl's default pager
-        assert!(is_shell("journalctl")); // follow/no-pager output
         assert!(!is_shell("vim"));
         assert!(!is_shell("htop"));
         assert!(!is_shell("nvim"));
@@ -177,4 +174,18 @@ mod tests {
         assert_eq!(classify(&none, "not json"), None);
         assert_eq!(classify("not json", &proc_with("zsh")), None);
     }
+
+    #[test]
+    fn pagers_keep_application_cursor_keys_and_mouse_capability() {
+        let pane = r#"{"result":{"pane":{"agent":null}}}"#;
+        // Fg::Shell also disables DECCKM. A pager's mouse policy must not
+        // change its cursor-key encoding, or assume less --mouse is off.
+        for name in ["less", "more", "most", "pager", "journalctl"] {
+            let proc = serde_json::json!({"result": {"process_info": {
+                "foreground_processes": [{"name": name}]
+            }}}).to_string();
+            assert_eq!(classify(pane, &proc), Some(Fg::Mouse), "{name}");
+        }
+    }
+
 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1370,7 +1370,12 @@ impl App {
                             (false, _) => match self.select.release(at, raw) {
                                 // the clipboard holds one thing, so a second
                                 // gesture in the same read legitimately wins
-                                Released::Selection(span) => copy_span = Some(span),
+                                Released::Selection(span) => {
+                                    copy_span = Some(span);
+                                    // Finish this gesture before a later press in
+                                    // the same read starts the next selection.
+                                    sel_changed |= self.select.clear();
+                                },
                                 // It was a click, not a drag. TUI/agent get it
                                 // (claude and codex discard the bytes cleanly).
                                 // A shell does not: the prompt never enabled
@@ -1415,9 +1420,6 @@ impl App {
         }
         if let Some((start, end)) = copy_span {
             let text = self.grid.selection_text(start, end);
-            // Copy-on-select matches herdr's native lifecycle: the highlight
-            // disappears as soon as the release has been copied.
-            sel_changed |= self.select.clear();
             match crate::select::osc52(&text) {
                 // no hint on success: herdr shows its own "copied to clipboard"
                 // toast when it takes the OSC 52, so ours would be a duplicate
@@ -2216,6 +2218,87 @@ mod tests {
         let (_, idx) = reconnect_delay(false, 0);
         let (_, idx) = reconnect_delay(true, idx);
         assert_eq!(reconnect_delay(false, idx), (2000, 2));
+    }
+
+
+    // Exercise the real input routing: a release and the next press can share
+    // one stdin read. A local sink stands in for the session; no SSH is used.
+    async fn selection_followed_by_press(next_drag: bool) {
+        let args = parse_args(&["unused".into(), "p1".into()]).unwrap();
+        let tty = true;
+        let (tx, _rx) = mpsc::channel(256);
+        let mut app = App {
+            args,
+            tty,
+            grid: Grid::new(),
+            renderer: Renderer::new(),
+            tx,
+            mode: Mode::Observe,
+            switching_to: None,
+            switch_at: None,
+            session: None,
+            next_gen: 0,
+            backoff_idx: 0,
+            reconnect_at: None,
+            control_failures: 0,
+            control_sticky: false,
+            pending_input: Vec::new(),
+            last_input: Instant::now(),
+            hint_clear_at: None,
+            predict: Predictor::new(),
+            remote_fg: None,
+            select: Select::new(),
+            last_select_rows: None,
+            fg_poll_at: None,
+            settle_at: None,
+            mouse_grabbed: tty, // startup wrote ?1002h when we're a tty
+            // startup leaves the pane in normal cursor mode; the first classification
+            // moves it if the remote turns out to be a TUI
+            app_cursor_keys: false,
+            paste_inflight: false,
+            paste_buf: Vec::new(),
+            mouse_buf: Vec::new(),
+            mouse_flush_at: None,
+            paste_queue: Vec::new(),
+            paste_original: None,
+        };
+        let mut child = tokio::process::Command::new("cat")
+            .stdin(Stdio::piped()).stdout(Stdio::null()).kill_on_drop(true)
+            .spawn().unwrap();
+        app.session = Some(Session {
+            gen: 1, mode: Mode::Control, pid: child.id().unwrap() as i32,
+            stdin: child.stdin.take().unwrap(),
+        });
+        app.mode = Mode::Control;
+        app.remote_fg = Some(Fg::Mouse);
+        // Keep foreground polling local to this fixture: suppress SSH probes.
+        app.fg_poll_at = Some(Instant::now());
+        // Blank cells exercise copy handling without writing to the clipboard.
+        app.grid.resize(80, 24);
+        app.handle_stdin(
+            b"\x1b[<0;1;1M\x1b[<32;4;1M\x1b[<0;4;1m\x1b[<0;1;2M".to_vec(),
+        ).await;
+        let result = app.select.release(
+            if next_drag { (1, 3) } else { (1, 0) }, b"release",
+        );
+        drop(app);
+        child.kill().await.unwrap();
+        let _ = child.wait().await;
+        if next_drag {
+            assert_eq!(result, Released::Selection(((1, 0), (1, 3))));
+        } else {
+            assert_eq!(result, Released::Click(b"\x1b[<0;1;2Mrelease".to_vec()));
+        }
+    }
+
+    #[tokio::test]
+    async fn copying_selection_preserves_next_click_in_same_read() {
+        selection_followed_by_press(false).await;
+    }
+
+    #[tokio::test]
+    async fn copying_selection_preserves_next_drag_in_same_read() {
+        selection_followed_by_press(true).await;
     }
 
 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -458,6 +458,60 @@ fn parse_mouse(bytes: &[u8], at: usize) -> Option<(u32, u32, u32, bool, usize)> 
     None
 }
 
+const MOUSE_INPUT_TIMEOUT: Duration = Duration::from_millis(150);
+const MAX_INCOMPLETE_MOUSE_BYTES: usize = 32;
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum MouseSplit {
+    Pending,
+    Passthrough(Vec<u8>),
+}
+
+/// Find a possible SGR mouse sequence that ends at the current read boundary.
+/// Only a short, syntactically valid prefix is held; ordinary input keeps
+/// flowing to the existing routing code.
+fn trailing_incomplete_mouse(bytes: &[u8]) -> Option<usize> {
+    for (at, byte) in bytes.iter().enumerate() {
+        if *byte != 0x1b {
+            continue;
+        }
+        let rest = &bytes[at..];
+        if rest == b"\x1b" || rest == b"\x1b[" {
+            return Some(at);
+        }
+        if rest.starts_with(b"\x1b[<")
+            && rest.len() <= MAX_INCOMPLETE_MOUSE_BYTES
+            && rest[3..].iter().all(|b| b.is_ascii_digit() || *b == b';')
+        {
+            return Some(at);
+        }
+    }
+    None
+}
+
+/// Hold only a trailing incomplete mouse sequence across stdin reads.
+pub(crate) fn split_mouse(buf: &mut Vec<u8>, chunk: Vec<u8>) -> MouseSplit {
+    let mut all = std::mem::take(buf);
+    all.extend_from_slice(&chunk);
+    let Some(at) = trailing_incomplete_mouse(&all) else {
+        return MouseSplit::Passthrough(all);
+    };
+    let tail = all.split_off(at);
+    *buf = tail;
+    if all.is_empty() {
+        MouseSplit::Pending
+    } else {
+        MouseSplit::Passthrough(all)
+    }
+}
+
+/// A timed-out lone ESC is still a key; an incomplete mouse prefix is dropped
+/// so it cannot leak as literal input into a remote shell.
+fn flush_mouse(buf: &mut Vec<u8>) -> Option<Vec<u8>> {
+    let pending = std::mem::take(buf);
+    (pending == b"\x1b").then_some(pending)
+}
+
 /// How a parsed mouse event should be routed while in control mode.
 #[derive(Debug, PartialEq, Eq)]
 enum MouseAction {
@@ -725,6 +779,9 @@ struct App {
     paste_inflight: bool,
     /// partially-received bracketed paste (see `intercept_paste`)
     paste_buf: Vec<u8>,
+    /// partially-received SGR mouse sequence
+    mouse_buf: Vec<u8>,
+    mouse_flush_at: Option<Instant>,
     /// input held back while an upload is in flight, flushed in order after
     paste_queue: Vec<Queued>,
     /// the payload that started the in-flight upload, so it can be forwarded
@@ -1082,6 +1139,24 @@ impl App {
         }
     }
 
+    /// Route ordinary input after preserving a partial SGR mouse sequence.
+    async fn route_mouse_input(&mut self, bytes: Vec<u8>) {
+        match split_mouse(&mut self.mouse_buf, bytes) {
+            MouseSplit::Pending => {}
+            MouseSplit::Passthrough(bytes) => self.route_input(bytes).await,
+        }
+        self.mouse_flush_at = (!self.mouse_buf.is_empty())
+            .then(|| Instant::now() + MOUSE_INPUT_TIMEOUT);
+    }
+
+    /// Flush an unfinished mouse prefix after its short completion window.
+    async fn flush_mouse_input(&mut self) {
+        self.mouse_flush_at = None;
+        if let Some(bytes) = flush_mouse(&mut self.mouse_buf) {
+            self.route_input(bytes).await;
+        }
+    }
+
     /// Drain every complete paste in this chunk, in order.
     ///
     /// Deliberately a loop, not a one-shot: two drops land in a single read
@@ -1094,9 +1169,15 @@ impl App {
         loop {
             match split_paste(&mut self.paste_buf, chunk) {
                 PasteSplit::Pending => return,
-                PasteSplit::Passthrough(bytes) => return self.route_input(bytes).await,
+                PasteSplit::Passthrough(bytes) => return self.route_mouse_input(bytes).await,
                 PasteSplit::Complete { before, body, after } => {
-                    self.route_input(before).await;
+                    self.route_mouse_input(before).await;
+                    // A partial mouse sequence cannot continue into a paste;
+                    // discard it before delivering the paste body directly.
+                    if !self.mouse_buf.is_empty() {
+                        self.mouse_buf.clear();
+                        self.mouse_flush_at = None;
+                    }
                     self.route_paste_body(body).await;
                     if after.is_empty() {
                         return;
@@ -1523,6 +1604,8 @@ pub async fn run(args: Args) -> Result<()> {
         app_cursor_keys: false,
         paste_inflight: false,
         paste_buf: Vec::new(),
+        mouse_buf: Vec::new(),
+        mouse_flush_at: None,
         paste_queue: Vec::new(),
         paste_original: None,
     };
@@ -1570,6 +1653,7 @@ pub async fn run(args: Args) -> Result<()> {
             idle_at,
             app.predict.deadline(),
             app.settle_at,
+            app.mouse_flush_at,
         ]);
 
         tokio::select! {
@@ -1650,6 +1734,9 @@ pub async fn run(args: Args) -> Result<()> {
                 if app.settle_at.is_some_and(|t| t <= now) {
                     app.settle_at = None;
                     app.spawn_foreground_poll(true); // forced: bypass the throttle
+                }
+                if app.mouse_flush_at.is_some_and(|t| t <= now) {
+                    app.flush_mouse_input().await;
                 }
                 if app.predict.deadline().is_some_and(|t| t <= now) {
                     app.predict.on_tick(); // wipe timed-out ghosts (no-echo prompts)
@@ -1797,6 +1884,44 @@ mod tests {
         assert!(!contains_wheel_press(b"\x1b[<64;10;5m")); // release, not press
         assert!(has_mouse_seq(b"xx\x1b[<0;1;1Myy"));
         assert!(!has_mouse_seq(b"plain text"));
+    }
+
+    #[test]
+    fn mouse_sequence_split_across_reads_is_reassembled() {
+        let mut buf = Vec::new();
+        assert_eq!(
+            split_mouse(&mut buf, b"pre\x1b[<0;3;2".to_vec()),
+            MouseSplit::Passthrough(b"pre".to_vec())
+        );
+        assert_eq!(buf, b"\x1b[<0;3;2");
+        assert_eq!(
+            split_mouse(&mut buf, b"Mpost".to_vec()),
+            MouseSplit::Passthrough(b"\x1b[<0;3;2Mpost".to_vec())
+        );
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn mouse_prefix_can_split_at_escape_and_csi_introducer() {
+        let mut buf = Vec::new();
+        assert_eq!(split_mouse(&mut buf, b"\x1b".to_vec()), MouseSplit::Pending);
+        assert_eq!(split_mouse(&mut buf, b"[".to_vec()), MouseSplit::Pending);
+        assert_eq!(
+            split_mouse(&mut buf, b"<0;3;2M".to_vec()),
+            MouseSplit::Passthrough(b"\x1b[<0;3;2M".to_vec())
+        );
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn timed_out_mouse_prefix_is_dropped_but_escape_survives() {
+        let mut mouse = b"\x1b[<0;3;2".to_vec();
+        assert_eq!(flush_mouse(&mut mouse), None);
+        assert!(mouse.is_empty());
+
+        let mut escape = b"\x1b".to_vec();
+        assert_eq!(flush_mouse(&mut escape), Some(b"\x1b".to_vec()));
+        assert!(escape.is_empty());
     }
 
 

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -1415,6 +1415,9 @@ impl App {
         }
         if let Some((start, end)) = copy_span {
             let text = self.grid.selection_text(start, end);
+            // Copy-on-select matches herdr's native lifecycle: the highlight
+            // disappears as soon as the release has been copied.
+            sel_changed |= self.select.clear();
             match crate::select::osc52(&text) {
                 // no hint on success: herdr shows its own "copied to clipboard"
                 // toast when it takes the OSC 52, so ours would be a duplicate


### PR DESCRIPTION
## Summary

Fix mouse drag selection in mirrored panes.

Mouse reports can be split across stdin reads, causing SGR sequences to be parsed incompletely. Additionally, completed selections remained highlighted after being copied, and normal clicks could leak raw SGR mouse bytes into text viewers such as `journalctl` and `less`.

This PR:

- Reassembles fragmented SGR mouse sequences across reads.
- Clears the local selection highlight immediately after copying.
- Prevents normal clicks from being forwarded to known non-mouse-aware viewers.
- Preserves mouse forwarding for applications that actually use mouse input.

## Validation

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --release`
- Manually validated drag selection, clipboard copying, release handling, and normal clicks in mirrored panes.

Result: text selection now behaves consistently with native Herdr selection.