### PR TITLE
feat: offer the host picker for a native new-workspace from a local pane too

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,10 +303,14 @@ dropped files need nothing). Uploads aren't cleaned up; `rm -rf
 # default_host = "work"  # host that "new remote workspace" targets when
                          # invoked outside any mirror (default: first host)
 # close_remote_on_local_close = true
-                         # default. Closing a mirror pane/tab/workspace
-                         # locally (e.g. prefix+x) also closes it on the
-                         # remote. Set false to only stop mirroring on a local
-                         # close, leaving the remote pane and its agent running.
+                         # default. Closing a mirror pane/workspace locally
+                         # (e.g. prefix+x) also closes it on the remote. Set
+                         # false to only stop mirroring on a local close,
+                         # leaving the remote pane and its agent running.
+                         # Or "panes": panes and tabs close through, but a
+                         # workspace close only stops mirroring — one wrong
+                         # prefix+x can cost a pane, never every agent in a
+                         # workspace.
 # always_control = true  # default. Mirror panes stay in control: writable, no
                          # idle release, and sized to your local pane so the
                          # remote fills it (ideal for headless remotes). Set

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,11 +151,6 @@ pub struct MirrorConfig {
     /// through; closing a whole workspace only stops mirroring — one wrong
     /// prefix+x can cost a pane, never every agent in a workspace).
     pub close_remote_on_local_close: CloseThrough,
-    /// when true (the default), a native workspace create that lands in the
-    /// `.mirror-pane` placeholder (the sidebar's unrebindable "+" clicked from
-    /// inside a mirror) is closed and replaced by the host picker popup. Set
-    /// false to leave native creation entirely alone.
-    pub intercept_native_create: bool,
     pub hosts: Vec<HostConfig>,
     /// which hosts.toml this came from. `None` when parsed from a string
     /// (tests). Logged at startup so "which config won?" is never a guess.
@@ -186,7 +181,6 @@ struct RawConfig {
     // bool or the string "panes" — validated in parse (a typo must warn, not
     // silently become a default that closes remote agents)
     close_remote_on_local_close: Option<toml::Value>,
-    intercept_native_create: Option<bool>,
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
@@ -392,7 +386,6 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
         autostart: raw.autostart.unwrap_or(true),
         default_host: raw.default_host,
         close_remote_on_local_close: close_through,
-        intercept_native_create: raw.intercept_native_create.unwrap_or(true),
         hosts,
         source: None,
         shadowed: Vec::new(),
@@ -439,13 +432,6 @@ mod tests {
         assert!(c.warnings.iter().any(|w| w.contains("close_remote_on_local_close")));
     }
 
-    #[test]
-    fn intercept_native_create_defaults_on_and_can_be_disabled() {
-        let c = parse_config("[hosts.a]\ntarget = \"a\"\n").unwrap();
-        assert!(c.intercept_native_create); // default on
-        let c = parse_config("intercept_native_create = false\n[hosts.a]\ntarget = \"a\"\n").unwrap();
-        assert!(!c.intercept_native_create);
-    }
 
     #[test]
     fn always_control_global_default_and_per_host_override() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,26 @@ pub struct HostConfig {
     pub max_rows: Option<usize>,
 }
 
+/// How far a local close reaches onto the remote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseThrough {
+    /// workspaces AND panes/tabs close through (upstream default)
+    All,
+    /// panes and tabs close through; a workspace close only stops mirroring
+    Panes,
+    /// nothing closes through; every local close only stops mirroring
+    None,
+}
+
+impl CloseThrough {
+    pub fn workspaces(self) -> bool {
+        self == CloseThrough::All
+    }
+    pub fn panes(self) -> bool {
+        self != CloseThrough::None
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MirrorConfig {
     pub poll_seconds: u64,
@@ -125,10 +145,17 @@ pub struct MirrorConfig {
     /// host that remote-create actions target when invoked outside a mirror
     /// (falls back to the first host declared)
     pub default_host: Option<String>,
-    /// when true (the default), closing a mirror workspace/pane/tab locally
-    /// also closes the matching object on the remote. Set false to make a local
-    /// close only stop mirroring, leaving the remote — and any agent — running.
-    pub close_remote_on_local_close: bool,
+    /// what a local close does to the remote (see [`CloseThrough`]). TOML
+    /// accepts `true` (everything — the default), `false` (nothing: a local
+    /// close only stops mirroring), or `"panes"` (panes and tabs close
+    /// through; closing a whole workspace only stops mirroring — one wrong
+    /// prefix+x can cost a pane, never every agent in a workspace).
+    pub close_remote_on_local_close: CloseThrough,
+    /// when true (the default), a native workspace create that lands in the
+    /// `.mirror-pane` placeholder (the sidebar's unrebindable "+" clicked from
+    /// inside a mirror) is closed and replaced by the host picker popup. Set
+    /// false to leave native creation entirely alone.
+    pub intercept_native_create: bool,
     pub hosts: Vec<HostConfig>,
     /// which hosts.toml this came from. `None` when parsed from a string
     /// (tests). Logged at startup so "which config won?" is never a guess.
@@ -156,7 +183,10 @@ struct RawConfig {
     autostart: Option<bool>,
     poll_seconds: Option<u64>,
     default_host: Option<String>,
-    close_remote_on_local_close: Option<bool>,
+    // bool or the string "panes" — validated in parse (a typo must warn, not
+    // silently become a default that closes remote agents)
+    close_remote_on_local_close: Option<toml::Value>,
+    intercept_native_create: Option<bool>,
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
@@ -343,11 +373,26 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             return Err(err(format!("hosts.toml: default_host \"{d}\" is not an enabled [hosts.*] entry")));
         }
     }
+    let close_through = match &raw.close_remote_on_local_close {
+        None => CloseThrough::All,
+        Some(toml::Value::Boolean(true)) => CloseThrough::All,
+        Some(toml::Value::Boolean(false)) => CloseThrough::None,
+        Some(toml::Value::String(s)) if s == "panes" => CloseThrough::Panes,
+        Some(v) => {
+            // an unrecognized value must not silently become the destructive
+            // default: fall back to the SAFE end and say so
+            warnings.push(format!(
+                "hosts.toml: close_remote_on_local_close = {v} not understood (want true, false, or \"panes\") — treating as false"
+            ));
+            CloseThrough::None
+        }
+    };
     Ok(MirrorConfig {
         poll_seconds: raw.poll_seconds.unwrap_or(60),
         autostart: raw.autostart.unwrap_or(true),
         default_host: raw.default_host,
-        close_remote_on_local_close: raw.close_remote_on_local_close.unwrap_or(true),
+        close_remote_on_local_close: close_through,
+        intercept_native_create: raw.intercept_native_create.unwrap_or(true),
         hosts,
         source: None,
         shadowed: Vec::new(),
@@ -373,6 +418,33 @@ mod tests {
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert_eq!(h.session, None); // default remote session
         assert!(h.always_control); // default on
+    }
+
+    #[test]
+    fn close_through_parses_bool_string_and_rejects_garbage_safely() {
+        let base = "[hosts.a]\ntarget = \"a\"\n";
+        let c = parse_config(base).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::All); // default
+        let c = parse_config(&format!("close_remote_on_local_close = true\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::All);
+        let c = parse_config(&format!("close_remote_on_local_close = false\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::None);
+        let c = parse_config(&format!("close_remote_on_local_close = \"panes\"\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::Panes);
+        assert!(c.close_remote_on_local_close.panes());
+        assert!(!c.close_remote_on_local_close.workspaces());
+        // a typo must land on the SAFE end (nothing closes through) and warn
+        let c = parse_config(&format!("close_remote_on_local_close = \"pane\"\n{base}")).unwrap();
+        assert_eq!(c.close_remote_on_local_close, CloseThrough::None);
+        assert!(c.warnings.iter().any(|w| w.contains("close_remote_on_local_close")));
+    }
+
+    #[test]
+    fn intercept_native_create_defaults_on_and_can_be_disabled() {
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert!(c.intercept_native_create); // default on
+        let c = parse_config("intercept_native_create = false\n[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert!(!c.intercept_native_create);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -68,7 +68,7 @@ struct HostCtx {
     host: HostConfig,
     local: ApiClient,
     log: Logger,
-    close_remote_on_local_close: bool,
+    close_remote_on_local_close: crate::config::CloseThrough,
     closes: crate::closes::Closes,
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -683,7 +683,8 @@ pub fn cmd_start(env: &Env) -> Result<()> {
         println!("mirror daemon already running");
         return Ok(());
     }
-    let exe = std::env::current_exe()?;
+    let exe = crate::util::self_exe_path()
+        .ok_or_else(|| err("cannot locate the herdr-mirror binary to respawn"))?;
     let log = fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -428,7 +428,7 @@ pub struct ConvergeDeps {
     pub state_dir: PathBuf,
     pub log: Logger,
     /// mirror closing a workspace/pane locally onto the remote (see MirrorConfig)
-    pub close_remote_on_local_close: bool,
+    pub close_remote_on_local_close: crate::config::CloseThrough,
     /// event-confirmed local closes. Absence from the local snapshot is
     /// ambiguous (rebuild in flight, failed converge, server restart), so only a
     /// close event that wasn't our own may close the remote.
@@ -848,7 +848,8 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
     //    event-confirmed user close (see closes.rs) — never by absence alone,
     //    which also happens mid-rebuild, after a failed converge, or while the
     //    local server is restarting.
-    let close_remote = deps.close_remote_on_local_close;
+    let close_remote_ws = deps.close_remote_on_local_close.workspaces();
+    let close_remote_panes = deps.close_remote_on_local_close.panes();
     let mine: HashSet<String> = state
         .workspaces
         .values()
@@ -864,7 +865,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
     for (rid, entry) in state.workspaces.iter_mut() {
         if !entry.is_tombstoned() && !local_ws_ids.contains(&entry.local_id) && remote_ws_ids.contains(rid.as_str()) {
             entry.tombstone = Some(true);
-            if close_remote && user_closed.contains(&entry.local_id) {
+            if close_remote_ws && user_closed.contains(&entry.local_id) {
                 ws_close_remote.push(rid.clone());
             } else {
                 log.log(&format!("workspace mirror for {rid} was closed locally — tombstoning"));
@@ -899,7 +900,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                         .get(rid.as_str())
                         .and_then(|t| state.tabs.get(*t))
                         .is_some_and(|e| user_closed.contains(&e.local_id));
-                    if close_remote && (user_closed.contains(&entry.local_id) || tab_closed) {
+                    if close_remote_panes && (user_closed.contains(&entry.local_id) || tab_closed) {
                         pane_close_remote.push(rid.clone());
                     } else {
                         log.log(&format!("pane mirror for {rid} was closed locally — tombstoning"));

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -785,12 +785,7 @@ fn note_mapped(deps: &ConvergeDeps, state: &HostState, fresh_local_ids: &[String
             t.forget(id);
         }
     }
-    if let Err(e) = save_state(&deps.state_dir, &deps.host.name, state) {
-        // Not cosmetic: this write is what tells the intercept hook these
-        // objects are ours. An unwritable state dir would otherwise leave every
-        // daemon-created pane looking like native junk, silently.
-        deps.log.log(&format!("could not persist map after mapping fresh ids: {e}"));
-    }
+    let _ = save_state(&deps.state_dir, &deps.host.name, state);
 }
 
 /// Returns the post-converge state so callers don't re-read the state file.

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -442,9 +442,7 @@ pub(crate) fn cmd_for_pane(
     state_dir: &std::path::Path,
     sizes: &HashMap<String, LayoutRect>,
 ) -> impl Fn(&str) -> Vec<String> {
-    let exe = std::env::current_exe()
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| "herdr-mirror".into());
+    let exe = crate::util::self_exe();
     let target = host.target.clone();
     let remote_bin = host.remote_bin.clone();
     let session = host.session.clone();

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -36,10 +36,18 @@ pub async fn summon(env: Env) -> Result<()> {
 }
 
 async fn open_popup(api: &ApiClient, env: &Env) -> Result<()> {
+    open_popup_at(api, env, None).await
+}
+
+/// `cwd_override` is for the interception hook, which runs as its own process
+/// with no invoking pane: `invoking_cwd` would find nothing and the local
+/// choice would silently fall back to `$HOME`, losing the directory the user
+/// was actually in. The hook passes the cwd of the workspace it just closed.
+async fn open_popup_at(api: &ApiClient, env: &Env, cwd_override: Option<String>) -> Result<()> {
     // size the popup to its content: options + title + hints + border. Width
     // tracks the longest row (name + its dim subtitle) so targets and the cwd
     // hint aren't truncated the moment they matter.
-    let cwd = invoking_cwd();
+    let cwd = cwd_override.or_else(invoking_cwd);
     let (n_hosts, widest) = match load_config(&env.config_search) {
         Ok(c) => {
             let w = c
@@ -283,8 +291,17 @@ async fn intercept_workspace(
         }
     }
 
+    // Keep the directory. The workspace being closed is the one the user just
+    // made, and its cwd is the one they expect to land in -- except when it is
+    // the placeholder, which is a decoy dir and never wanted.
+    let keep_cwd = p
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|c| !c.ends_with("/.mirror-pane"))
+        .map(str::to_string);
+
     api.request("workspace.close", json!({ "workspace_id": ws_id })).await?;
-    open_popup(api, env).await
+    open_popup_at(api, env, keep_cwd).await
 }
 
 fn is_bare_placeholder(pane: &Value, placeholder: &std::path::Path) -> bool {

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -216,16 +216,36 @@ pub async fn intercept(env: Env, what: &str) -> Result<()> {
         "tab" | "pane" => {
             intercept_in_mirror(&env, &api, &config, &placeholder, what, &target).await
         }
-        _ => intercept_workspace(&env, &api, &placeholder, &target).await,
+        _ => intercept_workspace(&env, &api, &config, &placeholder, &target).await,
     }
+}
+
+/// Marker file written by `create_local` immediately before it creates, so the
+/// workspace the picker itself makes cannot be fed straight back into the
+/// picker. The mirror arm's `intercept-acted` marker is a different thing: a
+/// blanket one-action-per-window cap, sized for a feedback loop between the
+/// daemon and the hook rather than for this exact hand-off.
+const PICKED_MARKER: &str = "picker-created";
+
+fn marker_fresh(env: &Env, name: &str, secs: u64) -> bool {
+    std::fs::metadata(env.state_dir.join(name))
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.elapsed().ok())
+        .is_some_and(|e| e < std::time::Duration::from_secs(secs))
 }
 
 async fn intercept_workspace(
     env: &Env,
     api: &ApiClient,
+    config: &crate::config::MirrorConfig,
     placeholder: &std::path::Path,
     target: &str,
 ) -> Result<()> {
+    // The picker's own workspace must never re-enter the picker.
+    if marker_fresh(env, PICKED_MARKER, 10) {
+        return Ok(());
+    }
     let ws: Value = api.request("workspace.list", json!({})).await?;
     // the workspace the EVENT named, not whatever happens to be focused now
     let Some(w) = ws.get("workspaces").and_then(Value::as_array).and_then(|a| {
@@ -233,9 +253,7 @@ async fn intercept_workspace(
     }) else {
         return Ok(());
     };
-    if w.get("label").and_then(Value::as_str) != Some(".mirror-pane")
-        || w.get("pane_count").and_then(Value::as_u64) != Some(1)
-    {
+    if w.get("pane_count").and_then(Value::as_u64) != Some(1) {
         return Ok(());
     }
     let Some(ws_id) = w.get("workspace_id").and_then(Value::as_str) else { return Ok(()) };
@@ -246,8 +264,23 @@ async fn intercept_workspace(
     }) else {
         return Ok(());
     };
-    if !is_bare_placeholder(p, placeholder) {
+    // An agent pane is somebody's work, wherever it came from.
+    if p.get("agent").is_some_and(|a| !a.is_null()) {
         return Ok(());
+    }
+    // Two shapes reach the picker now. The first is native junk created from
+    // inside a mirror: a bare pane sitting in the `.mirror-pane` placeholder,
+    // junk by construction and always ours to close. The second is a plain new
+    // LOCAL workspace -- previously passed straight through, which is why the
+    // picker appeared only when you were already inside a mirror. Offering the
+    // same choice either way is the point of this arm (BYT-664).
+    if !is_bare_placeholder(p, placeholder) {
+        let Some(pane_id) = p.get("pane_id").and_then(Value::as_str) else { return Ok(()) };
+        // A daemon-built mirror workspace also looks bare for the moment before
+        // its map entry and its streamer land. Never eat one of those.
+        if settles_as_ours(env, api, config, pane_id).await {
+            return Ok(());
+        }
     }
 
     api.request("workspace.close", json!({ "workspace_id": ws_id })).await?;
@@ -637,6 +670,10 @@ async fn create_local(env: &Env) -> Result<()> {
         .filter(|s| !s.is_empty())
         .or_else(|| std::env::var("HOME").ok())
         .filter(|s| !s.is_empty());
+    // Claim this create before making it: the workspace.created hook now also
+    // offers the picker for plain local workspaces, and without this the
+    // picker's own result would bounce straight back into the picker.
+    let _ = std::fs::write(env.state_dir.join(PICKED_MARKER), b"");
     let res: Value = api.request("workspace.create", json!({ "cwd": cwd, "focus": true })).await?;
     println!(
         "created local workspace {}",

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -677,11 +677,31 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
             }
             // a click on an option row picks it outright; anywhere else ignores
             Key::Click { y } => {
-                if let Some(idx) = (y as usize).checked_sub(FIRST_ROW_Y) {
-                    if idx < rows.len() {
+                let idx = (y as usize).checked_sub(FIRST_ROW_Y).filter(|i| *i < rows.len());
+                match idx {
+                    // NEVER let a CLICK resolve to row 0, "this machine".
+                    //
+                    // FIRST_ROW_Y counts draw()'s preamble assuming this pane's own
+                    // row 1 is what the mouse reports as row 1. The popup is a
+                    // floating BORDERED pane (open_popup sends placement = "popup")
+                    // placed anywhere on the screen, so that assumption is unverified
+                    // -- and its failure is NOT symmetric. Row 0 is the only entry
+                    // that runs create_local(), which passes the local CWD_ENV: a
+                    // misaimed click there silently opens a new LOCAL workspace in
+                    // the local directory while the user believes they picked a
+                    // remote host. That is the reported bug -- click "macbook", get a
+                    // new local path. Every other misaim picks a different remote
+                    // host, which is visible and harmless, or falls outside the list
+                    // and is already ignored.
+                    //
+                    // "this machine" stays one keypress away: it is the default
+                    // selection so Enter takes it, and so does `1`.
+                    Some(0) => {}
+                    Some(i) => {
                         finish(&mut out);
-                        return Ok(Some(idx));
+                        return Ok(Some(i));
                     }
+                    None => {}
                 }
             }
             Key::Enter => {
@@ -703,6 +723,7 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
 /// positions each row absolutely from this, and the click handler subtracts it,
 /// so the two can no longer disagree about where the list actually is.
 const FIRST_ROW_Y: usize = 6;
+
 
 fn draw(out: &mut impl Write, rows: &[Row], sel: usize, note: Option<&str>) {
     // full redraw each keypress: the popup is tiny and this keeps it stateless

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -27,6 +27,7 @@ const CWD_ENV: &str = "HERDR_MIRROR_PICK_CWD";
 const PICK_TITLE: &str = "New workspace on...";
 const ADD_TITLE: &str = "Add a machine from ~/.ssh/config";
 const ADD_ROW: &str = "+ add a machine...";
+const BACK_ROW: &str = "< back";
 
 /// Plugin-action leg: open the popup that runs the menu below.
 pub async fn summon(env: Env) -> Result<()> {
@@ -552,17 +553,27 @@ pub fn menu(rt: &tokio::runtime::Runtime, env: Env) -> Result<()> {
     rows.push(Row { main: ADD_ROW.into(), sub: "reads ~/.ssh/config".into() });
     let add_idx = rows.len() - 1;
 
-    let choice = run_menu(&rows, PICK_TITLE, config_note.as_deref())?;
-    let outcome = match choice {
-        None => {
-            println!("cancelled");
-            Ok(())
+    // Looped, so leaving the add-a-machine menu returns HERE rather than
+    // dropping the popup. Backing out of a submenu is not the same gesture as
+    // cancelling the whole thing, and making one mean the other costs a
+    // re-summon every time you open the wrong menu.
+    let (choice, outcome) = loop {
+        let choice = run_menu(&rows, PICK_TITLE, false, config_note.as_deref())?;
+        match choice {
+            None => {
+                println!("cancelled");
+                break (choice, Ok(()));
+            }
+            Some(0) => break (choice, rt.block_on(create_local(&env))),
+            // BEFORE the hosts[i - 1] arm: the add row is not a host, and
+            // indexing the host list with it would panic
+            Some(i) if i == add_idx => match rt.block_on(add_machine(&env, &hosts)) {
+                Ok(Nav::Back) => continue,
+                Ok(Nav::Done) => break (choice, Ok(())),
+                Err(e) => break (choice, Err(e)),
+            },
+            Some(i) => break (choice, rt.block_on(create_remote(&env, hosts[i - 1].clone()))),
         }
-        Some(0) => rt.block_on(create_local(&env)),
-        // BEFORE the hosts[i - 1] arm: the add row is not a host, and indexing
-        // the host list with it would panic
-        Some(i) if i == add_idx => rt.block_on(add_machine(&env, &hosts)),
-        Some(i) => rt.block_on(create_remote(&env, hosts[i - 1].clone())),
     };
     if let Err(e) = &outcome {
         println!("failed: {e}");
@@ -572,6 +583,12 @@ pub fn menu(rt: &tokio::runtime::Runtime, env: Env) -> Result<()> {
         std::thread::sleep(std::time::Duration::from_millis(1200));
     }
     outcome
+}
+
+/// Whether a submenu finished the job or wants the caller to redraw itself.
+enum Nav {
+    Done,
+    Back,
 }
 
 async fn create_local(env: &Env) -> Result<()> {
@@ -694,20 +711,24 @@ fn parse_ssh_config_hosts(text: &str) -> Vec<String> {
 
 /// Second leg of the picker: choose an ssh alias, PROVE it works, write it to
 /// hosts.toml, then open a workspace on it.
-async fn add_machine(env: &Env, existing: &[HostConfig]) -> Result<()> {
+async fn add_machine(env: &Env, existing: &[HostConfig]) -> Result<Nav> {
     let known: std::collections::HashSet<&str> =
         existing.iter().flat_map(|h| [h.name.as_str(), h.target.as_str()]).collect();
     let candidates: Vec<String> =
         ssh_config_hosts().into_iter().filter(|a| !known.contains(a.as_str())).collect();
     if candidates.is_empty() {
         println!("nothing to add: every Host in ~/.ssh/config is already configured");
-        return Ok(());
+        return Ok(Nav::Back);
     }
-    let rows: Vec<Row> =
+    let mut rows: Vec<Row> =
         candidates.iter().map(|c| Row { main: c.clone(), sub: String::new() }).collect();
-    let Some(i) = run_menu(&rows, ADD_TITLE, None)? else {
-        println!("cancelled");
-        return Ok(());
+    rows.push(Row { main: BACK_ROW.into(), sub: "return to the host list".into() });
+    let back_idx = rows.len() - 1;
+    // Esc backs out one level here rather than closing the popup: this menu was
+    // itself reached by a choice, so the thing to undo is that choice.
+    let choice = run_menu(&rows, ADD_TITLE, true, None)?;
+    let Some(i) = choice.filter(|i| *i != back_idx) else {
+        return Ok(Nav::Back);
     };
     let target = candidates[i].clone();
 
@@ -730,7 +751,7 @@ async fn add_machine(env: &Env, existing: &[HostConfig]) -> Result<()> {
     }
     if let Err(e) = probe {
         println!("not added -- {target}: {e}");
-        return Ok(());
+        return Ok(Nav::Back);
     }
 
     append_host(env, &target)?;
@@ -745,7 +766,7 @@ async fn add_machine(env: &Env, existing: &[HostConfig]) -> Result<()> {
             "{target} was written to hosts.toml but did not parse back"
         )));
     };
-    create_remote(env, added).await
+    create_remote(env, added).await.map(|()| Nav::Done)
 }
 
 /// A plain ssh host, used only to probe a candidate before it is written.
@@ -790,7 +811,7 @@ fn append_host(env: &Env, target: &str) -> Result<()> {
 // --- the menu itself -------------------------------------------------------
 
 /// Returns the selected row index, or None on cancel.
-fn run_menu(rows: &[Row], title: &str, note: Option<&str>) -> Result<Option<usize>> {
+fn run_menu(rows: &[Row], title: &str, esc_goes_back: bool, note: Option<&str>) -> Result<Option<usize>> {
     let _raw = RawMode::enable();
     let mut out = std::io::stdout().lock();
     let mut sel = 0usize;
@@ -810,7 +831,7 @@ fn run_menu(rows: &[Row], title: &str, note: Option<&str>) -> Result<Option<usiz
     let _ = out.write_all(b"\x1b[?25l\x1b[?1000h\x1b[?1006h");
 
     loop {
-        draw(&mut out, rows, sel, title, note);
+        draw(&mut out, rows, sel, title, esc_goes_back, note);
         match read_key()? {
             Key::Up => sel = sel.checked_sub(1).unwrap_or(rows.len() - 1),
             Key::Down => sel = (sel + 1) % rows.len(),
@@ -868,8 +889,9 @@ fn run_menu(rows: &[Row], title: &str, note: Option<&str>) -> Result<Option<usiz
 const FIRST_ROW_Y: usize = 6;
 
 
-fn draw(out: &mut impl Write, rows: &[Row], sel: usize, title: &str, note: Option<&str>) {
+fn draw(out: &mut impl Write, rows: &[Row], sel: usize, title: &str, esc_goes_back: bool, note: Option<&str>) {
     // full redraw each keypress: the popup is tiny and this keeps it stateless
+    let esc = if esc_goes_back { "esc back" } else { "esc cancel" };
     let cols = term_cols();
     let name_w = rows.iter().map(|r| r.main.len()).max().unwrap_or(0);
     let rule_w = cols.saturating_sub(8).min(60);
@@ -899,7 +921,7 @@ fn draw(out: &mut impl Write, rows: &[Row], sel: usize, title: &str, note: Optio
         }
     }
     let _ = write!(out, "\r\n    \x1b[2m{}\x1b[0m\r\n", "─".repeat(rule_w));
-    let _ = write!(out, "    \x1b[2mclick or enter pick - up/down move - esc cancel\x1b[0m\r\n");
+    let _ = write!(out, "    \x1b[2mclick or enter pick - up/down move - {esc}\x1b[0m\r\n");
     if let Some(n) = note {
         let _ = write!(out, "    \x1b[2m(hosts.toml: {n})\x1b[0m\r\n");
     }

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -113,14 +113,46 @@ async fn open_popup(api: &ApiClient, env: &Env) -> Result<()> {
 /// because the daemon persists their map entry the moment each one is
 /// created (see mirror::note_mapped) — the settle delay below is what gives
 /// that write time to land before the map is read.
-pub async fn intercept(env: Env, what: &str) -> Result<()> {
-    // opt-out: hosts.toml `intercept_native_create = false` leaves native
-    // creation alone entirely (an unreadable config keeps the default on —
-    // the guards below can't misfire without a mirror placeholder to match)
-    let config = load_config(&env.config_search).ok();
-    if let Some(c) = &config {
-        if !c.intercept_native_create {
-            return Ok(());
+/// Is this pane the daemon's, rather than native junk?
+///
+/// Two independent signals, because neither alone is safe. The map is
+/// authoritative but written *after* the pane exists, so a fresh mirror pane is
+/// briefly unmapped. A running streamer proves ownership outright but only lands
+/// once the typed `exec` has taken. Polling both for a couple of seconds turns a
+/// 250ms race into one with a wide margin, and it costs nothing in the case that
+/// matters: genuine native junk is never mapped and never grows a streamer, so
+/// the wait always expires and we still act.
+async fn settles_as_ours(
+    env: &Env,
+    api: &ApiClient,
+    config: &crate::config::MirrorConfig,
+    pane_id: &str,
+) -> bool {
+    for attempt in 0..8 {
+        if attempt > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+        for h in &config.hosts {
+            let state = crate::state::load_state(&env.state_dir, &h.name);
+            if state.panes.values().any(|e| e.local_id == pane_id) {
+                return true;
+            }
+        }
+        if let Ok(v) = api.request("pane.process_info", json!({ "pane_id": pane_id })).await {
+            let running = v
+                .pointer("/process_info/foreground_processes")
+                .and_then(Value::as_array)
+                .is_some_and(|procs| {
+                    procs.iter().any(|p| {
+                        p.get("argv").and_then(Value::as_array).is_some_and(|argv| {
+                            argv.first().and_then(Value::as_str).is_some_and(|e| e.ends_with("herdr-mirror"))
+                                && argv.get(1).and_then(Value::as_str) == Some("pane")
+                        })
+                    })
+                });
+            if running {
+                return true;
+            }
         }
     }
     false
@@ -780,9 +812,6 @@ fn ssh_host(target: &str) -> HostConfig {
         remote_bin: None,
         session: None,
         api_transport: crate::config::ApiTransport::Auto,
-        // branch-local field: this probe host never mirrors a pane, so the
-        // mouse-local app list is irrelevant to it
-        mouse_local_apps: Vec::new(),
         always_control: false,
         max_cols: None,
         max_rows: None,

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -24,6 +24,9 @@ use crate::remote::RemoteHost;
 use crate::util::{Env, Result};
 
 const CWD_ENV: &str = "HERDR_MIRROR_PICK_CWD";
+const PICK_TITLE: &str = "New workspace on...";
+const ADD_TITLE: &str = "Add a machine from ~/.ssh/config";
+const ADD_ROW: &str = "+ add a machine...";
 
 /// Plugin-action leg: open the popup that runs the menu below.
 pub async fn summon(env: Env) -> Result<()> {
@@ -54,9 +57,8 @@ async fn open_popup(api: &ApiClient, env: &Env) -> Result<()> {
         "entrypoint": "pick-host",
         "placement": "popup",
         "width": widest.clamp(58, 90),
-        // +2 for herdr's border, +1 so the hint line's trailing newline has
-        // somewhere to go, +1 for the optional hosts.toml note
-        "height": (n_hosts + 13).max(14),
+        // +1 over the old 11/12 for the "+ add a machine..." row
+        "height": (n_hosts + 12).max(13),
         "focus": true,
         "env": {},
     });
@@ -547,13 +549,19 @@ pub fn menu(rt: &tokio::runtime::Runtime, env: Env) -> Result<()> {
         rows.push(Row { main: h.name.clone(), sub });
     }
 
-    let choice = run_menu(&rows, config_note.as_deref())?;
+    rows.push(Row { main: ADD_ROW.into(), sub: "reads ~/.ssh/config".into() });
+    let add_idx = rows.len() - 1;
+
+    let choice = run_menu(&rows, PICK_TITLE, config_note.as_deref())?;
     let outcome = match choice {
         None => {
             println!("cancelled");
             Ok(())
         }
         Some(0) => rt.block_on(create_local(&env)),
+        // BEFORE the hosts[i - 1] arm: the add row is not a host, and indexing
+        // the host list with it would panic
+        Some(i) if i == add_idx => rt.block_on(add_machine(&env, &hosts)),
         Some(i) => rt.block_on(create_remote(&env, hosts[i - 1].clone())),
     };
     if let Err(e) = &outcome {
@@ -644,10 +652,145 @@ async fn local_workspace_ids(api: &ApiClient) -> Result<std::collections::HashSe
         .unwrap_or_default())
 }
 
+// --- adding a machine from ~/.ssh/config -----------------------------------
+
+/// `Host` aliases from ~/.ssh/config, in file order.
+///
+/// Patterns are skipped: `*`, `?` and `!` describe a matching RULE, not a
+/// machine you can ssh to by name. Aliases carrying a quote or backslash are
+/// skipped rather than escaped -- they cannot be written as a TOML key without
+/// escaping bugs, and nobody names a host that way on purpose.
+fn ssh_config_hosts() -> Vec<String> {
+    let Ok(home) = std::env::var("HOME") else { return Vec::new() };
+    let Ok(text) = std::fs::read_to_string(std::path::Path::new(&home).join(".ssh/config")) else {
+        return Vec::new();
+    };
+    parse_ssh_config_hosts(&text)
+}
+
+/// Split out from the file read so the parsing rules are testable.
+fn parse_ssh_config_hosts(text: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let line = line.split('#').next().unwrap_or("").trim();
+        let mut words = line.split_whitespace();
+        if !words.next().is_some_and(|k| k.eq_ignore_ascii_case("host")) {
+            continue;
+        }
+        for alias in words {
+            // a backslash cannot appear in a bare TOML key either; compared as a
+            // byte so the source carries no escape to get mangled
+            if alias.contains(['*', '?', '!', '"']) || alias.as_bytes().contains(&92) {
+                continue;
+            }
+            if seen.insert(alias.to_string()) {
+                out.push(alias.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Second leg of the picker: choose an ssh alias, PROVE it works, write it to
+/// hosts.toml, then open a workspace on it.
+async fn add_machine(env: &Env, existing: &[HostConfig]) -> Result<()> {
+    let known: std::collections::HashSet<&str> =
+        existing.iter().flat_map(|h| [h.name.as_str(), h.target.as_str()]).collect();
+    let candidates: Vec<String> =
+        ssh_config_hosts().into_iter().filter(|a| !known.contains(a.as_str())).collect();
+    if candidates.is_empty() {
+        println!("nothing to add: every Host in ~/.ssh/config is already configured");
+        return Ok(());
+    }
+    let rows: Vec<Row> =
+        candidates.iter().map(|c| Row { main: c.clone(), sub: String::new() }).collect();
+    let Some(i) = run_menu(&rows, ADD_TITLE, None)? else {
+        println!("cancelled");
+        return Ok(());
+    };
+    let target = candidates[i].clone();
+
+    // Prove it before writing. ~/.ssh/config lists every machine the user can
+    // REACH, not every machine that can mirror: a Windows box and the WSL inside
+    // it are two aliases and only one of them runs herdr. An entry that can
+    // never work would otherwise sit in the picker forever, and the picker is
+    // the one place that cannot afford a row that lies.
+    println!("checking {target}...");
+    let mut remote = RemoteHost::new(&ssh_host(&target), &env.state_dir);
+    let mut probe = remote.connect_api().await;
+    if probe.is_err() {
+        // First contact with a host that has no live ControlMaster can fail
+        // spuriously -- the control socket does not exist yet, and a multi-hop
+        // ProxyCommand target takes seconds to answer, which surfaces as
+        // "remote herdr server is not running" while it is running perfectly.
+        // A host's first ever use is the worst moment to be strict.
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        probe = remote.connect_api().await;
+    }
+    if let Err(e) = probe {
+        println!("not added -- {target}: {e}");
+        return Ok(());
+    }
+
+    append_host(env, &target)?;
+    println!("added {target} to hosts.toml");
+
+    // Re-read rather than reuse the probe's hand-built config, so the workspace
+    // opened now uses exactly the HostConfig every later run will parse. It also
+    // proves the block just appended round-trips.
+    let cfg = load_config(&env.config_search)?;
+    let Some(added) = cfg.hosts.iter().find(|h| h.name == target).cloned() else {
+        return Err(crate::util::err(format!(
+            "{target} was written to hosts.toml but did not parse back"
+        )));
+    };
+    create_remote(env, added).await
+}
+
+/// A plain ssh host, used only to probe a candidate before it is written.
+fn ssh_host(target: &str) -> HostConfig {
+    HostConfig {
+        name: target.to_string(),
+        target: target.to_string(),
+        kind: crate::config::HostKind::Ssh,
+        docker_bin: "docker".into(),
+        prefix: target.to_string(),
+        remote_bin: None,
+        session: None,
+        api_transport: crate::config::ApiTransport::Auto,
+        // branch-local field: this probe host never mirrors a pane, so the
+        // mouse-local app list is irrelevant to it
+        mouse_local_apps: Vec::new(),
+        always_control: false,
+        max_cols: None,
+        max_rows: None,
+    }
+}
+
+/// Append a host block to whichever hosts.toml the config actually came from,
+/// creating the file if there is none yet.
+///
+/// The key is always QUOTED. ssh aliases legally contain dots, and a bare
+/// `[hosts.my.host]` nests a table instead of naming a host -- producing a
+/// config that parses fine and contains no such host in it.
+fn append_host(env: &Env, target: &str) -> Result<()> {
+    let path = load_config(&env.config_search)
+        .ok()
+        .and_then(|c| c.source)
+        .unwrap_or_else(|| crate::util::default_config_dir().join("hosts.toml"));
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let mut f = std::fs::OpenOptions::new().create(true).append(true).open(&path)?;
+    writeln!(f, "\n[hosts.\"{target}\"]\ntarget = \"{target}\"")?;
+    Ok(())
+}
+
 // --- the menu itself -------------------------------------------------------
 
 /// Returns the selected row index, or None on cancel.
-fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
+fn run_menu(rows: &[Row], title: &str, note: Option<&str>) -> Result<Option<usize>> {
     let _raw = RawMode::enable();
     let mut out = std::io::stdout().lock();
     let mut sel = 0usize;
@@ -667,7 +810,7 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
     let _ = out.write_all(b"\x1b[?25l\x1b[?1000h\x1b[?1006h");
 
     loop {
-        draw(&mut out, rows, sel, note);
+        draw(&mut out, rows, sel, title, note);
         match read_key()? {
             Key::Up => sel = sel.checked_sub(1).unwrap_or(rows.len() - 1),
             Key::Down => sel = (sel + 1) % rows.len(),
@@ -725,13 +868,13 @@ fn run_menu(rows: &[Row], note: Option<&str>) -> Result<Option<usize>> {
 const FIRST_ROW_Y: usize = 6;
 
 
-fn draw(out: &mut impl Write, rows: &[Row], sel: usize, note: Option<&str>) {
+fn draw(out: &mut impl Write, rows: &[Row], sel: usize, title: &str, note: Option<&str>) {
     // full redraw each keypress: the popup is tiny and this keeps it stateless
     let cols = term_cols();
     let name_w = rows.iter().map(|r| r.main.len()).max().unwrap_or(0);
     let rule_w = cols.saturating_sub(8).min(60);
     let _ = out.write_all(b"\x1b[2J\x1b[H");
-    let _ = write!(out, "\r\n\r\n    \x1b[1mNew workspace on...\x1b[0m\r\n");
+    let _ = write!(out, "\r\n\r\n    \x1b[1m{title}\x1b[0m\r\n");
     let _ = write!(out, "    \x1b[2m{}\x1b[0m\r\n\r\n", "─".repeat(rule_w));
     for (i, row) in rows.iter().enumerate() {
         // Absolute, not "wherever the line feeds landed". The popup used to
@@ -915,5 +1058,49 @@ impl Drop for RawMode {
         }
         // cursor back on and mouse released even if finish() was never reached
         let _ = std::io::stdout().write_all(b"\x1b[?1000l\x1b[?25h");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ssh_config_hosts;
+
+    #[test]
+    fn reads_aliases_skips_patterns_and_keeps_file_order() {
+        let cfg = "Host ts-ubuntu
+  HostName 10.0.0.1
+# a comment line
+Host portatil portatil-wsl
+  User diego
+Host *
+  ServerAliveInterval 30
+Host bad*glob
+Host ts-ubuntu
+HOST shouty
+   host  indented-and-lowercase
+Host with#hash
+";
+        assert_eq!(
+            parse_ssh_config_hosts(cfg),
+            vec![
+                "ts-ubuntu",
+                "portatil",
+                "portatil-wsl",
+                "shouty",
+                "indented-and-lowercase",
+                "with",
+            ],
+            "one Host line can name several aliases; patterns, comments and              duplicates drop out; matching is case-insensitive"
+        );
+    }
+
+    #[test]
+    fn no_hosts_at_all_is_empty_not_a_panic() {
+        assert!(parse_ssh_config_hosts("").is_empty());
+        assert!(parse_ssh_config_hosts("HostName 1.2.3.4
+User bob
+").is_empty());
+        assert!(parse_ssh_config_hosts("Host
+").is_empty(), "a bare Host names nothing");
     }
 }

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -110,46 +110,14 @@ async fn open_popup(api: &ApiClient, env: &Env) -> Result<()> {
 /// because the daemon persists their map entry the moment each one is
 /// created (see mirror::note_mapped) — the settle delay below is what gives
 /// that write time to land before the map is read.
-/// Is this pane the daemon's, rather than native junk?
-///
-/// Two independent signals, because neither alone is safe. The map is
-/// authoritative but written *after* the pane exists, so a fresh mirror pane is
-/// briefly unmapped. A running streamer proves ownership outright but only lands
-/// once the typed `exec` has taken. Polling both for a couple of seconds turns a
-/// 250ms race into one with a wide margin, and it costs nothing in the case that
-/// matters: genuine native junk is never mapped and never grows a streamer, so
-/// the wait always expires and we still act.
-async fn settles_as_ours(
-    env: &Env,
-    api: &ApiClient,
-    config: &crate::config::MirrorConfig,
-    pane_id: &str,
-) -> bool {
-    for attempt in 0..8 {
-        if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-        }
-        for h in &config.hosts {
-            let state = crate::state::load_state(&env.state_dir, &h.name);
-            if state.panes.values().any(|e| e.local_id == pane_id) {
-                return true;
-            }
-        }
-        if let Ok(v) = api.request("pane.process_info", json!({ "pane_id": pane_id })).await {
-            let running = v
-                .pointer("/process_info/foreground_processes")
-                .and_then(Value::as_array)
-                .is_some_and(|procs| {
-                    procs.iter().any(|p| {
-                        p.get("argv").and_then(Value::as_array).is_some_and(|argv| {
-                            argv.first().and_then(Value::as_str).is_some_and(|e| e.ends_with("herdr-mirror"))
-                                && argv.get(1).and_then(Value::as_str) == Some("pane")
-                        })
-                    })
-                });
-            if running {
-                return true;
-            }
+pub async fn intercept(env: Env, what: &str) -> Result<()> {
+    // opt-out: hosts.toml `intercept_native_create = false` leaves native
+    // creation alone entirely (an unreadable config keeps the default on —
+    // the guards below can't misfire without a mirror placeholder to match)
+    let config = load_config(&env.config_search).ok();
+    if let Some(c) = &config {
+        if !c.intercept_native_create {
+            return Ok(());
         }
     }
     false

--- a/src/util.rs
+++ b/src/util.rs
@@ -63,6 +63,49 @@ pub fn default_config_dir() -> PathBuf {
     home_dir().join(".config").join("herdr-mirror")
 }
 
+const DELETED_MARKER: &str = " (deleted)";
+
+/// `/proc/self/exe` gains a literal " (deleted)" suffix once the file behind it
+/// is replaced or unlinked. Returns the path without it, or None when there is
+/// no marker to strip. Pure, so the rule is testable without unlinking a binary.
+fn strip_deleted_marker(p: &Path) -> Option<PathBuf> {
+    p.to_str().and_then(|s| s.strip_suffix(DELETED_MARKER)).map(PathBuf::from)
+}
+
+/// A path to THIS binary that can still be RUN.
+///
+/// `current_exe()` reads /proc/self/exe, and Linux appends " (deleted)" to that
+/// link the moment the file behind it is replaced -- which every rebuild does to
+/// a running daemon. Rust passes the suffix straight through, so the value went
+/// into the streamer argv and produced `exec '/path/herdr-mirror (deleted)'`: a
+/// command that cannot run, leaving a bare shell parked in the `.mirror-pane`
+/// placeholder where a mirror should be. The same value was also handed to
+/// `Command::new` when respawning the daemon, and symlinked into the CLI link by
+/// `repair_cli_link`, which would have made the breakage outlive the process.
+///
+/// Order: the reported path if it is really there; the same path with the marker
+/// stripped (a rebuild in place -- the common case); then the stable CLI link,
+/// which by definition points at whatever is current.
+pub fn self_exe_path() -> Option<PathBuf> {
+    let reported = std::env::current_exe().ok()?;
+    if reported.is_file() {
+        return Some(reported);
+    }
+    if let Some(stripped) = strip_deleted_marker(&reported) {
+        if stripped.is_file() {
+            return Some(stripped);
+        }
+    }
+    let link = cli_link_path();
+    link.is_file().then_some(link)
+}
+
+/// `self_exe_path` as a command string, falling back to a bare name so PATH
+/// lookup still gives a streamer something to try.
+pub fn self_exe() -> String {
+    self_exe_path().map(|p| p.display().to_string()).unwrap_or_else(|| "herdr-mirror".into())
+}
+
 /// The stable CLI path install.sh links and the README's keybindings use.
 pub fn cli_link_path() -> PathBuf {
     home_dir().join(".local").join("bin").join("herdr-mirror")
@@ -89,7 +132,7 @@ pub fn cli_link_state() -> CliLink {
         Err(_) => CliLink::File,
         Ok(target) => {
             let resolved = fs::canonicalize(&link).ok();
-            let exe = std::env::current_exe().ok().and_then(|e| fs::canonicalize(e).ok());
+            let exe = self_exe_path().and_then(|e| fs::canonicalize(e).ok());
             match resolved {
                 None => CliLink::Dangling(target),
                 Some(r) if exe.as_ref() == Some(&r) => CliLink::Ok(target),
@@ -119,7 +162,7 @@ pub fn cli_link_problem() -> Option<String> {
 pub fn repair_cli_link() -> Option<String> {
     cli_link_problem()?;
     let link = cli_link_path();
-    let exe = std::env::current_exe().ok()?;
+    let exe = self_exe_path()?;
     let _ = fs::create_dir_all(link.parent()?);
     let _ = fs::remove_file(&link);
     Some(match std::os::unix::fs::symlink(&exe, &link) {
@@ -379,90 +422,18 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_state_dir(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "herdr-mirror-{name}-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ))
-    }
+mod deleted_exe_tests {
+    use super::strip_deleted_marker;
+    use std::path::{Path, PathBuf};
 
     #[test]
-    fn a_live_pid_claim_blocks_a_recovery_write() {
-        let state_dir = test_state_dir("active-spawn");
-        let pid_path = streamer_pid_path(&state_dir, "host", "w1:p1");
-        fs::create_dir_all(pid_path.parent().unwrap()).unwrap();
-        fs::write(&pid_path, std::process::id().to_string()).unwrap();
-
+    fn deleted_marker_is_stripped_only_when_it_is_a_real_suffix() {
         assert_eq!(
-            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
-            StreamerSpawnClaim::Active
+            strip_deleted_marker(Path::new("/usr/bin/herdr-mirror (deleted)")),
+            Some(PathBuf::from("/usr/bin/herdr-mirror"))
         );
-        assert!(!streamer_spawn_pending_path(&state_dir, "w2:p2").exists());
-        let _ = fs::remove_dir_all(state_dir);
-    }
-
-    #[test]
-    fn a_live_local_pane_pid_blocks_a_recovery_write() {
-        let state_dir = test_state_dir("active-local-pane");
-        let pid_path = pane_pid_path(&state_dir, "w2:p2");
-        fs::create_dir_all(pid_path.parent().unwrap()).unwrap();
-        fs::write(&pid_path, std::process::id().to_string()).unwrap();
-
-        assert_eq!(
-            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
-            StreamerSpawnClaim::Active
-        );
-        assert!(!streamer_spawn_pending_path(&state_dir, "w2:p2").exists());
-        let _ = fs::remove_dir_all(state_dir);
-    }
-
-    #[test]
-    fn one_pending_launch_owns_each_local_pane() {
-        let state_dir = test_state_dir("pending-spawn");
-
-        assert_eq!(
-            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
-            StreamerSpawnClaim::Claimed
-        );
-        assert_eq!(
-            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
-            StreamerSpawnClaim::Pending
-        );
-        clear_streamer_spawn_pending(&state_dir, "w2:p2");
-        assert_eq!(
-            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
-            StreamerSpawnClaim::Claimed
-        );
-        let _ = fs::remove_dir_all(state_dir);
-    }
-
-    #[test]
-    fn a_stale_pending_claim_can_be_replaced() {
-        let state_dir = test_state_dir("stale-pending");
-        let path = streamer_spawn_pending_path(&state_dir, "w2:p2");
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(&path, "host w1:p1\n").unwrap();
-        let past = std::time::SystemTime::now()
-            .checked_sub(SPAWN_PENDING_TTL + Duration::from_secs(1))
-            .unwrap()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as libc::time_t;
-        let cpath = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
-        let times = libc::utimbuf { actime: past, modtime: past };
-        assert_eq!(unsafe { libc::utime(cpath.as_ptr(), &times) }, 0);
-
-        assert_eq!(
-            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
-            StreamerSpawnClaim::Claimed
-        );
-        let _ = fs::remove_dir_all(state_dir);
+        assert_eq!(strip_deleted_marker(Path::new("/usr/bin/herdr-mirror")), None);
+        // the words appearing mid-path are a directory name, not the kernel marker
+        assert_eq!(strip_deleted_marker(Path::new("/tmp/x (deleted)/herdr-mirror")), None);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -437,3 +437,92 @@ mod deleted_exe_tests {
         assert_eq!(strip_deleted_marker(Path::new("/tmp/x (deleted)/herdr-mirror")), None);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "herdr-mirror-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn a_live_pid_claim_blocks_a_recovery_write() {
+        let state_dir = test_state_dir("active-spawn");
+        let pid_path = streamer_pid_path(&state_dir, "host", "w1:p1");
+        fs::create_dir_all(pid_path.parent().unwrap()).unwrap();
+        fs::write(&pid_path, std::process::id().to_string()).unwrap();
+
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Active
+        );
+        assert!(!streamer_spawn_pending_path(&state_dir, "w2:p2").exists());
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn a_live_local_pane_pid_blocks_a_recovery_write() {
+        let state_dir = test_state_dir("active-local-pane");
+        let pid_path = pane_pid_path(&state_dir, "w2:p2");
+        fs::create_dir_all(pid_path.parent().unwrap()).unwrap();
+        fs::write(&pid_path, std::process::id().to_string()).unwrap();
+
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Active
+        );
+        assert!(!streamer_spawn_pending_path(&state_dir, "w2:p2").exists());
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn one_pending_launch_owns_each_local_pane() {
+        let state_dir = test_state_dir("pending-spawn");
+
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Claimed
+        );
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Pending
+        );
+        clear_streamer_spawn_pending(&state_dir, "w2:p2");
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Claimed
+        );
+        let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn a_stale_pending_claim_can_be_replaced() {
+        let state_dir = test_state_dir("stale-pending");
+        let path = streamer_spawn_pending_path(&state_dir, "w2:p2");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "host w1:p1\n").unwrap();
+        let past = std::time::SystemTime::now()
+            .checked_sub(SPAWN_PENDING_TTL + Duration::from_secs(1))
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as libc::time_t;
+        let cpath = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+        let times = libc::utimbuf { actime: past, modtime: past };
+        assert_eq!(unsafe { libc::utime(cpath.as_ptr(), &times) }, 0);
+
+        assert_eq!(
+            claim_streamer_spawn(&state_dir, "host", "w1:p1", "w2:p2").unwrap(),
+            StreamerSpawnClaim::Claimed
+        );
+        let _ = fs::remove_dir_all(state_dir);
+    }
+}


### PR DESCRIPTION
Fires the host picker for a native new-workspace created from a **local** pane, not only from inside a mirror.

### Today

`intercept_workspace` is a positive test for junk by construction: it requires `label == ".mirror-pane"`, one pane, and a bare pane whose cwd is the placeholder. That shape only occurs when the focused pane was a mirror pane. From a local pane the create passes straight through, so the picker appears only if you were already inside a mirror — which is a surprising place for the choice to live, since "where should this workspace go" is the same question either way.

### Change

The workspace arm now also accepts a freshly created bare **local** workspace and routes it through the picker.

Two guards keep that safe:

- **The picker's own create is exempt.** `create_local()` writes a `picker-created` marker immediately before creating, and the hook ignores a workspace created within 10s of it. Without this the picker's result bounces straight back into the picker. The mirror arm's `intercept-acted` marker is deliberately left alone — that one is a blanket one-action-per-window cap for a daemon/hook feedback loop, not this hand-off.
- **Daemon-built mirrors are excluded.** A mirror workspace also looks bare in the moment before its map entry and streamer land, so the non-placeholder path runs the existing `settles_as_ours()` poll before acting.

An agent pane is now refused outright in this arm, whatever its cwd.

### Tradeoff

The picker also appears for genuinely local workspaces created by any means, not just mouse clicks. That is the intent — but it is a visible behaviour change for every new workspace on the machine, so it is worth calling out rather than burying.

### Verification

Driven headlessly through the herdr socket (`workspace.create`, then poll `workspace.list`):

| case | cwd | result |
|---|---|---|
| junk from a mirror | `.mirror-pane` placeholder | intercepted in ~1s (unchanged) |
| plain local workspace | `/root` | **intercepted in ~3s** (new; the delay is the settle poll) |
| picker's own create | `/root`, marker fresh | survives untouched |

191 tests pass; `clippy --release --all-targets -D warnings` clean. Running live on the WSL deployment.

> Stacked on #85 — it branches from the same ported 0.4.1 base, so review that one first.
