### PR TITLE
Add bounded SSH stream connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,10 +331,101 @@ target = "work"
                                      # "socket" = ssh -L forward, "exec" = relay
                                      # over ssh exec (needs socat or python3).
                                      # auto = socket, falling back to exec.
+# ssh_streams_per_connection = 1     # opt-in ssh stream pooling — see below.
 
 [hosts.vps]                          # add more hosts freely; each is independent
 target = "ssh://niko@203.0.113.7:2222"
 ```
+
+### SSH stream pooling (opt-in)
+
+Every mirror pane's data stream is, by default, its own direct ssh connection
+— isolated, and nothing shared to go stale. `ssh_streams_per_connection`
+(global or per-host, like `always_control`) instead lets up to N pane streams
+share one ssh connection, multiplexed the same way `ssh -O forward` already
+shares the daemon's own control-plane connection:
+
+```toml
+ssh_streams_per_connection = 4   # up to 4 pane streams per ssh connection
+
+[hosts.vps]
+target = "vps"
+# ssh_streams_per_connection = 8 # per-host override
+```
+
+Absence, or `1`, is today's one-connection-per-pane behavior — nothing
+changes for anyone who doesn't set this. `0` is treated as unset, the same as
+a `max_cols`/`max_rows` typo.
+
+**Capacity, not a hash bucket.** N is a live-stream *ceiling* per connection,
+tracked in each host's `*-map.json` (`streamSlot`) and reassigned only when a
+pane's current slot can no longer hold it — panes are never shuffled around
+just to rebalance. A streamer's argv (and therefore its slot) is fixed for
+its process's life, so an ordinary ssh reconnect adopts nothing; a pane picks
+up a changed slot only when its streamer *process* is recreated — hide/show,
+or closing and reopening the pane — and a one-line hint in the pane says so
+when a change is waiting.
+
+**Isolated from ordinary use.** Pooling only ever overrides the ssh
+multiplexing options (`-S`/ControlPath, `ControlMaster`) on a pane's data
+connection — every other ssh_config resolution for that target (ProxyJump,
+GSSAPI, certificates, identity files, agent forwarding) still applies. It is
+a private socket per host/target/slot, entirely separate from the daemon's
+own `<host>.ctl` control-plane master (foreground polls, paste, clipboard)
+and from plain `ssh <host>`/Auth Buddy, neither of which is ever pointed at a
+pool socket.
+
+**Master lifecycle.** The daemon is the *sole* creator of a slot's
+ControlMaster, always under a cross-process file lock so a concurrent
+converge pass and a separately-invoked `herdr-mirror once` can't race to
+replace the same socket. It pre-creates a slot's master both right before
+spawning newly-created pooled panes and, more broadly, after every converge
+pass — concurrently across slots and on short timeouts, so a single
+unreachable slot can't serialize into a multi-minute stall, and a slot that
+keeps failing is backed off rather than retried on every pass. `once` never
+creates or replaces a master itself, even when it spawns a newly-created
+pooled pane: it is a one-shot client with nothing left running afterward to
+supervise or recover a master it might have started, so its streamers
+attach exactly like the daemon's do — `ControlMaster=no`, reusing whatever
+master the daemon has already brought up for that slot, or falling back to
+a direct connection if there isn't one yet. Pane streams generally connect
+with `ControlMaster=no`: a streamer only ever attaches to a master that
+already exists, never creates one, so it falls back to an ordinary direct
+connection if the slot's master isn't up yet or refuses (same as the
+`MaxSessions` case below) rather than racing to create one outside the
+daemon's lock. Every pool master persists for a bounded idle window rather
+than forever, so a slot no longer used (its panes closed, or a target/N
+change stopped assigning it) lets its master exit and clean up its own
+socket on its own instead of accumulating a permanent background process.
+
+**Failure blast radius.** Every stream sharing a slot's connection dies
+together if that connection drops — the tradeoff for fewer open connections.
+N is your dial on that radius: keep it low if a dropped mux master losing
+several panes at once would be disruptive.
+
+**`MaxSessions` caveat.** N is *Mirror's own* assignment capacity, not a
+guarantee the ssh server will honor it. OpenSSH multiplexes multiple ordinary
+sessions (a plain `ssh host command`, which is what each pooled pane stream
+is) over one connection only up to the server's `MaxSessions` (default 10,
+sometimes lower); current portable OpenSSH's mux client falls through to an
+ordinary direct connection — logging a message, but still succeeding — when a
+session is refused past that limit, verified against upstream source rather
+than documented as a guarantee, so treat it as current-OpenSSH/vendor-
+dependent behavior, not a contract. That fallback is specific to ordinary
+sessions: the `-O check`/`-O forward` administrative commands the daemon's
+own control-plane master relies on have no such fallback and simply fail,
+which is why that code path handles its own errors rather than assuming one.
+
+A pane streaming successfully is therefore **not proof it is actually
+pooled** — a session that quietly fell back to direct looks identical from
+the outside. `herdr-mirror status`'s slot occupancy reflects Mirror's
+*intended* assignment, not a live confirmation of it. Keep N at or below your
+target's effective `MaxSessions` if you want pooling to be reliable rather
+than a best-effort optimization.
+
+**Docker is unaffected.** Docker hosts always `docker exec` a fresh channel
+per stream — there is no ssh connection to share — so this setting is a
+no-op there.
 
 ## Devcontainer
 

--- a/src/binding.rs
+++ b/src/binding.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 
 use serde_json::{json, Value};
 
-use crate::config::load_config;
+use crate::config::load_config_for_env;
 use crate::remote::RemoteHost;
 use crate::util::{err, herdr_config_path, Env, Result};
 
@@ -121,7 +121,7 @@ pub async fn remote_actions(env: Env, host_arg: Option<&str>) -> Result<()> {
     if host_arg != Some("local") {
         // remote-actions is a discovery command, so unlike remote-invoke a
         // missing/broken hosts.toml only matters when hosts were asked for
-        let hosts = match load_config(&env.config_search) {
+        let hosts = match load_config_for_env(&env) {
             Ok(c) => c.hosts,
             Err(e) if host_arg.is_none() => {
                 println!("(no hosts listed: {e})");

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,12 @@ pub struct HostConfig {
     /// of the local pane blank instead. Observe is unaffected either way.
     pub max_cols: Option<usize>,
     pub max_rows: Option<usize>,
+    /// ssh hosts only: how many pane streams may share one ssh ControlMaster
+    /// connection. 1 (the default; absence resolves here too) is today's
+    /// one-direct-connection-per-pane behavior. Docker always execs a fresh
+    /// `docker exec` per stream with no multiplexing, so this is a no-op
+    /// there — same reasoning as `api_transport` being ssh-only.
+    pub ssh_streams_per_connection: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -160,6 +166,7 @@ struct RawConfig {
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
+    ssh_streams_per_connection: Option<usize>,
     // toml::Table (preserve_order) keeps declaration order — the first host
     // is the remote-create fallback, so order is user-visible
     #[serde(default)]
@@ -182,6 +189,7 @@ struct RawHost {
     max_cols: Option<usize>,
     max_rows: Option<usize>,
     api_transport: Option<String>,
+    ssh_streams_per_connection: Option<usize>,
 }
 
 /// Resolve `kind` + its ref fields, rejecting combinations that would silently
@@ -203,7 +211,10 @@ fn resolve_kind(name: &str, h: &RawHost) -> Result<(HostKind, String)> {
             if h.container.is_some() || h.folder.is_some() {
                 return Err(bad("container/folder need kind = \"docker\"".into()));
             }
-            let target = h.target.clone().ok_or_else(|| bad("missing target".into()))?;
+            let target = h
+                .target
+                .clone()
+                .ok_or_else(|| bad("missing target".into()))?;
             Ok((HostKind::Ssh, nonempty("target", &target)?))
         }
         "docker" => {
@@ -227,7 +238,9 @@ fn resolve_kind(name: &str, h: &RawHost) -> Result<(HostKind, String)> {
                 }
             }
         }
-        other => Err(bad(format!("unknown kind \"{other}\" (expected ssh or docker)"))),
+        other => Err(bad(format!(
+            "unknown kind \"{other}\" (expected ssh or docker)"
+        ))),
     }
 }
 
@@ -240,21 +253,142 @@ fn resolve_kind(name: &str, h: &RawHost) -> Result<(HostKind, String)> {
 /// command typed in a terminal. Searching every candidate either way keeps the
 /// two modes in agreement (see `util::config_candidates`).
 pub fn load_config(candidates: &[PathBuf]) -> Result<MirrorConfig> {
-    let found: Vec<PathBuf> =
-        candidates.iter().map(|d| d.join("hosts.toml")).filter(|f| f.is_file()).collect();
+    let found: Vec<PathBuf> = candidates
+        .iter()
+        .map(|d| d.join("hosts.toml"))
+        .filter(|f| f.is_file())
+        .collect();
     let Some(file) = found.first() else {
-        let searched =
-            candidates.iter().map(|d| format!("  {}", d.join("hosts.toml").display()));
+        let searched = candidates
+            .iter()
+            .map(|d| format!("  {}", d.join("hosts.toml").display()));
         return Err(err(format!(
             "no hosts.toml found — searched:\n{}\n\ncreate one with:\n\n[hosts.<name>]\ntarget = \"<ssh target>\"\n",
             searched.collect::<Vec<_>>().join("\n")
         )));
     };
-    let text = std::fs::read_to_string(file)
-        .map_err(|e| err(format!("{}: {e}", file.display())))?;
+    let text =
+        std::fs::read_to_string(file).map_err(|e| err(format!("{}: {e}", file.display())))?;
     let mut config = parse_config(&text).map_err(|e| err(format!("{}: {e}", file.display())))?;
     config.source = Some(file.clone());
     config.shadowed = found[1..].to_vec();
+    Ok(config)
+}
+
+/// Catches a real 64-bit hash collision between two DIFFERENT unsafe host
+/// names (astronomically unlikely, see util.rs, but silent unless checked).
+/// A safe host name never needs this check: two different safe names are
+/// never equal by construction, and a safe name's root-level path can never
+/// alias an unsafe name's hashed path under `util::unsafe_host_artifacts_dir`
+/// regardless of what either looks like — they're in different directories.
+/// Every unsafe-host-derived path — state map, hidden marker, host lock,
+/// atomic temp file, control-plane socket — comes from this exact stem, so
+/// a collision here would otherwise surface at runtime as one host's state
+/// silently clobbering another's, far harder to diagnose than rejecting the
+/// config up front with both names in the error.
+fn validate_unique_host_stems(hosts: &[HostConfig]) -> Result<()> {
+    validate_unique_stems(
+        "internal path stem",
+        hosts
+            .iter()
+            .filter(|h| !crate::util::is_safe_path_component(&h.name))
+            .map(|h| (h.name.as_str(), crate::util::unsafe_host_stem(&h.name))),
+    )
+}
+
+/// Same idea, for the stream-pool socket namespace (`remote::stream_control_path`)
+/// rather than the state/control-plane one: two DIFFERENT (host, target)
+/// pairs whose `util::stream_namespace_hash` collides would otherwise let
+/// one host's pooled pane streams attach to another's master. Checked once
+/// per pooled host (`N > 1`), not once per slot: `ssh_streams_per_connection`
+/// is a per-slot pane-count *capacity*, not a slot count — the actual
+/// number of slots a host uses depends on how many panes are open and can
+/// exceed N (see `stream_pool`) — so there is no finite "every slot" to
+/// enumerate, and the namespace hash never includes slot anyway (see
+/// `stream_control_path`), only host+target. Docker hosts (and any host
+/// with pooling off) never open a stream-pool socket at all, so they have
+/// nothing to check. O(hosts), regardless of how large N is configured.
+fn validate_unique_stream_namespaces(hosts: &[HostConfig]) -> Result<()> {
+    validate_unique_stems(
+        "stream-pool namespace",
+        hosts
+            .iter()
+            .filter(|h| !h.kind.is_docker() && h.ssh_streams_per_connection > 1)
+            .map(|h| {
+                (
+                    h.name.as_str(),
+                    crate::util::stream_namespace_hash(&h.name, &h.target),
+                )
+            }),
+    )
+}
+
+/// The one validation that actually proves two configured hosts won't share
+/// a live ControlMaster: `util::unsafe_host_stem`/`stream_namespace_hash`
+/// catch a real hash collision within their OWN category, but
+/// `remote::control_socket_base`'s v0.4.1-compatible path for a SAFE-but-
+/// overlong host name deliberately stays on the unprefixed,
+/// budget-truncated legacy hash (see its doc comment) — so a generated stem
+/// like `remote-development-environment-w-<hash>` can equal a second,
+/// entirely unrelated host's short verbatim name. Whether that actually
+/// happens depends on the real `state_dir` (which sets the truncation
+/// budget), not knowable at config PARSE time, which is why this takes it
+/// as a parameter and runs separately from `parse_config` — see
+/// `load_config_for_env`, the one place both are available together. Every
+/// host, docker included, gets a control-plane socket via
+/// `remote::control_path`, so none are excluded here (unlike the
+/// stream-namespace check above, which only ssh hosts ever open).
+fn validate_actual_control_paths(hosts: &[HostConfig], state_dir: &std::path::Path) -> Result<()> {
+    validate_unique_stems(
+        "control-plane socket path",
+        hosts.iter().map(|h| {
+            let path = crate::remote::control_path(state_dir, &h.name);
+            (h.name.as_str(), path.display().to_string())
+        }),
+    )
+}
+
+/// The duplicate-detection logic itself, given each entry's display name
+/// and already-derived stem: reject the first repeat, naming both entries
+/// and (for `validate_actual_control_paths`) the actual colliding path.
+/// Taking precomputed `(name, stem)` pairs rather than a stem function
+/// keeps this one implementation shared by every caller above, which
+/// otherwise differ in what a "stem" even is (a host name alone, a
+/// host+target pair, or a full runtime path). A real hash collision isn't
+/// practical to construct in a test, so tests exercise this with
+/// deliberately colliding stems instead, which is what actually proves this
+/// finds and reports a collision rather than the hash happening not to have
+/// one.
+fn validate_unique_stems<'a>(
+    what: &str,
+    entries: impl Iterator<Item = (&'a str, String)>,
+) -> Result<()> {
+    let mut stems: std::collections::HashMap<String, &str> = std::collections::HashMap::new();
+    for (name, stem) in entries {
+        if let Some(&other) = stems.get(stem.as_str()) {
+            return Err(err(format!(
+                "hosts.toml: \"{other}\" and \"{name}\" both derive the same {what} \"{stem}\" \
+                 — rename one of them"
+            )));
+        }
+        stems.insert(stem, name);
+    }
+    Ok(())
+}
+
+/// The narrowest boundary where a config and the state_dir it will actually
+/// run against are both known — every call path that will go on to touch a
+/// host (daemon start, converge, `once`, hide/show, ...) must load its
+/// config through here rather than `load_config` directly, or a host whose
+/// legacy-hashed control-plane stem happens to equal another host's
+/// literal name would only be caught the first time something actually
+/// tries to use the colliding socket.
+pub fn load_config_for_env(env: &crate::util::Env) -> Result<MirrorConfig> {
+    let config = load_config(&env.config_search)?;
+    validate_actual_control_paths(&config.hosts, &env.state_dir)?;
+    for host in &config.hosts {
+        crate::remote::validate_socket_path_budget(&env.state_dir, host)?;
+    }
     Ok(config)
 }
 
@@ -269,14 +403,28 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     let size_cap = |v: Option<usize>| v.filter(|&n| n > 0);
     for (key, v) in [("max_cols", raw.max_cols), ("max_rows", raw.max_rows)] {
         if v == Some(0) {
-            warnings.push(format!("{key} = 0 ignored: 0 means unset, not \"cap to nothing\""));
+            warnings.push(format!(
+                "{key} = 0 ignored: 0 means unset, not \"cap to nothing\""
+            ));
         }
     }
     let global_max_cols = size_cap(raw.max_cols);
     let global_max_rows = size_cap(raw.max_rows);
+    // Same "0 is a typo, not an instruction" reasoning as the size caps: a
+    // pool of 0 connections can't stream anything, so it is treated as unset
+    // (falls back to 1, direct-per-pane) rather than silently disabling
+    // streaming.
+    if raw.ssh_streams_per_connection == Some(0) {
+        warnings.push(
+            "ssh_streams_per_connection = 0 ignored: 0 means unset, not \"no streams\"".into(),
+        );
+    }
+    let global_streams_per_connection = size_cap(raw.ssh_streams_per_connection).unwrap_or(1);
     let mut hosts: Vec<HostConfig> = Vec::new();
     for (name, value) in raw.hosts {
-        let h: RawHost = value.try_into().map_err(|e| err(format!("[hosts.{name}]: {e}")))?;
+        let h: RawHost = value
+            .try_into()
+            .map_err(|e| err(format!("[hosts.{name}]: {e}")))?;
         if h.enabled == Some(false) {
             continue;
         }
@@ -287,6 +435,12 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
                      rather than clearing it"
                 ));
             }
+        }
+        if h.ssh_streams_per_connection == Some(0) {
+            warnings.push(format!(
+                "[hosts.{name}]: ssh_streams_per_connection = 0 ignored; it falls through to \
+                 any global value rather than clearing it"
+            ));
         }
         // Skip-with-warning, not abort. Aborting would let one typo'd entry
         // stop the daemon entirely and take every *other* host's mirrors down
@@ -320,6 +474,8 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             always_control: h.always_control.unwrap_or(global_always_control),
             max_cols: size_cap(h.max_cols).or(global_max_cols),
             max_rows: size_cap(h.max_rows).or(global_max_rows),
+            ssh_streams_per_connection: size_cap(h.ssh_streams_per_connection)
+                .unwrap_or(global_streams_per_connection),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
             api_transport,
             kind,
@@ -335,14 +491,21 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
         return Err(err(if warnings.is_empty() {
             "hosts.toml: no enabled [hosts.*] entries".to_string()
         } else {
-            format!("hosts.toml: no usable [hosts.*] entries\n{}", warnings.join("\n"))
+            format!(
+                "hosts.toml: no usable [hosts.*] entries\n{}",
+                warnings.join("\n")
+            )
         }));
     }
     if let Some(d) = &raw.default_host {
         if !hosts.iter().any(|h| &h.name == d) {
-            return Err(err(format!("hosts.toml: default_host \"{d}\" is not an enabled [hosts.*] entry")));
+            return Err(err(format!(
+                "hosts.toml: default_host \"{d}\" is not an enabled [hosts.*] entry"
+            )));
         }
     }
+    validate_unique_host_stems(&hosts)?;
+    validate_unique_stream_namespaces(&hosts)?;
     Ok(MirrorConfig {
         poll_seconds: raw.poll_seconds.unwrap_or(60),
         autostart: raw.autostart.unwrap_or(true),
@@ -448,7 +611,8 @@ mod tests {
     fn default_host_must_exist() {
         assert!(parse_config("default_host = \"nope\"\n[hosts.work]\ntarget = \"w\"\n").is_err());
         // unset default_host falls back to the first host declared
-        let c = parse_config("[hosts.zeta]\ntarget = \"z\"\n[hosts.alpha]\ntarget = \"a\"\n").unwrap();
+        let c =
+            parse_config("[hosts.zeta]\ntarget = \"z\"\n[hosts.alpha]\ntarget = \"a\"\n").unwrap();
         assert_eq!(c.default_host().unwrap().name, "zeta");
     }
 
@@ -461,7 +625,8 @@ mod tests {
     /// must survive parsing (a sorted map would put alpha first).
     #[test]
     fn preserves_declaration_order() {
-        let c = parse_config("[hosts.zeta]\ntarget = \"z\"\n[hosts.alpha]\ntarget = \"a\"\n").unwrap();
+        let c =
+            parse_config("[hosts.zeta]\ntarget = \"z\"\n[hosts.alpha]\ntarget = \"a\"\n").unwrap();
         assert_eq!(c.hosts[0].name, "zeta");
         assert_eq!(c.hosts[1].name, "alpha");
     }
@@ -501,7 +666,10 @@ mod tests {
         .unwrap();
         let tok = c.hosts.iter().find(|h| h.name == "tok").unwrap();
         assert_eq!(tok.kind, HostKind::DockerFolder("/Users/n/proj".into()));
-        assert_eq!(tok.target, "/Users/n/proj", "display target falls back to the ref");
+        assert_eq!(
+            tok.target, "/Users/n/proj",
+            "display target falls back to the ref"
+        );
         assert!(tok.kind.is_docker());
         let named = c.hosts.iter().find(|h| h.name == "named").unwrap();
         assert_eq!(named.kind, HostKind::DockerContainer("crazy_ride".into()));
@@ -559,7 +727,11 @@ mod tests {
         .unwrap();
         assert_eq!(c.hosts.len(), 1);
         assert_eq!(c.hosts[0].name, "good");
-        assert!(c.warnings[0].contains("unknown api_transport"), "{:?}", c.warnings);
+        assert!(
+            c.warnings[0].contains("unknown api_transport"),
+            "{:?}",
+            c.warnings
+        );
     }
 
     #[test]
@@ -573,16 +745,81 @@ mod tests {
         assert_eq!(c.hosts[0].docker_bin, "/usr/local/bin/docker");
     }
 
+    #[test]
+    fn ssh_streams_per_connection_defaults_to_one() {
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert_eq!(c.hosts[0].ssh_streams_per_connection, 1);
+    }
+
+    #[test]
+    fn ssh_streams_per_connection_global_default_and_per_host_override() {
+        let c = parse_config(
+            "ssh_streams_per_connection = 4\n\
+             [hosts.a]\ntarget = \"a\"\n\
+             [hosts.b]\ntarget = \"b\"\nssh_streams_per_connection = 8\n",
+        )
+        .unwrap();
+        let a = c.hosts.iter().find(|h| h.name == "a").unwrap();
+        let b = c.hosts.iter().find(|h| h.name == "b").unwrap();
+        assert_eq!(a.ssh_streams_per_connection, 4, "inherits the global value");
+        assert_eq!(b.ssh_streams_per_connection, 8, "per-host override");
+    }
+
+    /// A pool of 0 connections can't stream anything — same "typo, not an
+    /// instruction" reasoning as a 0 size cap — so it is unset (falls back to
+    /// 1) rather than silently disabling every stream.
+    #[test]
+    fn ssh_streams_per_connection_zero_warns_and_falls_through() {
+        let c =
+            parse_config("ssh_streams_per_connection = 0\n[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert_eq!(c.hosts[0].ssh_streams_per_connection, 1);
+        assert!(
+            c.warnings
+                .iter()
+                .any(|w| w.contains("ssh_streams_per_connection = 0 ignored")),
+            "{:?}",
+            c.warnings
+        );
+
+        let c = parse_config(
+            "ssh_streams_per_connection = 4\n[hosts.a]\ntarget = \"a\"\nssh_streams_per_connection = 0\n",
+        )
+        .unwrap();
+        assert_eq!(
+            c.hosts[0].ssh_streams_per_connection, 4,
+            "0 falls through to the global"
+        );
+        assert!(
+            c.warnings
+                .iter()
+                .any(|w| w.contains("falls through to any global value")),
+            "{:?}",
+            c.warnings
+        );
+    }
+
+    /// Meaningless for docker (no ssh ControlMaster to share), but accepted
+    /// rather than rejected — same reasoning as `docker_bin` being a no-op on
+    /// ssh hosts: a global setting easily reaches a mixed fleet, and a field
+    /// that does nothing for one kind is simpler than a kind-specific reject.
+    #[test]
+    fn ssh_streams_per_connection_parses_on_docker_hosts_as_a_no_op() {
+        let c = parse_config(
+            "ssh_streams_per_connection = 4\n\
+             [hosts.a]\nkind = \"docker\"\ncontainer = \"c\"\n",
+        )
+        .unwrap();
+        assert_eq!(c.hosts[0].ssh_streams_per_connection, 4);
+    }
+
     /// One malformed host must not take the whole config down with it. The
     /// stricter validation added alongside container support originally
     /// aborted the load, which was worse than the behaviour it replaced: a
     /// single typo stopped every *other* host from mirroring.
     #[test]
     fn a_bad_host_is_skipped_not_fatal() {
-        let c = parse_config(
-            "[hosts.good]\ntarget = \"vps\"\n[hosts.bad]\ntarget = \"\"\n",
-        )
-        .expect("one bad host must not abort the load");
+        let c = parse_config("[hosts.good]\ntarget = \"vps\"\n[hosts.bad]\ntarget = \"\"\n")
+            .expect("one bad host must not abort the load");
         assert_eq!(c.hosts.len(), 1);
         assert_eq!(c.hosts[0].name, "good");
         assert_eq!(c.warnings.len(), 1, "the skip must be reported, not silent");
@@ -595,23 +832,33 @@ mod tests {
     /// nothing" when the user plainly did.
     #[test]
     fn all_hosts_invalid_is_still_an_error() {
-        let e = parse_config("[hosts.a]\ntarget = \"\"\n").unwrap_err().to_string();
+        let e = parse_config("[hosts.a]\ntarget = \"\"\n")
+            .unwrap_err()
+            .to_string();
         assert!(e.contains("no usable"), "{e}");
-        assert!(e.contains("target is empty"), "must name the actual reason: {e}");
+        assert!(
+            e.contains("target is empty"),
+            "must name the actual reason: {e}"
+        );
         // an empty file has no reasons to give, so it keeps the plain message
         let e = parse_config("").unwrap_err().to_string();
         assert!(!e.contains("no usable"), "{e}");
     }
 
     fn tmpdir(tag: &str) -> PathBuf {
-        let d = std::env::temp_dir().join(format!("herdr-mirror-cfgtest-{tag}-{}", std::process::id()));
+        let d =
+            std::env::temp_dir().join(format!("herdr-mirror-cfgtest-{tag}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&d);
         std::fs::create_dir_all(&d).unwrap();
         d
     }
 
     fn write_hosts(dir: &Path, name: &str) {
-        std::fs::write(dir.join("hosts.toml"), format!("[hosts.{name}]\ntarget = \"t\"\n")).unwrap();
+        std::fs::write(
+            dir.join("hosts.toml"),
+            format!("[hosts.{name}]\ntarget = \"t\"\n"),
+        )
+        .unwrap();
     }
 
     /// A config in a *later* candidate must still be found. This is the
@@ -646,9 +893,17 @@ mod tests {
     fn missing_config_error_lists_every_candidate() {
         let a = tmpdir("miss-a");
         let b = tmpdir("miss-b");
-        let e = load_config(&[a.clone(), b.clone()]).unwrap_err().to_string();
-        assert!(e.contains(&a.join("hosts.toml").display().to_string()), "{e}");
-        assert!(e.contains(&b.join("hosts.toml").display().to_string()), "{e}");
+        let e = load_config(&[a.clone(), b.clone()])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            e.contains(&a.join("hosts.toml").display().to_string()),
+            "{e}"
+        );
+        assert!(
+            e.contains(&b.join("hosts.toml").display().to_string()),
+            "{e}"
+        );
     }
 
     #[test]
@@ -656,16 +911,362 @@ mod tests {
         // silently dropping a typo'd cap leaves the user believing it applied
         let c = parse_config("max_cols = 0\n[hosts.a]\ntarget = \"a\"\n").unwrap();
         assert_eq!(c.hosts[0].max_cols, None);
-        assert!(c.warnings.iter().any(|w| w.contains("max_cols = 0 ignored")), "{:?}", c.warnings);
-
-        // and 0 per host is not a way to opt out of a global cap
-        let c =
-            parse_config("max_cols = 200\n[hosts.a]\ntarget = \"a\"\nmax_cols = 0\n").unwrap();
-        assert_eq!(c.hosts[0].max_cols, Some(200), "0 falls through to the global");
         assert!(
-            c.warnings.iter().any(|w| w.contains("falls through to any global cap")),
+            c.warnings
+                .iter()
+                .any(|w| w.contains("max_cols = 0 ignored")),
             "{:?}",
             c.warnings
         );
+
+        // and 0 per host is not a way to opt out of a global cap
+        let c = parse_config("max_cols = 200\n[hosts.a]\ntarget = \"a\"\nmax_cols = 0\n").unwrap();
+        assert_eq!(
+            c.hosts[0].max_cols,
+            Some(200),
+            "0 falls through to the global"
+        );
+        assert!(
+            c.warnings
+                .iter()
+                .any(|w| w.contains("falls through to any global cap")),
+            "{:?}",
+            c.warnings
+        );
+    }
+
+    /// Real distinct host names must never trip the duplicate-stem check —
+    /// this is the false-positive risk of adding it at all, so it gets its
+    /// own explicit config-level test beyond the many other host configs
+    /// already parsed successfully elsewhere in this module.
+    #[test]
+    fn distinct_ordinary_host_names_never_collide_on_stem() {
+        let c = parse_config(
+            "[hosts.azure]\ntarget = \"azure\"\n\
+             [hosts.rdev]\ntarget = \"rdev\"\n\
+             [hosts.prod-us-east-1]\ntarget = \"t\"\n",
+        )
+        .unwrap();
+        assert_eq!(c.hosts.len(), 3);
+    }
+
+    /// The duplicate-stem check's own detection logic, independent of
+    /// whether the real 64-bit hash ever actually collides (it shouldn't —
+    /// see util.rs): deliberately colliding stems prove this finds and
+    /// reports a duplicate rather than the hash simply not having one to
+    /// find.
+    #[test]
+    fn validate_unique_stems_reports_both_names_on_a_forced_collision() {
+        let names = ["alpha", "beta", "gamma"];
+        let err = validate_unique_stems(
+            "stem",
+            names.into_iter().map(|n| (n, "same-stem".to_string())),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("alpha"), "{err}");
+        assert!(err.contains("beta"), "{err}");
+        assert!(err.contains("same-stem"), "{err}");
+    }
+
+    #[test]
+    fn validate_unique_stems_accepts_genuinely_distinct_stems() {
+        let names = ["alpha", "beta", "gamma"];
+        assert!(
+            validate_unique_stems("stem", names.into_iter().map(|n| (n, n.to_string()))).is_ok()
+        );
+    }
+
+    /// `validate_unique_host_stems` (the real entry point `parse_config`
+    /// calls) must actually be wired to the real `unsafe_host_stem`, not a
+    /// stand-in — this is the wiring `validate_unique_stems_*` above can't
+    /// cover since it always takes an injected function. Uses unsafe names:
+    /// safe ones are filtered out before this check ever runs (see its doc
+    /// comment), so a safe-only config would pass trivially either way.
+    #[test]
+    fn validate_unique_host_stems_uses_the_real_unsafe_host_stem() {
+        let hosts = vec![test_host("a/b", "t1"), test_host("c/d", "t2")];
+        assert!(validate_unique_host_stems(&hosts).is_ok());
+    }
+
+    fn test_host(name: &str, target: &str) -> HostConfig {
+        HostConfig {
+            name: name.into(),
+            prefix: name.into(),
+            target: target.into(),
+            kind: HostKind::Ssh,
+            remote_bin: None,
+            session: None,
+            always_control: true,
+            max_cols: None,
+            max_rows: None,
+            ssh_streams_per_connection: 1,
+            docker_bin: "docker".into(),
+            api_transport: ApiTransport::Auto,
+        }
+    }
+
+    /// A host with pooling actually on (`ssh_streams_per_connection > 1`):
+    /// `validate_unique_stream_namespaces` skips any host at the default
+    /// `1` (it never opens a stream-pool socket at all), so a test of that
+    /// check needs this, not plain `test_host`.
+    fn pooled_host(name: &str, target: &str) -> HostConfig {
+        let mut h = test_host(name, target);
+        h.ssh_streams_per_connection = 4;
+        h
+    }
+
+    /// `validate_unique_stream_namespaces` (the real entry point
+    /// `parse_config` calls) must actually be wired to the real
+    /// `stream_namespace_hash`, keyed on host+target, not a stand-in.
+    #[test]
+    fn validate_unique_stream_namespaces_uses_the_real_namespace_base() {
+        let hosts = vec![
+            pooled_host("azure", "azure.example.com"),
+            pooled_host("rdev", "rdev.example.com"),
+        ];
+        assert!(validate_unique_stream_namespaces(&hosts).is_ok());
+    }
+
+    /// Two hosts sharing a target (a real, supported setup — e.g. the same
+    /// machine reached under two names/sessions) must not be flagged: the
+    /// namespace hashes host+target together, not target alone.
+    #[test]
+    fn validate_unique_stream_namespaces_allows_a_shared_target() {
+        let hosts = vec![
+            pooled_host("a", "shared.example.com"),
+            pooled_host("b", "shared.example.com"),
+        ];
+        assert!(validate_unique_stream_namespaces(&hosts).is_ok());
+    }
+
+    /// `ssh_streams_per_connection` is a per-slot pane-count capacity, not a
+    /// slot count: an earlier version of this check enumerated `0..N` slots
+    /// per host, which was both conceptually wrong (a host can use more
+    /// slots than N — see `stream_pool::fresh_panes_fill_the_lowest_slot_first`,
+    /// where capacity 2 still reaches slot 2 for 5 panes) and unbounded
+    /// (a huge configured N made validation itself slow, and needed a
+    /// usize -> u32 cast that could truncate). The namespace hash is
+    /// host+target only, so validating a huge N must still be instant.
+    #[test]
+    fn validate_unique_stream_namespaces_is_o_of_hosts_even_for_a_huge_capacity() {
+        let mut huge = pooled_host("huge", "huge.example.com");
+        huge.ssh_streams_per_connection = usize::MAX;
+        let started = std::time::Instant::now();
+        assert!(validate_unique_stream_namespaces(&[huge]).is_ok());
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "must not scale with the configured capacity"
+        );
+    }
+
+    /// Docker hosts never open a stream-pool socket, so they must never be
+    /// able to trip this check even if their (name, target) happen to
+    /// duplicate something.
+    #[test]
+    fn validate_unique_stream_namespaces_skips_docker_hosts() {
+        let mut docker = pooled_host("d", "same-target");
+        docker.kind = HostKind::DockerContainer("c".into());
+        let hosts = vec![pooled_host("a", "same-target"), docker];
+        assert!(validate_unique_stream_namespaces(&hosts).is_ok());
+    }
+
+    /// An ordinary host left at the `ssh_streams_per_connection` default
+    /// (pooling off) never opens a stream-pool socket at all, so it must
+    /// never be able to trip this check even against an otherwise-colliding
+    /// pooled host.
+    #[test]
+    fn validate_unique_stream_namespaces_skips_unpooled_hosts() {
+        let unpooled = test_host("a", "same-target");
+        let hosts = vec![unpooled, pooled_host("b", "same-target")];
+        assert!(validate_unique_stream_namespaces(&hosts).is_ok());
+    }
+
+    /// The exact defect an independent review reported: preserving v0.4.1's
+    /// legacy, budget-truncated control-plane stem for a safe-but-overlong
+    /// host name means the generated stem (a readable prefix plus an
+    /// 8-hex-char hash) can equal a second, distinct host's short verbatim
+    /// name. Computed from the real `remote::control_path` rather than a
+    /// hardcoded golden so this doesn't depend on matching the review's
+    /// exact hash digits — the mechanism, not one specific value, is what's
+    /// under test.
+    #[test]
+    fn validate_actual_control_paths_catches_the_reported_collision() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let long_name = "remote-development-environment-with-a-very-long-name";
+        let generated_stem = crate::remote::control_path(&state_dir, long_name)
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let hosts = vec![
+            test_host(long_name, "target"),
+            test_host(&generated_stem, "target2"),
+        ];
+        let err = validate_actual_control_paths(&hosts, &state_dir)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains(long_name), "{err}");
+        assert!(err.contains(&generated_stem), "{err}");
+    }
+
+    /// The state-dir-dependent budget is what makes this collision possible
+    /// at all: the same pair of names, under a state_dir short enough that
+    /// neither one needs truncating, produce two distinct, harmless paths.
+    #[test]
+    fn validate_actual_control_paths_depends_on_the_real_budget() {
+        let short_state_dir = PathBuf::from("/s");
+        let long_name = "remote-development-environment-with-a-very-long-name";
+        let generated_stem_for_a_deep_dir = crate::remote::control_path(
+            &PathBuf::from("/Users/example/.local/state/herdr-mirror"),
+            long_name,
+        )
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+        let hosts = vec![
+            test_host(long_name, "target"),
+            test_host(&generated_stem_for_a_deep_dir, "target2"),
+        ];
+        assert!(validate_actual_control_paths(&hosts, &short_state_dir).is_ok());
+    }
+
+    /// Two unrelated, ordinary host names must never be flagged — the
+    /// false-positive risk of adding path validation at all.
+    #[test]
+    fn validate_actual_control_paths_accepts_genuinely_distinct_hosts() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let hosts = vec![test_host("azure", "t"), test_host("rdev", "t2")];
+        assert!(validate_actual_control_paths(&hosts, &state_dir).is_ok());
+    }
+
+    /// A real 32-bit FNV-1a collision between two short, plain host names
+    /// (found by brute-force search, not synthetic) must NOT be rejected:
+    /// both are short enough to be used verbatim under any realistic
+    /// state_dir, so their control-plane paths never actually collide —
+    /// exactly the false positive the old, budget-unaware
+    /// `validate_no_legacy_socket_hash_collisions` check could not avoid,
+    /// which is why it was replaced by this one instead of kept alongside
+    /// it.
+    #[test]
+    fn validate_actual_control_paths_does_not_falsely_flag_a_harmless_hash_collision() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let hosts = vec![test_host("host10579", "t"), test_host("host343082", "t2")];
+        assert!(validate_actual_control_paths(&hosts, &state_dir).is_ok());
+    }
+
+    /// Every configured host, docker included, gets a control-plane socket
+    /// (`RemoteHost::new` calls `socket_stem` regardless of kind) — unlike
+    /// the stream-pool namespace check, this one must not skip docker
+    /// hosts.
+    #[test]
+    fn validate_actual_control_paths_covers_docker_hosts_too() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let mut docker = test_host("dup-name", "t2");
+        docker.kind = HostKind::DockerContainer("c".into());
+        let hosts = vec![test_host("dup-name", "t"), docker];
+        assert!(validate_actual_control_paths(&hosts, &state_dir).is_err());
+    }
+
+    /// `load_config_for_env` is the actual entry point every real call path
+    /// must use: this proves an on-disk config with a colliding pair is
+    /// rejected before anything could open an ssh process, using the real
+    /// file-loading path (`load_config`) plus the real state_dir check
+    /// together, not either one in isolation.
+    #[test]
+    fn load_config_for_env_rejects_a_config_with_colliding_control_paths_before_any_host_operation()
+    {
+        let config_dir = tmpdir("collide-load");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        // A fixed, realistic path budget for the collision itself — distinct
+        // from `config_dir` (a real, writable location `hosts.toml` needs to
+        // live in), which the test harness's own temp path depth would
+        // otherwise make unpredictably short.
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let long_name = "remote-development-environment-with-a-very-long-name";
+        let generated_stem = crate::remote::control_path(&state_dir, long_name)
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        std::fs::write(
+            config_dir.join("hosts.toml"),
+            format!(
+                "[hosts.{long_name}]\ntarget = \"t1\"\n[hosts.{generated_stem}]\ntarget = \"t2\"\n"
+            ),
+        )
+        .unwrap();
+
+        let env = crate::util::Env {
+            config_search: vec![config_dir.clone()],
+            state_dir,
+            local_socket: config_dir.join("local.sock"),
+        };
+        let err = load_config_for_env(&env).unwrap_err().to_string();
+        assert!(err.contains(long_name), "{err}");
+        let _ = std::fs::remove_dir_all(&config_dir);
+    }
+
+    /// The other half of the same proof, through the identical real
+    /// `load_config_for_env` call path: two short, plain host names that
+    /// share a 32-bit legacy hash (found by brute-force search, not
+    /// synthetic — see `remote::legacy_socket_hash_has_a_known_real_collision`)
+    /// must load successfully under a normal state_dir, since their actual
+    /// control-plane paths never collide (both are short enough to be used
+    /// verbatim — see `remote::socket_stem`). This is the exact false
+    /// positive the removed, budget-unaware `validate_no_legacy_socket_hash_collisions`
+    /// check could not avoid; nothing in `parse_config` or
+    /// `load_config_for_env` may reject this pair.
+    #[test]
+    fn load_config_for_env_accepts_a_harmless_legacy_hash_collision_before_any_host_operation() {
+        let config_dir = tmpdir("no-false-positive-load");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("hosts.toml"),
+            "[hosts.host10579]\ntarget = \"t1\"\n[hosts.host343082]\ntarget = \"t2\"\n",
+        )
+        .unwrap();
+
+        let env = crate::util::Env {
+            config_search: vec![config_dir.clone()],
+            state_dir: PathBuf::from("/Users/example/.local/state/herdr-mirror"),
+            local_socket: config_dir.join("local.sock"),
+        };
+        let config = load_config_for_env(&env).unwrap();
+        assert_eq!(config.hosts.len(), 2);
+        let _ = std::fs::remove_dir_all(&config_dir);
+    }
+
+    /// The call-path proof for the socket-path-budget check: a `state_dir`
+    /// too deep for even a short host's live ControlPath must be rejected
+    /// by `load_config_for_env` itself — before any host connection is
+    /// attempted — not left to fail later inside `ssh`. See
+    /// `remote::validate_socket_path_budget_rejects_a_state_dir_too_deep_for_a_live_control_path`
+    /// for the underlying arithmetic; this proves it is actually wired into
+    /// the one function every real call path loads config through.
+    #[test]
+    fn load_config_for_env_rejects_a_state_dir_too_deep_for_any_live_control_path() {
+        let config_dir = tmpdir("budget-load");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("hosts.toml"),
+            "[hosts.prod]\ntarget = \"t1\"\n",
+        )
+        .unwrap();
+
+        let env = crate::util::Env {
+            config_search: vec![config_dir.clone()],
+            state_dir: PathBuf::from(format!("/{}", "a".repeat(89))),
+            local_socket: config_dir.join("local.sock"),
+        };
+        let err = load_config_for_env(&env).unwrap_err().to_string();
+        assert!(err.contains("prod"), "{err}");
+        let _ = std::fs::remove_dir_all(&config_dir);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -13,7 +13,7 @@
 // arrive through one select loop, so converge and the status fast-path never
 // interleave.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsRawFd;
@@ -26,7 +26,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use crate::api::{ApiClient, EventStream};
-use crate::config::{load_config, HostConfig};
+use crate::config::{load_config_for_env, HostConfig};
 use crate::mirror::{
     apply_remote_closes, converge, mark_unknown, mirror_source, push_pane_status, regroup_sidebar,
     teardown, AgentInfo, ConvergeDeps,
@@ -231,6 +231,13 @@ async fn resubscribe(
 /// Fast-path: apply coalesced status updates without a remote snapshot.
 /// Returns true if an event referenced a pane we don't mirror yet.
 async fn flush_status(ctx: &HostCtx, pending: HashMap<String, Value>) -> bool {
+    let _lock = match crate::state::lock_host(&ctx.env_state_dir, &ctx.host.name).await {
+        Ok(l) => l,
+        Err(e) => {
+            ctx.log.log(&format!("[{}] could not lock state: {e}", ctx.host.name));
+            return false;
+        }
+    };
     let mut state = load_state(&ctx.env_state_dir, &ctx.host.name);
     let mut need_converge = false;
     for (remote_id, data) in pending {
@@ -249,6 +256,52 @@ async fn flush_status(ctx: &HostCtx, pending: HashMap<String, Value>) -> bool {
         ctx.log.log(&format!("[{}] state save failed: {e}", ctx.host.name));
     }
     need_converge
+}
+
+/// Per-slot retry cooldown for `ensure_stream_masters`, so a persistently
+/// unreachable slot is attempted once and then left alone for a while rather
+/// than retried on every converge pass — which, in an event-driven daemon,
+/// can be every few hundred milliseconds during active use. Lives for the
+/// host task's whole lifetime (across reconnects), the same way
+/// `remembered_transport` does, since the point is exactly to remember a
+/// recent failure past any single converge pass.
+#[derive(Default)]
+struct StreamMasterBackoff {
+    last_failure: HashMap<u32, std::time::Instant>,
+}
+
+/// How long a slot sits out after failing before it's attempted again.
+const STREAM_MASTER_RETRY_BACKOFF: Duration = Duration::from_secs(120);
+
+impl StreamMasterBackoff {
+    /// Of `wanted`, which are due for a (re)attempt right now: never
+    /// attempted, or last failed at least `STREAM_MASTER_RETRY_BACKOFF` ago.
+    fn due(&self, wanted: &std::collections::BTreeSet<u32>, now: std::time::Instant) -> Vec<u32> {
+        wanted
+            .iter()
+            .copied()
+            .filter(|slot| {
+                self.last_failure
+                    .get(slot)
+                    .is_none_or(|t| now.saturating_duration_since(*t) >= STREAM_MASTER_RETRY_BACKOFF)
+            })
+            .collect()
+    }
+
+    /// A slot outside `wanted` (no longer assigned to any live pane) has
+    /// nothing left to back off — drop it so a slot number that's since been
+    /// reused doesn't inherit a stale failure timestamp from its predecessor.
+    fn retain_only(&mut self, wanted: &std::collections::BTreeSet<u32>) {
+        self.last_failure.retain(|slot, _| wanted.contains(slot));
+    }
+
+    fn note_result(&mut self, slot: u32, ok: bool, now: std::time::Instant) {
+        if ok {
+            self.last_failure.remove(&slot);
+        } else {
+            self.last_failure.insert(slot, now);
+        }
+    }
 }
 
 /// Which transport the next reconnect should try first.
@@ -284,6 +337,7 @@ async fn run_connected(
     backoff_idx: &mut usize,
     remembered_transport: &mut Option<crate::config::ApiTransport>,
     exec_streak: &mut u32,
+    stream_master_backoff: &mut StreamMasterBackoff,
 ) -> Result<()> {
     let mut remote_host = crate::remote::RemoteHost::new(&ctx.host, &ctx.env_state_dir);
     // a fresh RemoteHost is built on every reconnect, so what worked last
@@ -302,12 +356,13 @@ async fn run_connected(
         log: ctx.log.clone(),
         close_remote_on_local_close: ctx.close_remote_on_local_close,
         closes: ctx.closes.clone(),
+        precreate_stream_masters: true,
     };
     // broadcast-only first: subscribing a since-dead pane id is rejected, so
     // converge must prune the map before the per-pane upgrade
     let mut stream = remote.subscribe(sub_list(&[])).await?;
     let mut subscribed_key = String::from("<broadcast>");
-    let state = converge(&deps).await?;
+    let state = converge_and_ensure_masters(ctx, &deps, stream_master_backoff).await?;
     resubscribe(ctx, &remote, &mut stream, &mut subscribed_key, &state).await?;
     ctx.log.log(&format!("[{}] connected and synced", ctx.host.name));
 
@@ -382,7 +437,7 @@ async fn run_connected(
                         &ctx.closes,
                     )
                     .await;
-                    let state = converge(&deps).await?;
+                    let state = converge_and_ensure_masters(ctx, &deps, stream_master_backoff).await?;
                     // pane set may have changed
                     resubscribe(ctx, &remote, &mut stream, &mut subscribed_key, &state).await?;
                 }
@@ -407,6 +462,7 @@ async fn host_task(ctx: HostCtx, mut poke: mpsc::Receiver<()>) {
     // point of remembering at all (see `run_connected`)
     let mut remembered_transport: Option<crate::config::ApiTransport> = None;
     let mut exec_streak = 0u32;
+    let mut stream_master_backoff = StreamMasterBackoff::default();
     loop {
         // Before dialling, and again after every failed dial: taking a hidden
         // host's mirrors down needs only the LOCAL api, so it must not wait on a
@@ -426,6 +482,7 @@ async fn host_task(ctx: HostCtx, mut poke: mpsc::Receiver<()>) {
             &mut backoff_idx,
             &mut remembered_transport,
             &mut exec_streak,
+            &mut stream_master_backoff,
         )
         .await
         {
@@ -562,6 +619,13 @@ async fn heal_zombie_mirrors(
             h.name,
             dead.len()
         ));
+        // Pre-create any stream-pool slot masters these panes need before
+        // respawning: same reasoning as after `converge` in `run_connected`.
+        // A throwaway backoff tracker is fine here — healing only runs after
+        // a local server restart, already rare enough that this can't turn
+        // into the repeated-retry storm the daemon's own per-host tracker
+        // guards against on every converge tick.
+        ensure_stream_masters(h, state_dir, &state, log, &mut StreamMasterBackoff::default()).await;
         // Surgical on purpose: session-restore brought the workspace, tabs, panes
         // and layout back intact — only the streamer processes died. Exec the
         // streamer back into each existing pane rather than closing the workspace
@@ -571,13 +635,123 @@ async fn heal_zombie_mirrors(
         //
         // Sizes live in the remote layout, which we don't have here; the wrapper
         // falls back to its default and the next converge reconciles.
-        let cmd_for = crate::mirror::cmd_for_pane(h, state_dir, &HashMap::new());
+        let slots: BTreeMap<String, u32> =
+            state.panes.iter().filter_map(|(rid, e)| e.stream_slot.map(|s| (rid.clone(), s))).collect();
+        let cmd_for = crate::mirror::cmd_for_pane(h, state_dir, &HashMap::new(), &slots);
         for (remote_pane_id, local_pane_id) in dead {
             let argv = cmd_for(&remote_pane_id);
             crate::mirror::spawn_streamer_pane(local, state_dir, &local_pane_id, &argv, log).await;
         }
         let _ = pokers[i].try_send(());
     }
+}
+
+/// Apply this pass's fresh-slot ensure outcomes to `backoff`. A free function
+/// (not inlined into `converge_and_ensure_masters`) so it can be unit-tested
+/// directly: the property that matters — these outcomes are recorded even
+/// when the overall converge `Result` is an error — is exactly what
+/// `converge`'s return shape (a plain tuple, not `Result<(state, results)>`)
+/// exists to make possible, and this is where callers must apply it BEFORE
+/// looking at that `Result` to preserve it.
+fn apply_fresh_slot_results(
+    backoff: &mut StreamMasterBackoff,
+    fresh_slot_results: Vec<(u32, Result<()>)>,
+    now: std::time::Instant,
+) {
+    for (slot, result) in fresh_slot_results {
+        backoff.note_result(slot, result.is_ok(), now);
+    }
+}
+
+/// Run one converge pass, feeding this pass's fresh-slot pre-create outcomes
+/// into the daemon's persistent backoff BEFORE the broader post-converge
+/// maintenance sweep (`ensure_stream_masters`) runs. Without this ordering, a
+/// slot that just failed inside `converge` looks never-attempted to that
+/// sweep and gets retried immediately — one failed attempt turning straight
+/// into a second, the same converge tick.
+async fn converge_and_ensure_masters(
+    ctx: &HostCtx,
+    deps: &ConvergeDeps,
+    stream_master_backoff: &mut StreamMasterBackoff,
+) -> Result<HostState> {
+    let (state_result, fresh_slot_results) = converge(deps).await;
+    // Applied unconditionally, before the `?` below can bail out on a later
+    // converge failure — otherwise a slot this pass's fresh-slot precreate
+    // already tried and failed would look never-attempted to the sweep two
+    // lines down.
+    apply_fresh_slot_results(stream_master_backoff, fresh_slot_results, std::time::Instant::now());
+    let state = state_result?;
+    ensure_stream_masters(&ctx.host, &ctx.env_state_dir, &state, &ctx.log, stream_master_backoff).await;
+    Ok(state)
+}
+
+/// Pre-create the ControlMaster for every ssh stream-pool slot this host's
+/// live panes are currently assigned to, so streamers about to (re)spawn find
+/// an already-listening master instead of running direct. A no-op when
+/// pooling is off, on a docker host, or once every needed master is already
+/// up; failures only log — a streamer whose slot has no live master here
+/// simply runs direct until a later pass creates one.
+async fn ensure_stream_masters(
+    host: &HostConfig,
+    state_dir: &std::path::Path,
+    state: &HostState,
+    log: &Logger,
+    backoff: &mut StreamMasterBackoff,
+) {
+    if host.ssh_streams_per_connection <= 1 || host.kind.is_docker() {
+        return;
+    }
+    let wanted: std::collections::BTreeSet<u32> =
+        state.panes.values().filter(|e| !e.is_tombstoned()).filter_map(|e| e.stream_slot).collect();
+    backoff.retain_only(&wanted);
+    let due = backoff.due(&wanted, std::time::Instant::now());
+    if due.is_empty() {
+        return;
+    }
+    let now = std::time::Instant::now();
+    for (slot, result) in
+        crate::remote::ensure_stream_masters_concurrent(state_dir, host, due, log).await
+    {
+        if let Err(e) = &result {
+            log.log(&format!(
+                "[{}] could not pre-create ssh stream pool slot {slot} master ({e}) — \
+                 its streams will fall back to a direct connection; retrying in {}s",
+                host.name,
+                STREAM_MASTER_RETRY_BACKOFF.as_secs()
+            ));
+        }
+        backoff.note_result(slot, result.is_ok(), now);
+    }
+}
+
+/// `status`'s one line of ssh stream pool visibility: configured capacity and
+/// per-slot occupancy, straight from persisted state — no live socket probe,
+/// so this stays as cheap as the rest of `status`. That occupancy is the
+/// INTENDED assignment, not necessarily what a running streamer is currently
+/// attached to: a pane only picks up a slot change when its streamer process
+/// is recreated (hide/show, or closing and reopening the pane), not on an
+/// ordinary ssh reconnect. `None` when pooling is off or no pane currently
+/// has a slot (a fresh host before its first converge).
+fn stream_pool_status_line(capacity: usize, state: &HostState) -> Option<String> {
+    if capacity <= 1 {
+        return None;
+    }
+    let mut occupancy: BTreeMap<u32, usize> = BTreeMap::new();
+    for entry in state.panes.values().filter(|e| !e.is_tombstoned()) {
+        if let Some(slot) = entry.stream_slot {
+            *occupancy.entry(slot).or_insert(0) += 1;
+        }
+    }
+    if occupancy.is_empty() {
+        return None;
+    }
+    let detail: Vec<String> =
+        occupancy.iter().map(|(slot, count)| format!("{slot}:{count}/{capacity}")).collect();
+    Some(format!(
+        "ssh stream pool: capacity {capacity} per connection, {} slot(s) (intended assignment) — {}",
+        occupancy.len(),
+        detail.join(", ")
+    ))
 }
 
 // Local events: mirror closes drive tombstoning — poke every host so the
@@ -654,7 +828,7 @@ pub async fn cmd_run(env: Env) -> Result<()> {
     let _daemon_lifetime = acquire_daemon_lifetime(&env)?;
     let detached = std::env::var("HERDR_MIRROR_DETACHED").is_ok();
     let log = Logger::new(&env.state_dir, !detached);
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(&env)?;
     log.log(&format!(
         "daemon starting (pid {}, hosts: {}, config: {})",
         std::process::id(),
@@ -823,7 +997,7 @@ pub fn cmd_ensure(env: &Env) {
     if running_pid(env).is_some() || is_paused(env) {
         return;
     }
-    match load_config(&env.config_search) {
+    match load_config_for_env(env) {
         Ok(c) if c.autostart => {
             let _ = cmd_start(env);
         }
@@ -852,7 +1026,7 @@ pub fn cmd_status(env: &Env) -> Result<()> {
             println!("cli link: {} is a regular file (not managed)", crate::util::cli_link_path().display())
         }
     }
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(env)?;
     if let Some(src) = &config.source {
         println!("config: {}", src.display());
     }
@@ -882,6 +1056,9 @@ pub fn cmd_status(env: &Env) -> Result<()> {
             "host {} ({}): {ws} mirror workspaces, {panes} mirror panes{hidden}",
             h.name, h.target
         );
+        if let Some(line) = stream_pool_status_line(h.ssh_streams_per_connection, &state) {
+            println!("  {line}");
+        }
         let tombs: Vec<String> = state
             .workspaces
             .iter()
@@ -905,7 +1082,7 @@ pub fn cmd_status(env: &Env) -> Result<()> {
 
 pub async fn cmd_once(env: Env) -> Result<()> {
     let log = Logger::new(&env.state_dir, true);
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(&env)?;
     let local = ApiClient::connect(&env.local_socket).await?;
     for h in &config.hosts {
         // converge would only freeze anyway, and dialling a host someone hid
@@ -916,7 +1093,12 @@ pub async fn cmd_once(env: Env) -> Result<()> {
         }
         let mut remote_host = crate::remote::RemoteHost::new(h, &env.state_dir);
         let (remote, _status) = remote_host.connect_api().await?;
-        converge(&ConvergeDeps {
+        // Never precreates a stream-pool master (see the doc comment on
+        // `ConvergeDeps::precreate_stream_masters`): a one-shot run has
+        // nothing to supervise one afterward. A freshly spawned pooled
+        // streamer here still reuses a master the daemon already created,
+        // or runs direct.
+        let (state_result, _fresh_slot_results) = converge(&ConvergeDeps {
             local: local.clone(),
             remote,
             host: h.clone(),
@@ -927,8 +1109,10 @@ pub async fn cmd_once(env: Env) -> Result<()> {
             // close signal — an empty tracker means this pass syncs but never
             // closes a remote object, which is the correct conservative default
             closes: crate::closes::new_closes(),
+            precreate_stream_masters: false,
         })
-        .await?;
+        .await;
+        state_result?;
         log.log(&format!("[{}] one-shot mirror complete", h.name));
     }
     Ok(())
@@ -937,12 +1121,13 @@ pub async fn cmd_once(env: Env) -> Result<()> {
 /// Un-tombstone mirrors the user closed: deleting the entries makes converge
 /// recreate them through the normal paths. Pokes the daemon; never converges.
 pub fn cmd_restore(env: &Env, filter_host: Option<&str>, filter_id: Option<&str>) -> Result<()> {
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(env)?;
     let mut cleared = 0usize;
     for h in &config.hosts {
         if filter_host.is_some_and(|f| f != h.name) {
             continue;
         }
+        let _lock = crate::state::lock_host_blocking(&env.state_dir, &h.name)?;
         let mut state = load_state(&env.state_dir, &h.name);
         let ws_doomed: Vec<String> = state
             .workspaces
@@ -1002,7 +1187,7 @@ pub async fn cmd_teardown(env: Env) -> Result<()> {
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
     set_paused(&env, true); // torn down stays down until an explicit start
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(&env)?;
     let local = ApiClient::connect(&env.local_socket).await?;
     for h in &config.hosts {
         teardown(&local, &env.state_dir, &h.name, &log, None).await?;
@@ -1100,6 +1285,160 @@ mod tests {
         // a later success clears it, so a fixed host returns to the forward
         assert_eq!(remember_transport(Some(ApiTransport::Socket), &mut streak), Some(ApiTransport::Socket));
         assert_eq!(remember_transport(Some(ApiTransport::Exec), &mut streak), None);
+    }
+
+    #[test]
+    fn stream_master_backoff_retries_a_never_attempted_slot_immediately() {
+        let backoff = StreamMasterBackoff::default();
+        let wanted: std::collections::BTreeSet<u32> = [0, 1].into_iter().collect();
+        assert_eq!(backoff.due(&wanted, std::time::Instant::now()), vec![0, 1]);
+    }
+
+    /// A slot that just failed must not be retried again on the very next
+    /// call — that repeated-every-pass retry is exactly what turned one
+    /// unreachable slot into a stall across many converge passes.
+    #[test]
+    fn stream_master_backoff_skips_a_recently_failed_slot() {
+        let mut backoff = StreamMasterBackoff::default();
+        let now = std::time::Instant::now();
+        backoff.note_result(0, false, now);
+        let wanted: std::collections::BTreeSet<u32> = [0, 1].into_iter().collect();
+        assert_eq!(backoff.due(&wanted, now), vec![1], "slot 0 just failed, must sit out");
+
+        // once the backoff window has elapsed, it becomes due again
+        let later = now + STREAM_MASTER_RETRY_BACKOFF;
+        assert_eq!(backoff.due(&wanted, later), vec![0, 1]);
+    }
+
+    /// A success clears any remembered failure, so a slot that recovers is
+    /// not artificially held back once it starts working again.
+    #[test]
+    fn stream_master_backoff_success_clears_the_failure() {
+        let mut backoff = StreamMasterBackoff::default();
+        let now = std::time::Instant::now();
+        backoff.note_result(0, false, now);
+        backoff.note_result(0, true, now);
+        let wanted: std::collections::BTreeSet<u32> = [0].into_iter().collect();
+        assert_eq!(backoff.due(&wanted, now), vec![0]);
+    }
+
+    /// A slot no longer assigned to any live pane must not keep a stale
+    /// failure timestamp around — otherwise a slot number reused later (a
+    /// different pane, after enough churn) would inherit its predecessor's
+    /// cooldown for no reason.
+    #[test]
+    fn stream_master_backoff_forgets_slots_no_longer_wanted() {
+        let mut backoff = StreamMasterBackoff::default();
+        let now = std::time::Instant::now();
+        backoff.note_result(0, false, now);
+        backoff.retain_only(&std::collections::BTreeSet::new());
+        let wanted: std::collections::BTreeSet<u32> = [0].into_iter().collect();
+        assert_eq!(backoff.due(&wanted, now), vec![0], "slot 0 must be retried immediately, not held back");
+    }
+
+    /// Regression for the "double-attempt in one tick" bug: converge's
+    /// fresh-slot pre-create and the daemon's post-converge maintenance
+    /// sweep must share one backoff view, or a slot that just failed inside
+    /// converge looks never-attempted to the sweep that immediately follows
+    /// it and gets retried again in the same tick. This composes
+    /// `note_result` + `due` in the exact order
+    /// `converge_and_ensure_masters` runs them, standing in for the parts of
+    /// that async wiring (real ConvergeDeps/ApiClient) this crate has no
+    /// mocking harness for.
+    #[test]
+    fn fresh_slot_failure_suppresses_the_immediate_post_converge_retry() {
+        let mut backoff = StreamMasterBackoff::default();
+        let now = std::time::Instant::now();
+
+        // converge's fresh-slot pre-create just failed slot 0; slot 1 backed
+        // only already-existing panes this pass, so converge never touched it
+        let fresh_slot_results: Vec<(u32, crate::util::Result<()>)> =
+            vec![(0, Err(crate::util::err("unreachable")))];
+        apply_fresh_slot_results(&mut backoff, fresh_slot_results, now);
+
+        // the post-converge sweep runs immediately after, wanting both slots
+        let wanted: std::collections::BTreeSet<u32> = [0, 1].into_iter().collect();
+        assert_eq!(
+            backoff.due(&wanted, now),
+            vec![1],
+            "slot 0 must not be retried again in the same tick it just failed in"
+        );
+    }
+
+    /// Regression for a second bug in the same area: `converge`'s return
+    /// shape must keep fresh-slot outcomes available even when a LATER part
+    /// of that same pass (layout/pane RPCs) errors out overall. Before the
+    /// fix, `converge` only handed back `(state, fresh_slot_results)` inside
+    /// its `Result`'s `Ok` arm, so an error anywhere after the precreate step
+    /// silently discarded a precreate failure that had already happened —
+    /// and the immediate post-converge sweep would then retry it right away,
+    /// exactly the double-attempt the backoff exists to prevent.
+    #[test]
+    fn fresh_slot_results_survive_a_later_converge_error() {
+        let mut backoff = StreamMasterBackoff::default();
+        let now = std::time::Instant::now();
+
+        // what `converge()` now returns when precreate failed slot 0 and a
+        // later step then errored: the state Result is Err, but the
+        // fresh-slot outcomes are still present alongside it (not nested
+        // inside the Result, so the two can't be lost together)
+        let converge_return: (crate::util::Result<HostState>, Vec<(u32, crate::util::Result<()>)>) =
+            (Err(crate::util::err("later converge step failed")), vec![(0, Err(crate::util::err("unreachable")))]);
+        let (state_result, fresh_slot_results) = converge_return;
+
+        // applying outcomes must not be skipped by an early `?` on state_result
+        apply_fresh_slot_results(&mut backoff, fresh_slot_results, now);
+        assert!(state_result.is_err(), "the overall converge error must still propagate to the caller");
+
+        let wanted: std::collections::BTreeSet<u32> = [0, 1].into_iter().collect();
+        assert_eq!(
+            backoff.due(&wanted, now),
+            vec![1],
+            "slot 0 must be suppressed even though converge itself errored later"
+        );
+    }
+
+    fn pane_with_slot(local_id: &str, slot: Option<u32>) -> crate::state::PaneEntry {
+        crate::state::PaneEntry {
+            local_id: local_id.into(),
+            tombstone: None,
+            seq: 0,
+            reported: None,
+            stream_slot: slot,
+            workspace_id: None,
+        }
+    }
+
+    #[test]
+    fn stream_pool_status_line_hidden_when_capacity_is_one() {
+        let mut state = HostState::default();
+        state.panes.insert("p1".into(), pane_with_slot("l1", Some(0)));
+        assert_eq!(stream_pool_status_line(1, &state), None);
+    }
+
+    #[test]
+    fn stream_pool_status_line_hidden_until_a_pane_has_a_slot() {
+        // pooling configured, but converge hasn't run yet (or every pane is
+        // still unassigned) — nothing useful to report
+        assert_eq!(stream_pool_status_line(4, &HostState::default()), None);
+    }
+
+    #[test]
+    fn stream_pool_status_line_reports_capacity_and_occupancy() {
+        let mut state = HostState::default();
+        state.panes.insert("p1".into(), pane_with_slot("l1", Some(0)));
+        state.panes.insert("p2".into(), pane_with_slot("l2", Some(0)));
+        state.panes.insert("p3".into(), pane_with_slot("l3", Some(1)));
+        // a tombstoned pane's old slot must not inflate occupancy
+        let mut closed = pane_with_slot("l4", Some(1));
+        closed.tombstone = Some(true);
+        state.panes.insert("p4".into(), closed);
+
+        let line = stream_pool_status_line(2, &state).unwrap();
+        assert_eq!(
+            line,
+            "ssh stream pool: capacity 2 per connection, 2 slot(s) (intended assignment) — 0:2/2, 1:1/2"
+        );
     }
 
     fn argv(parts: &[&str]) -> Vec<Value> {

--- a/src/filelock.rs
+++ b/src/filelock.rs
@@ -1,0 +1,261 @@
+// OS-backed advisory locking (`flock(2)`), shared by every serialization this
+// crate needs across processes: the ssh master-socket lock (remote.rs) and
+// the per-host state-map lock (state.rs). One implementation so both get the
+// identical acquire/release/timeout semantics rather than two hand-rolled
+// variants drifting apart.
+//
+// Lock order (must be respected by every caller that could hold more than
+// one at once, to rule out deadlock rather than merely avoid it in today's
+// call graph): `daemon.lock` (whole-daemon singleton, cmd_start) outermost,
+// then a per-host state lock (state.rs), then a per-master-socket lock
+// (remote.rs) innermost. In practice only converge ever holds two at once —
+// the state lock while it acquires a stream-pool slot's master lock — and it
+// does so in exactly this order.
+
+use std::fs;
+use std::os::fd::AsRawFd;
+use std::path::Path;
+use std::time::Duration;
+
+use crate::util::{err, Result};
+
+/// One process's hold on a path's flock. Dropping it closes the file, which
+/// releases the flock immediately — including on a crash, since the kernel
+/// releases every flock an exiting process still holds. There is
+/// deliberately no "is this lock stale" check anywhere in this module:
+/// flock's release-on-close is exactly what makes one unnecessary, and a
+/// hand-rolled staleness heuristic (a PID file, an mtime cutoff, ...) would
+/// itself be a second race to get wrong.
+pub struct FileLock {
+    _file: fs::File,
+}
+
+fn open_lock_file(path: &Path) -> Result<fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    // Mode is set on create only (existing files keep whatever mode they
+    // already have); umask can only narrow 0600 further, never widen it.
+    fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| err(format!("cannot open lock file {}: {e}", path.display())))
+}
+
+/// One nonblocking `flock` attempt.
+pub fn try_lock_nb(path: &Path) -> Result<Option<FileLock>> {
+    let file = open_lock_file(path)?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(Some(FileLock { _file: file }));
+    }
+    let e = std::io::Error::last_os_error();
+    if e.kind() == std::io::ErrorKind::WouldBlock {
+        return Ok(None);
+    }
+    Err(err(format!("cannot lock {}: {e}", path.display())))
+}
+
+/// Acquire `path`'s lock, blocking the calling thread until held or `budget`
+/// elapses. For synchronous call sites only (e.g. `cmd_restore`) that have no
+/// tokio runtime entered to use `acquire_async` — anything running on a
+/// tokio worker thread must use `acquire_async` instead, or this would
+/// freeze the whole runtime. Polls `try_lock_nb` on the same interval as
+/// `acquire_async` rather than a true blocking `flock`, so a stuck holder
+/// fails this loudly on a bound rather than hanging the caller forever —
+/// unlike `cmd_start`'s separate, deliberately unbounded `daemon.lock` (a
+/// one-time startup singleton, not a per-operation lock).
+pub fn acquire_blocking(path: &Path, budget: Duration) -> Result<FileLock> {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if let Some(lock) = try_lock_nb(path)? {
+            return Ok(lock);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(err(format!("timed out waiting for the lock on {}", path.display())));
+        }
+        std::thread::sleep(RETRY_INTERVAL);
+    }
+}
+
+const RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Acquire `path`'s lock asynchronously, retrying a nonblocking `flock` on a
+/// bounded interval rather than parking a tokio worker thread on a real
+/// blocking wait. Each attempt runs on tokio's blocking-task pool via
+/// `spawn_blocking` (a single syscall, back almost immediately either way);
+/// the `sleep` between attempts is an ordinary async wait, so this never
+/// blocks the async runtime. Bounded by `budget`: a peer that never releases
+/// (crashed processes release automatically; a genuinely wedged one does
+/// not) can't stall this caller past it.
+pub async fn acquire_async(path: &Path, budget: Duration) -> Result<FileLock> {
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        let attempt_path = path.to_path_buf();
+        let acquired = tokio::task::spawn_blocking(move || try_lock_nb(&attempt_path))
+            .await
+            .map_err(|e| err(format!("lock task did not complete: {e}")))??;
+        if let Some(lock) = acquired {
+            return Ok(lock);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(err(format!("timed out waiting for the lock on {}", path.display())));
+        }
+        tokio::time::sleep(RETRY_INTERVAL).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// pid + nanos alone can repeat across a genuinely parallel full-suite
+    /// run (an isolated sandbox reusing low pids in its own pid namespace);
+    /// the atomic counter rules out same-process reuse deterministically.
+    fn test_path(name: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let nanos = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let salt = &counter as *const u64 as usize;
+        let unique =
+            crate::util::short_hash(&format!("{}-{nanos}-{counter}-{salt:x}", std::process::id()));
+        std::env::temp_dir().join(format!("herdr-mirror-filelock-{name}-{unique}.lock"))
+    }
+
+    #[test]
+    fn try_lock_nb_excludes_a_second_open_file_description_on_the_same_path() {
+        let path = test_path("excl");
+        let first = try_lock_nb(&path).unwrap().expect("first attempt must acquire");
+        assert!(try_lock_nb(&path).unwrap().is_none(), "a second open must not also acquire");
+        drop(first);
+        // No caller in this crate assumes a release is visible to the very
+        // next attempt — `acquire_async`/`acquire_blocking` always retry on a
+        // bounded interval — so the test shouldn't assert a same-instant
+        // guarantee either; under heavy concurrent test-suite scheduling
+        // (only there — never serial, never in an isolated stress loop of
+        // thousands of iterations) an immediate recheck occasionally saw a
+        // just-released lock reported as still held for a few milliseconds.
+        let mut relockable = false;
+        for _ in 0..20 {
+            if try_lock_nb(&path).unwrap().is_some() {
+                relockable = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(relockable, "the path must be lockable again once released");
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn a_freshly_created_lock_file_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = test_path("mode");
+        let _lock = try_lock_nb(&path).unwrap().expect("must acquire");
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "lock files must not be group/world readable regardless of umask");
+        let _ = fs::remove_file(&path);
+    }
+
+    /// The property every caller of this module relies on: two concurrent
+    /// holders of the same path must never be inside the locked section at
+    /// the same time. Real OS threads with independent `File::open`s, since
+    /// `flock` exclusion is keyed on the open file description, not the
+    /// owning process — the same kernel mechanism a second process gets.
+    #[test]
+    fn locks_actually_exclude_concurrent_holders() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let path = test_path("serialize");
+        let overlap = Arc::new(AtomicUsize::new(0));
+        let max_overlap = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let path = path.clone();
+                let overlap = overlap.clone();
+                let max_overlap = max_overlap.clone();
+                std::thread::spawn(move || loop {
+                    let Some(_guard) = try_lock_nb(&path).unwrap() else {
+                        std::thread::sleep(Duration::from_millis(1));
+                        continue;
+                    };
+                    let now = overlap.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_overlap.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(Duration::from_millis(5));
+                    overlap.fetch_sub(1, Ordering::SeqCst);
+                    break;
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(max_overlap.load(Ordering::SeqCst), 1, "holders of the same path must never overlap");
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn acquire_blocking_waits_for_release_within_its_budget() {
+        let path = test_path("blocking");
+        let held = try_lock_nb(&path).unwrap().expect("test setup must acquire first");
+        let release_at = Duration::from_millis(30);
+        let path2 = path.clone();
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(release_at);
+            drop(held);
+        });
+        let started = std::time::Instant::now();
+        let _second = acquire_blocking(&path2, Duration::from_secs(2)).expect("must eventually acquire");
+        assert!(started.elapsed() >= release_at, "must have actually waited for the release");
+        releaser.join().unwrap();
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn acquire_blocking_times_out_on_a_held_lock() {
+        let path = test_path("blocking-timeout");
+        let _held = try_lock_nb(&path).unwrap().expect("test setup must acquire first");
+        let budget = Duration::from_millis(150);
+        let started = std::time::Instant::now();
+        let result = acquire_blocking(&path, budget);
+        assert!(result.is_err(), "a lock nobody ever releases must time out, not hang forever");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "must fail within its budget rather than blocking indefinitely"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn acquire_async_succeeds_once_the_holder_releases() {
+        let path = test_path("async-acquire");
+        let held = try_lock_nb(&path).unwrap().expect("test setup must acquire first");
+        let path2 = path.clone();
+        let released = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            drop(held);
+            path2
+        });
+        acquire_async(&path, Duration::from_secs(2)).await.expect("must acquire once the holder releases");
+        released.await.unwrap();
+        let _ = fs::remove_file(&path);
+    }
+
+    /// A budget that expires before the holder releases must fail loudly,
+    /// not hang — every caller's non-fatal fallback depends on this
+    /// returning in bounded time.
+    #[tokio::test]
+    async fn acquire_async_times_out_on_a_held_lock() {
+        let path = test_path("async-timeout");
+        let _held = try_lock_nb(&path).unwrap().expect("test setup must acquire first");
+        let result = acquire_async(&path, Duration::from_millis(150)).await;
+        assert!(result.is_err(), "must not hang past its budget");
+        let _ = fs::remove_file(&path);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod config;
 mod cwd_policy;
 mod daemon;
 mod docker;
+mod filelock;
 mod foreground;
 mod grid;
 mod layout_sync;
@@ -31,6 +32,7 @@ mod remote_action;
 mod select;
 mod ssh_relay;
 mod state;
+mod stream_pool;
 mod util;
 
 use util::{Env, Result};

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -6,7 +6,7 @@
 // mirror locally" (tombstone — don't recreate) from "remote object went away"
 // (close the mirror).
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -300,9 +300,24 @@ pub async fn apply_hidden(
     log: &Logger,
     closes: &crate::closes::Closes,
 ) {
-    // The guard, not the caller's job: this is called on every host_task loop
-    // and before every connected converge, so without it the daemon closes the
-    // mirrors it just created, forever.
+    // Fast, lock-free peek: skip lock acquisition entirely for the
+    // overwhelmingly common "not hidden" case. Not the final answer — see
+    // the re-check below.
+    if !crate::state::is_hidden(state_dir, host_name) {
+        return;
+    }
+    let _lock = match crate::state::lock_host(state_dir, host_name).await {
+        Ok(l) => l,
+        Err(e) => {
+            log.log(&format!("hidden: could not lock state for {host_name}: {e}"));
+            return;
+        }
+    };
+    // Re-read now that this host's state lock is ours alone: `show` (which
+    // clears the marker under the same lock — see remote_action.rs) may have
+    // run between the peek above and acquiring this lock, and closing
+    // mirrors on that stale "hidden" observation would fight the user's
+    // `show` instead of losing the race cleanly.
     let hidden = crate::state::is_hidden(state_dir, host_name);
     if !hidden {
         return;
@@ -433,14 +448,100 @@ pub struct ConvergeDeps {
     /// ambiguous (rebuild in flight, failed converge, server restart), so only a
     /// close event that wasn't our own may close the remote.
     pub closes: crate::closes::Closes,
+    /// Whether this pass may create a stream-pool slot master for a freshly
+    /// spawned pooled pane. The daemon (which also runs the post-converge
+    /// `ensure_stream_masters` sweep and holds the process for a master's
+    /// whole `ControlPersist` lifetime) sets this; `cmd_once` does not — a
+    /// one-shot invocation that created a master would leave it running,
+    /// unsupervised, after the process that created it has already exited,
+    /// with nothing left to recover it if it later dies. A pooled streamer
+    /// spawned with no master here still attaches with `ControlMaster=no`
+    /// (see pane.rs::ssh_stream_args): it reuses one if the daemon happens
+    /// to already have created it, or falls back to a direct connection.
+    pub precreate_stream_masters: bool,
+}
+
+/// Build the pane-id -> current-slot map fed to `stream_pool::allocate`.
+///
+/// Starts from every currently-mapped, non-tombstoned pane rather than only
+/// panes present in this pass's `remote_panes` snapshot: the reap-on-absence
+/// logic earlier in `converge_inner` only removes a pane once it has been
+/// missing from two consecutive snapshots (a transient/partial remote
+/// snapshot must not look like a mass removal), so by the time this runs
+/// every pane still in `state_panes` is one that logic chose to keep. The
+/// allocator must honor that same restraint — a pane missing from just this
+/// one snapshot keeps its existing slot rather than looking unassigned, which
+/// would otherwise evict it from its slot and hand that capacity to another
+/// pane for one pass, then move it right back the next. That restraint is
+/// exactly why a pane's own persisted `PaneEntry::workspace_id` (not only
+/// this pass's `remote_panes`) has to gate the seed too: a pane whose
+/// workspace was tombstoned in an EARLIER pass, then goes missing from a
+/// later transient/partial snapshot, would otherwise keep looking like an
+/// ordinary kept pane forever, since it never again appears in
+/// `remote_panes` for the workspace-tombstone check below to catch.
+///
+/// `remote_panes` is `(pane_id, workspace_id)` for this pass's remote
+/// snapshot; a pane whose workspace is `mirror_ws_ids` (another mirror's own
+/// streamer workspace) or a tombstoned workspace in `state_workspaces`, or
+/// that is itself locally tombstoned, is never a candidate — an already-slotted
+/// pane loses its slot as soon as we learn (this pass) that its workspace
+/// qualifies, freeing that capacity for others. A workspace absent from
+/// `state_workspaces` (genuinely new, not yet mapped) is unaffected.
+fn stream_pool_candidates<'a>(
+    state_panes: &BTreeMap<String, PaneEntry>,
+    state_workspaces: &BTreeMap<String, WsEntry>,
+    remote_panes: impl Iterator<Item = (&'a str, &'a str)>,
+    mirror_ws_ids: &HashSet<String>,
+) -> BTreeMap<String, Option<u32>> {
+    let ws_tombstoned = |ws: &str| state_workspaces.get(ws).is_some_and(|w| w.is_tombstoned());
+    let mut candidates: BTreeMap<String, Option<u32>> = state_panes
+        .iter()
+        .filter(|(_, e)| !e.is_tombstoned() && !e.workspace_id.as_deref().is_some_and(ws_tombstoned))
+        .map(|(rid, e)| (rid.clone(), e.stream_slot))
+        .collect();
+    for (pane_id, workspace_id) in remote_panes {
+        if mirror_ws_ids.contains(workspace_id) || ws_tombstoned(workspace_id) {
+            candidates.remove(pane_id);
+            continue;
+        }
+        if state_panes.get(pane_id).is_some_and(|e| e.is_tombstoned()) {
+            continue;
+        }
+        candidates.entry(pane_id.to_string()).or_insert(None);
+    }
+    candidates
+}
+
+/// Shown to the user in a pane's own status row (see
+/// `state::set_pane_hint`/`take_pane_hint`) when its ssh stream-pool slot
+/// assignment changes. Names the only mechanisms that actually pick up a new
+/// slot — a streamer's argv is fixed for its process's life, so an ordinary
+/// ssh reconnect adopts nothing.
+const STREAM_SLOT_CHANGE_HINT: &str =
+    "ssh stream pool slot changed — hide/show or close and reopen this pane to move onto it";
+
+/// Daemon log line for the same event as `STREAM_SLOT_CHANGE_HINT`, with the
+/// pane and slot numbers for operators reading the log.
+fn stream_slot_change_log(host_name: &str, rid: &str, previous: Option<u32>, new_slot: Option<u32>) -> String {
+    format!(
+        "[{host_name}] pane {rid} ssh stream pool slot {previous:?} -> {new_slot:?} — takes effect \
+         when this pane's streamer is recreated (hide/show, or close and reopen the pane)"
+    )
 }
 
 /// argv for one mirror pane: this same binary in `pane` mode. Panes without a
 /// known size get no --cols/--rows (the wrapper falls back to a default).
+///
+/// `stream_slots` maps remote pane id -> ssh stream-pool slot (see
+/// `stream_pool`); a pane absent from it, or a host with
+/// `ssh_streams_per_connection <= 1`, gets no `--stream-ctl-path` at all, so
+/// an unconfigured or docker host's argv is byte-identical to before pooling
+/// existed.
 pub(crate) fn cmd_for_pane(
     host: &HostConfig,
     state_dir: &std::path::Path,
     sizes: &HashMap<String, LayoutRect>,
+    stream_slots: &BTreeMap<String, u32>,
 ) -> impl Fn(&str) -> Vec<String> {
     let exe = crate::util::self_exe();
     let target = host.target.clone();
@@ -451,12 +552,16 @@ pub(crate) fn cmd_for_pane(
     let max_rows = host.max_rows;
     let kind = host.kind.clone();
     let docker_bin = host.docker_bin.clone();
+    let ssh_streams_per_connection = host.ssh_streams_per_connection;
     // daemon's ControlMaster socket for this host (see remote.rs); the streamer
     // reuses it for cheap foreground polls
     let ctl_path = crate::remote::control_path(state_dir, &host.name)
         .display()
         .to_string();
     let sizes = sizes.clone();
+    let host_name = host.name.clone();
+    let state_dir = state_dir.to_path_buf();
+    let stream_slots = stream_slots.clone();
     move |pane_id: &str| {
         let mut argv = vec![
             exe.clone(),
@@ -489,6 +594,16 @@ pub(crate) fn cmd_for_pane(
         match &kind {
             crate::config::HostKind::Ssh => {
                 argv.extend(["--ctl-path".into(), ctl_path.clone()]);
+                // a *separate* mux master from --ctl-path above: this one is
+                // shared by up to N pane data streams, --ctl-path stays the
+                // control-plane-only master
+                if ssh_streams_per_connection > 1 {
+                    if let Some(&slot) = stream_slots.get(pane_id) {
+                        let stream_ctl =
+                            crate::remote::stream_control_path(&state_dir, &host_name, &target, slot);
+                        argv.extend(["--stream-ctl-path".into(), stream_ctl.display().to_string()]);
+                    }
+                }
             }
             crate::config::HostKind::DockerContainer(name) => {
                 argv.extend(["--container".into(), name.clone()]);
@@ -791,16 +906,52 @@ fn note_mapped(deps: &ConvergeDeps, state: &HostState, fresh_local_ids: &[String
     }
 }
 
-/// Returns the post-converge state so callers don't re-read the state file.
-pub async fn converge(deps: &ConvergeDeps) -> Result<HostState> {
+/// Returns the post-converge state (when this pass succeeded) alongside the
+/// outcome of any fresh ssh stream-pool slot master this pass pre-created —
+/// unconditionally, independent of whether the rest of converge succeeded,
+/// so a later layout/pane error can't discard a precreate result that
+/// already happened. Deliberately NOT nested inside the `Result`: callers
+/// that drive a persistent per-slot retry backoff (the daemon's
+/// `ensure_stream_masters`) must apply these before propagating the overall
+/// error, or a slot this pass's precreate just tried and failed looks
+/// never-attempted to the immediate post-converge sweep and gets retried in
+/// the same tick.
+///
+/// Holds this host's state lock (`state::lock_host`) for the whole
+/// load → reconcile → save span, so a concurrent `once` (or another host
+/// task, though today only one exists per host) can't interleave a save with
+/// this one and silently discard part of it.
+pub async fn converge(deps: &ConvergeDeps) -> (Result<HostState>, Vec<(u32, Result<()>)>) {
+    let _lock = match crate::state::lock_host(&deps.state_dir, &deps.host.name).await {
+        Ok(l) => l,
+        Err(e) => return (Err(e), Vec::new()),
+    };
     let mut state = load_state(&deps.state_dir, &deps.host.name);
-    let result = converge_inner(deps, &mut state).await;
+    let mut fresh_slot_results: Vec<(u32, Result<()>)> = Vec::new();
+    let result = converge_inner(deps, &mut state, &mut fresh_slot_results).await;
     // save even on error: a crash mid-pass must not orphan created mirrors
-    save_state(&deps.state_dir, &deps.host.name, &state)?;
-    result.map(|()| state)
+    if let Err(e) = save_state(&deps.state_dir, &deps.host.name, &state) {
+        return (Err(e), fresh_slot_results);
+    }
+    (result.map(|()| state), fresh_slot_results)
 }
 
-async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()> {
+/// Whether this converge pass should attempt to pre-create a stream-pool
+/// slot master for a freshly spawned pane: only when pooling is actually in
+/// use for this host AND the caller allows creating one at all (see
+/// `ConvergeDeps::precreate_stream_masters` — `cmd_once` sets this false).
+/// Pulled out of `converge_inner` as its own function because that one
+/// needs a live `ApiClient` this crate has no harness to mock, so the
+/// policy itself is what gets a direct test instead.
+fn should_precreate_fresh_slot_masters(pooling_active: bool, precreate_allowed: bool) -> bool {
+    pooling_active && precreate_allowed
+}
+
+async fn converge_inner(
+    deps: &ConvergeDeps,
+    state: &mut HostState,
+    fresh_slot_results: &mut Vec<(u32, Result<()>)>,
+) -> Result<()> {
     let host = &deps.host;
     let log = &deps.log;
     // Hidden hosts freeze here and go no further. Deliberately BEFORE the
@@ -835,7 +986,6 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
             sizes.insert(p.pane_id.clone(), p.rect.clone());
         }
     }
-    let cmd_for = cmd_for_pane(&deps.host, &deps.state_dir, &sizes);
     let _ = std::fs::create_dir_all(mirror_pane_cwd(&deps.state_dir));
 
     // 1. detect mirrors that are gone locally. Always tombstone (never remove)
@@ -977,6 +1127,98 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
         };
         if panes.iter().all(|p| pane_is_mirror(p)) {
             mirror_ws_ids.insert(rws.workspace_id.clone());
+        }
+    }
+
+    // Persist which remote workspace each currently-observed, already-mapped
+    // pane belongs to (see `PaneEntry::workspace_id`) — independent of
+    // whether pooling is even on, since a pane created before this field
+    // existed (or before its workspace was known) needs exactly one
+    // observation to backfill it. Set once; a pane never changes workspace.
+    for p in &remote_snap.panes {
+        if let Some(entry) = state.panes.get_mut(&p.pane_id) {
+            if entry.workspace_id.is_none() {
+                entry.workspace_id = Some(p.workspace_id.clone());
+            }
+        }
+    }
+
+    // ssh stream pooling (see `stream_pool`): assign every remote pane that
+    // will have a live mirror by the end of this pass — already-mapped panes
+    // plus ones about to be created below — to a pool slot. Panes inside
+    // another mirror's own streamer workspace are excluded, same as the
+    // creation logic further down never materializes them.
+    let stream_capacity = host.ssh_streams_per_connection;
+    let pooling_active = stream_capacity > 1 && !host.kind.is_docker();
+    let slot_for: BTreeMap<String, u32> = if pooling_active {
+        let candidates = stream_pool_candidates(
+            &state.panes,
+            &state.workspaces,
+            remote_snap.panes.iter().map(|p| (p.pane_id.as_str(), p.workspace_id.as_str())),
+            &mirror_ws_ids,
+        );
+        crate::stream_pool::allocate(&candidates, stream_capacity)
+    } else {
+        BTreeMap::new()
+    };
+    // Reflect the fresh allocation onto already-mapped panes (this loop runs
+    // before any pane is created below, so every entry visited here is a
+    // pre-existing, presumably-already-running pane).
+    //
+    // The pane's running streamer is not restarted: killing it would race a
+    // brand-new stream against whatever the remote pane/agent is mid-doing.
+    // A streamer's argv (and therefore its slot) is fixed for the process's
+    // life, so an ordinary ssh reconnect adopts nothing — only recreating
+    // the streamer PROCESS does (hide/show, or closing and reopening the
+    // pane). `cmd_for` below already reflects the new slot for whichever
+    // comes first; a hint tells the user how to make it happen sooner.
+    for (rid, entry) in state.panes.iter_mut() {
+        let new_slot = slot_for.get(rid).copied();
+        if entry.stream_slot == new_slot {
+            continue;
+        }
+        let previous = entry.stream_slot;
+        entry.stream_slot = new_slot;
+        log.log(&stream_slot_change_log(&host.name, rid, previous, new_slot));
+        crate::state::set_pane_hint(&deps.state_dir, &entry.local_id, STREAM_SLOT_CHANGE_HINT);
+    }
+    let cmd_for = cmd_for_pane(&deps.host, &deps.state_dir, &sizes, &slot_for);
+
+    // Pre-create the ControlMaster for any slot a pane about to be freshly
+    // created (below) will use, BEFORE any such pane is spawned: streamers
+    // never create a master themselves (`ControlMaster=no`, see
+    // pane.rs::ssh_stream_args), so a slot with no live master here means
+    // those panes simply run direct until a later pass creates one. A slot
+    // only ever backing already-existing panes needs no action here; the
+    // daemon's own post-converge sweep (`ensure_stream_masters`) covers
+    // recovering a slot whose master died with no new pane involved.
+    // Non-fatal either way. Gated on `precreate_stream_masters`: `cmd_once`
+    // leaves this false (see its doc comment on `ConvergeDeps`) precisely so
+    // a one-shot run never creates a master nothing then supervises.
+    //
+    // Results are handed back via `fresh_slot_results` rather than only
+    // logged here: the daemon's post-converge sweep runs a persistent
+    // per-slot retry backoff, and without this a slot that just failed here
+    // would look never-attempted to that sweep and get retried immediately
+    // afterward — one failed attempt turning straight into a second.
+    if should_precreate_fresh_slot_masters(pooling_active, deps.precreate_stream_masters) {
+        let fresh_slots: BTreeSet<u32> = slot_for
+            .iter()
+            .filter(|(rid, _)| !state.panes.contains_key(*rid))
+            .map(|(_, slot)| *slot)
+            .collect();
+        for (slot, result) in
+            crate::remote::ensure_stream_masters_concurrent(&deps.state_dir, &deps.host, fresh_slots, log)
+                .await
+        {
+            if let Err(e) = &result {
+                log.log(&format!(
+                    "[{}] could not pre-create ssh stream pool slot {slot} master before \
+                     spawning new pooled panes ({e}) — they will fall back to a direct connection",
+                    host.name
+                ));
+            }
+            fresh_slot_results.push((slot, result));
         }
     }
 
@@ -1213,7 +1455,14 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                     let seq = state.panes.get(rid).map(|e| e.seq).unwrap_or(0);
                     state.panes.insert(
                         rid.clone(),
-                        PaneEntry { local_id: local_id.clone(), tombstone: None, seq, reported: None },
+                        PaneEntry {
+                            local_id: local_id.clone(),
+                            tombstone: None,
+                            seq,
+                            reported: None,
+                            stream_slot: slot_for.get(rid).copied(),
+                            workspace_id: Some(rtab.workspace_id.clone()),
+                        },
                     );
                     fresh.push(local_id.clone());
                     to_spawn.push((local_id, rid.clone()));
@@ -1281,7 +1530,14 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                     // unmapped placeholder panes 250ms after pane.created
                     state.panes.insert(
                         place.pane.clone(),
-                        PaneEntry { local_id: local_id.clone(), tombstone: None, seq: 0, reported: None },
+                        PaneEntry {
+                            local_id: local_id.clone(),
+                            tombstone: None,
+                            seq: 0,
+                            reported: None,
+                            stream_slot: slot_for.get(&place.pane).copied(),
+                            workspace_id: Some(rtab.workspace_id.clone()),
+                        },
                     );
                     note_mapped(deps, state, std::slice::from_ref(&local_id));
                     spawn_streamer_pane(&deps.local, &deps.state_dir, &local_id, &cmd_for(&place.pane), &deps.log)
@@ -1317,7 +1573,14 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                         split_mirror_pane(&deps.local, &target, &direction, None, &cwd).await?;
                     state.panes.insert(
                         rp.pane_id.clone(),
-                        PaneEntry { local_id: local_id.clone(), tombstone: None, seq: 0, reported: None },
+                        PaneEntry {
+                            local_id: local_id.clone(),
+                            tombstone: None,
+                            seq: 0,
+                            reported: None,
+                            stream_slot: slot_for.get(&rp.pane_id).copied(),
+                            workspace_id: Some(rtab.workspace_id.clone()),
+                        },
                     );
                     note_mapped(deps, state, std::slice::from_ref(&local_id));
                     spawn_streamer_pane(&deps.local, &deps.state_dir, &local_id, &cmd_for(&rp.pane_id), &deps.log)
@@ -1520,6 +1783,13 @@ pub async fn apply_remote_closes(
     if closed.is_empty() {
         return;
     }
+    let _lock = match crate::state::lock_host(state_dir, host_name).await {
+        Ok(l) => l,
+        Err(e) => {
+            log.log(&format!("[{host_name}] could not lock state: {e}"));
+            return;
+        }
+    };
     let mut state = load_state(state_dir, host_name);
     let mut changed = false;
     for rid in closed {
@@ -1559,6 +1829,7 @@ pub async fn push_statuses(deps: &ConvergeDeps, remote_snap: &Snapshot, state: &
 /// Only panes we actually reported an agent onto; inventing agent rows for
 /// plain mirrored terminals pollutes the agents panel.
 pub async fn mark_unknown(local: &ApiClient, state_dir: &std::path::Path, host_name: &str, reason: &str) {
+    let Ok(_lock) = crate::state::lock_host(state_dir, host_name).await else { return };
     let mut state = load_state(state_dir, host_name);
     let source = mirror_source(host_name);
     let custom = clamp_status(reason);
@@ -1593,6 +1864,7 @@ pub async fn teardown(
     log: &Logger,
     closes: Option<&crate::closes::Closes>,
 ) -> Result<()> {
+    let _lock = crate::state::lock_host(state_dir, host_name).await?;
     let state = load_state(state_dir, host_name);
     // Wipe the id map BEFORE closing the local windows. teardown (and the
     // restart / zombie-heal that call it) means "stop mirroring here" — never
@@ -1760,6 +2032,7 @@ mod tests {
             max_cols: None,
             max_rows: None,
             api_transport: crate::config::ApiTransport::Auto,
+            ssh_streams_per_connection: 1,
         }
     }
 
@@ -1793,7 +2066,7 @@ mod tests {
     }
 
     fn tombstoned(local_id: &str) -> PaneEntry {
-        PaneEntry { local_id: local_id.into(), tombstone: Some(true), seq: 0, reported: None }
+        PaneEntry { local_id: local_id.into(), tombstone: Some(true), seq: 0, reported: None, stream_slot: None, workspace_id: None }
     }
 
     /// A locally-closed (tombstoned) pane must not survive into the tree a tab
@@ -1807,7 +2080,7 @@ mod tests {
         let mut panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
         panes.insert(
             "p1".into(),
-            PaneEntry { local_id: "l1".into(), tombstone: None, seq: 0, reported: None },
+            PaneEntry { local_id: "l1".into(), tombstone: None, seq: 0, reported: None, stream_slot: None, workspace_id: None },
         );
         let mut ids = Vec::new();
         walk_pane_ids(&prune_closed(&tree, &panes).unwrap(), &mut ids);
@@ -1846,7 +2119,7 @@ mod tests {
     #[test]
     fn ssh_pane_argv_is_stable() {
         let state_dir = std::path::Path::new("/state");
-        let cmd = cmd_for_pane(&ssh_host(), state_dir, &HashMap::new());
+        let cmd = cmd_for_pane(&ssh_host(), state_dir, &HashMap::new(), &BTreeMap::new());
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1864,13 +2137,269 @@ mod tests {
         assert!(argv[0].ends_with("herdr-mirror") || argv[0].contains("herdr_mirror"), "{}", argv[0]);
     }
 
+    /// Capacity 1 (the default) or an unassigned pane must never add
+    /// `--stream-ctl-path`: an unconfigured host's argv must stay
+    /// byte-identical to pre-pooling behavior even if a stale slot map is
+    /// passed in by mistake.
+    #[test]
+    fn unpooled_argv_never_carries_stream_ctl_path() {
+        let state_dir = std::path::Path::new("/state");
+        let mut slots = BTreeMap::new();
+        slots.insert("w1:p1".to_string(), 0u32);
+        // capacity 1: the daemon never builds a non-empty slot map for this
+        // host, but the argv builder itself must still refuse to use one
+        let argv = cmd_for_pane(&ssh_host(), state_dir, &HashMap::new(), &slots)("w1:p1");
+        assert!(!argv.iter().any(|a| a == "--stream-ctl-path"), "{argv:?}");
+
+        // capacity > 1 but this specific pane has no assigned slot
+        let mut host = ssh_host();
+        host.ssh_streams_per_connection = 4;
+        let argv = cmd_for_pane(&host, state_dir, &HashMap::new(), &BTreeMap::new())("w1:p1");
+        assert!(!argv.iter().any(|a| a == "--stream-ctl-path"), "{argv:?}");
+    }
+
+    /// A pooled pane's argv must carry `--stream-ctl-path`, separate from and
+    /// after `--ctl-path`, and it must round-trip through the pane parser.
+    #[test]
+    fn pooled_argv_carries_stream_ctl_path_separately_from_ctl_path() {
+        let state_dir = std::path::Path::new("/state");
+        let mut host = ssh_host();
+        host.ssh_streams_per_connection = 4;
+        let mut slots = BTreeMap::new();
+        slots.insert("w1:p1".to_string(), 2u32);
+        let argv = cmd_for_pane(&host, state_dir, &HashMap::new(), &slots)("w1:p1");
+        assert_eq!(
+            argv[1..],
+            [
+                "pane",
+                "vps",
+                "w1:p1",
+                "--always-control",
+                "--ctl-path",
+                "/state/vps.ctl",
+                "--stream-ctl-path",
+                &crate::remote::stream_control_path(state_dir, "vps", "vps", 2).display().to_string(),
+            ]
+        );
+        let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
+        assert_eq!(parsed.ctl_path.as_deref(), Some("/state/vps.ctl"));
+        assert_eq!(
+            parsed.stream_ctl_path,
+            Some(crate::remote::stream_control_path(state_dir, "vps", "vps", 2).display().to_string())
+        );
+    }
+
+    fn mapped_pane(local_id: &str, slot: Option<u32>) -> PaneEntry {
+        PaneEntry { local_id: local_id.into(), tombstone: None, seq: 0, reported: None, stream_slot: slot, workspace_id: None }
+    }
+
+    fn mapped_pane_in_ws(local_id: &str, slot: Option<u32>, workspace_id: &str) -> PaneEntry {
+        PaneEntry {
+            local_id: local_id.into(),
+            tombstone: None,
+            seq: 0,
+            reported: None,
+            stream_slot: slot,
+            workspace_id: Some(workspace_id.into()),
+        }
+    }
+
+    fn no_workspaces() -> BTreeMap<String, WsEntry> {
+        BTreeMap::new()
+    }
+
+    /// A hole in one pass's remote snapshot (a transient/partial fetch — the
+    /// exact case the absent-twice reap logic above already guards) must not
+    /// look like a pane removal to the allocator: an already-mapped pane
+    /// missing from `remote_panes` this one pass must keep its slot.
+    #[test]
+    fn candidates_retain_a_mapped_pane_missing_from_one_snapshot() {
+        let mut state_panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
+        state_panes.insert("p1".into(), mapped_pane("l1", Some(0)));
+        state_panes.insert("p2".into(), mapped_pane("l2", Some(1)));
+
+        // this pass's snapshot only reports p1 — p2 is a transient hole
+        let remote_panes = vec![("p1", "w1")];
+        let candidates =
+            stream_pool_candidates(&state_panes, &no_workspaces(), remote_panes.into_iter(), &HashSet::new());
+        assert_eq!(candidates.get("p1"), Some(&Some(0)));
+        assert_eq!(candidates.get("p2"), Some(&Some(1)), "a one-pass hole must not evict p2's slot");
+
+        // and once it reappears, it is still simply present with its slot —
+        // not re-added as a fresh unassigned pane
+        let remote_panes = vec![("p1", "w1"), ("p2", "w1")];
+        let candidates =
+            stream_pool_candidates(&state_panes, &no_workspaces(), remote_panes.into_iter(), &HashSet::new());
+        assert_eq!(candidates.get("p2"), Some(&Some(1)));
+        assert_eq!(candidates.len(), 2, "reappearance must not duplicate or add a stray entry");
+    }
+
+    /// A brand-new remote pane not yet mapped is a fresh unassigned
+    /// candidate; a tombstoned (locally-closed) one is never a candidate at
+    /// all, matching the creation logic that never re-materializes it.
+    #[test]
+    fn candidates_add_new_panes_and_skip_tombstoned_ones() {
+        let mut state_panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
+        state_panes.insert("p1".into(), mapped_pane("l1", Some(0)));
+        let mut closed = mapped_pane("l2", Some(1));
+        closed.tombstone = Some(true);
+        state_panes.insert("p2".into(), closed);
+
+        let remote_panes = vec![("p1", "w1"), ("p2", "w1"), ("p3", "w1")];
+        let candidates =
+            stream_pool_candidates(&state_panes, &no_workspaces(), remote_panes.into_iter(), &HashSet::new());
+        assert_eq!(candidates.get("p1"), Some(&Some(0)));
+        assert_eq!(candidates.get("p2"), None, "a tombstoned pane is never a candidate");
+        assert_eq!(candidates.get("p3"), Some(&None), "a brand-new pane is unassigned");
+    }
+
+    /// A remote pane belonging to another mirror's own streamer workspace is
+    /// never a candidate, same as the creation logic that never
+    /// materializes it.
+    #[test]
+    fn candidates_skip_panes_in_a_mirror_of_mirror_workspace() {
+        let state_panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
+        let mut mirror_ws_ids = HashSet::new();
+        mirror_ws_ids.insert("w9".to_string());
+        let remote_panes = vec![("p1", "w9")];
+        let candidates =
+            stream_pool_candidates(&state_panes, &no_workspaces(), remote_panes.into_iter(), &mirror_ws_ids);
+        assert!(candidates.is_empty());
+    }
+
+    fn tombstoned_ws(local_id: &str) -> WsEntry {
+        WsEntry { local_id: local_id.into(), tombstone: Some(true), root_tab_local_id: None, last_remote_label: None }
+    }
+
+    /// The workspace mirror was closed locally (tombstoned), but its remote
+    /// panes can still show up in a snapshot for a pass or two before the
+    /// cascading pane-tombstone logic catches up — those panes must consume
+    /// no slot, and an already-slotted one must give its slot back up as
+    /// soon as we learn its workspace is tombstoned.
+    #[test]
+    fn candidates_exclude_panes_in_a_tombstoned_workspace() {
+        let mut state_panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
+        state_panes.insert("p1".into(), mapped_pane("l1", Some(0))); // already slotted
+        let mut state_workspaces: BTreeMap<String, WsEntry> = BTreeMap::new();
+        state_workspaces.insert("w1".into(), tombstoned_ws("lw1"));
+
+        let remote_panes = vec![("p1", "w1"), ("p2", "w1")];
+        let candidates =
+            stream_pool_candidates(&state_panes, &state_workspaces, remote_panes.into_iter(), &HashSet::new());
+        assert!(candidates.is_empty(), "{candidates:?}");
+    }
+
+    /// The exact defect an independent review reported: a pane whose
+    /// workspace was tombstoned in an EARLIER pass, then goes missing from a
+    /// later transient/partial snapshot, is never again seen alongside its
+    /// `workspace_id` in `remote_panes` — only `PaneEntry::workspace_id`
+    /// (persisted the first time the pane was observed) can still identify
+    /// it. Without consulting that field, the "retain a one-pass hole"
+    /// restraint (`candidates_retain_a_mapped_pane_missing_from_one_snapshot`)
+    /// would let it keep its slot forever once its workspace is gone.
+    #[test]
+    fn candidates_exclude_a_pane_missing_from_snapshot_whose_persisted_workspace_is_tombstoned() {
+        let mut state_panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
+        state_panes.insert("p1".into(), mapped_pane_in_ws("l1", Some(0), "w1"));
+        let mut state_workspaces: BTreeMap<String, WsEntry> = BTreeMap::new();
+        state_workspaces.insert("w1".into(), tombstoned_ws("lw1"));
+
+        // p1 does not appear in this pass's snapshot at all
+        let remote_panes: Vec<(&str, &str)> = vec![];
+        let candidates =
+            stream_pool_candidates(&state_panes, &state_workspaces, remote_panes.into_iter(), &HashSet::new());
+        assert!(candidates.is_empty(), "{candidates:?}");
+    }
+
+    /// A hole plus reappearance: p1's workspace is tombstoned and it is
+    /// missing this pass (excluded via its persisted workspace_id), but if
+    /// it reappears in a LATER pass it is evicted there too (the existing
+    /// direct-observation path), never resurrected as a candidate in
+    /// between.
+    #[test]
+    fn candidates_stay_excluded_across_a_hole_and_a_reappearance_in_a_tombstoned_workspace() {
+        let mut state_panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
+        state_panes.insert("p1".into(), mapped_pane_in_ws("l1", Some(0), "w1"));
+        let mut state_workspaces: BTreeMap<String, WsEntry> = BTreeMap::new();
+        state_workspaces.insert("w1".into(), tombstoned_ws("lw1"));
+
+        let candidates = stream_pool_candidates(
+            &state_panes,
+            &state_workspaces,
+            Vec::<(&str, &str)>::new().into_iter(),
+            &HashSet::new(),
+        );
+        assert!(candidates.is_empty(), "hole: {candidates:?}");
+
+        let candidates = stream_pool_candidates(
+            &state_panes,
+            &state_workspaces,
+            vec![("p1", "w1")].into_iter(),
+            &HashSet::new(),
+        );
+        assert!(candidates.is_empty(), "reappearance: {candidates:?}");
+    }
+
+    /// A workspace that is simply new (not yet in `state_workspaces` at all)
+    /// must not be mistaken for a tombstoned one — its panes still allocate.
+    #[test]
+    fn candidates_still_allocate_panes_in_a_genuinely_new_workspace() {
+        let state_panes: BTreeMap<String, PaneEntry> = BTreeMap::new();
+        let remote_panes = vec![("p1", "w-new")];
+        let candidates =
+            stream_pool_candidates(&state_panes, &no_workspaces(), remote_panes.into_iter(), &HashSet::new());
+        assert_eq!(candidates.get("p1"), Some(&None), "a new workspace's pane must still be a candidate");
+    }
+
+    /// Migration wording must point at a mechanism that actually adopts a
+    /// new slot (recreating the streamer process), never at reconnect —
+    /// a streamer's argv, and thus its slot, is fixed for the process's life.
+    #[test]
+    fn stream_slot_change_log_names_recreation_not_reconnect() {
+        let msg = stream_slot_change_log("vps", "w1:p1", Some(0), Some(1));
+        assert!(msg.contains("recreated"), "{msg}");
+        assert!(msg.contains("hide/show"), "{msg}");
+        assert!(!msg.to_lowercase().contains("reconnect"), "{msg}");
+    }
+
+    #[test]
+    fn stream_slot_change_hint_directs_to_hide_show_or_reopen() {
+        assert!(STREAM_SLOT_CHANGE_HINT.contains("hide/show"));
+        assert!(STREAM_SLOT_CHANGE_HINT.contains("close and reopen"));
+    }
+
+    /// `cmd_once` must never create a stream-pool master: it has no
+    /// persistent backoff and nothing left running to supervise or recover
+    /// one after the process exits. Only the daemon (pooling active AND
+    /// precreation allowed) precreates.
+    #[test]
+    fn should_precreate_fresh_slot_masters_requires_both_pooling_and_daemon_ownership() {
+        assert!(should_precreate_fresh_slot_masters(true, true), "daemon + pooling: precreates");
+        assert!(!should_precreate_fresh_slot_masters(true, false), "once + pooling: must not precreate");
+        assert!(!should_precreate_fresh_slot_masters(false, true), "daemon, pooling off: nothing to precreate");
+        assert!(!should_precreate_fresh_slot_masters(false, false), "once, pooling off: nothing to precreate");
+    }
+
+    /// Docker panes never carry a stream ctl path: there is no ssh
+    /// ControlMaster to share, so a slot map is simply ignored.
+    #[test]
+    fn docker_argv_ignores_stream_slots() {
+        let mut host = ssh_host();
+        host.ssh_streams_per_connection = 4;
+        host.kind = crate::config::HostKind::DockerContainer("crazy_ride".into());
+        let mut slots = BTreeMap::new();
+        slots.insert("w1:p1".to_string(), 0u32);
+        let argv = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &slots)("w1:p1");
+        assert!(!argv.iter().any(|a| a == "--stream-ctl-path"), "{argv:?}");
+    }
+
     /// When remote_bin is set, it must appear on the argv (cross-process contract
     /// with the pane parser) rather than being re-resolved by the streamer.
     #[test]
     fn ssh_pane_argv_carries_explicit_remote_bin() {
         let mut host = ssh_host();
         host.remote_bin = Some("/opt/herdr".into());
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &BTreeMap::new());
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1891,7 +2420,7 @@ mod tests {
     fn ssh_pane_argv_carries_remote_session() {
         let mut host = ssh_host();
         host.session = Some("work".into());
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &BTreeMap::new());
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1919,7 +2448,7 @@ mod tests {
         host.target = "/Users/n/proj".into();
         host.kind = crate::config::HostKind::DockerFolder("/Users/n/proj".into());
         host.docker_bin = "/usr/local/bin/docker".into();
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &BTreeMap::new());
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1949,7 +2478,7 @@ mod tests {
         // absolute path (GUI-launched daemons without /usr/local/bin on PATH)
         // would then silently get "cannot run docker".
         host.docker_bin = "/usr/local/bin/docker".into();
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &BTreeMap::new());
         let argv = cmd("w1:p1");
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
         assert_eq!(parsed.pane_target, "w1:p1");
@@ -1965,7 +2494,7 @@ mod tests {
     fn ssh_pane_argv_without_always_control() {
         let mut host = ssh_host();
         host.always_control = false;
-        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &BTreeMap::new());
         let argv = cmd("w1:p1");
         assert_eq!(
             argv[1..],
@@ -1979,12 +2508,12 @@ mod tests {
     fn size_caps_reach_the_streamer_argv() {
         let mut host = ssh_host();
         host.always_control = false;
-        let uncapped = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        let uncapped = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &BTreeMap::new())("w1:p1");
         assert!(!uncapped.iter().any(|a| a == "--max-cols" || a == "--max-rows"));
 
         host.max_cols = Some(212);
         host.max_rows = Some(58);
-        let argv = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        let argv = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new(), &BTreeMap::new())("w1:p1");
         let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
         assert_eq!(parsed.max_cols, Some(212));
         assert_eq!(parsed.max_rows, Some(58));

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -19,9 +19,21 @@
 //   --max-rows N        uncapped — control fills the local pane). Set for a
 //                       remote with its own display: the remote keeps its own
 //                       geometry and the rest of the local pane stays blank.
+//   --stream-ctl-path PATH   join the daemon's ssh stream pool at this control
+//                       socket (`ssh_streams_per_connection` in hosts.toml):
+//                       `-S PATH -o ControlMaster=no` on top of the ordinary
+//                       ssh invocation below, so this stream attaches to a
+//                       master the daemon already created (never creating
+//                       one itself) and shares it with up to N others.
+//                       Every other ssh option (ProxyJump, GSSAPI,
+//                       certificates, identity files, agent forwarding, the
+//                       target's own ssh_config) still applies unchanged.
+//                       Distinct from --ctl-path, which stays the daemon's
+//                       own control-plane master.
 //
-// Every stream gets its own direct ssh connection (no shared ControlMaster):
-// isolated, and nothing persists to go stale on a flaky network.
+// Every stream gets its own direct ssh connection by default (no shared
+// ControlMaster): isolated, and nothing persists to go stale on a flaky
+// network. `--stream-ctl-path` is the opt-in exception above.
 //
 // One owner of all state, message-driven: frames, keystrokes, timers, and
 // ssh-child exits arrive on one channel; a session generation number tags
@@ -75,6 +87,12 @@ pub struct Args {
     /// (`ssh -S <path>`) to skip a handshake. None → polls connect directly.
     ///
     pub ctl_path: Option<String>,
+    /// ssh stream-pool slot's control socket (see module docs). `Some` only
+    /// when the host is configured `ssh_streams_per_connection > 1` and the
+    /// daemon assigned this pane a slot; overrides only the multiplexing
+    /// options on the data-stream ssh invocation in `spawn_session`, never
+    /// `ctl_path` above.
+    pub stream_ctl_path: Option<String>,
     /// container to exec into instead of ssh. `None` = ssh host.
     pub container: Option<ContainerArg>,
 }
@@ -102,6 +120,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
         max_cols: None,
         max_rows: None,
         ctl_path: None,
+        stream_ctl_path: None,
         container: None,
     };
     let mut container_name: Option<String> = None;
@@ -140,6 +159,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                     .filter(|&n| n > 0)
             }
             "--ctl-path" => args.ctl_path = Some(next("--ctl-path")?),
+            "--stream-ctl-path" => args.stream_ctl_path = Some(next("--stream-ctl-path")?),
             "--container" => container_name = Some(next("--container")?),
             "--container-folder" => container_folder = Some(next("--container-folder")?),
             "--docker-bin" => docker_bin = next("--docker-bin")?,
@@ -234,17 +254,38 @@ pub(crate) fn sh_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-fn ssh_stream_args(ssh_target: &str, cmd: &str) -> Vec<String> {
-    let mut argv: Vec<String> = crate::remote::SSH_COMMON_OPTS
-        .iter()
-        .map(|arg| (*arg).to_string())
-        .collect();
-    // A pane stream is long-lived and interactive. It must not inherit a
-    // ControlPath from ~/.ssh/config: a stale shared master can hang
-    // the stream before the remote command starts. `-S none` disables control
-    // socket use without changing the daemon's intentional multiplexing.
-    argv.extend(["-S".into(), "none".into(), ssh_target.into(), cmd.into()]);
-    argv
+/// ssh args for this pane's data-stream connection, ahead of `ssh_target` and
+/// the remote command. Pure and unit-tested on its own (`spawn_session`
+/// itself spawns a real child, which isn't worth mocking just to see its
+/// argv).
+///
+/// Unpooled (the default), a pane stream must not inherit a ControlPath from
+/// ~/.ssh/config: a stale shared master can hang the stream before the
+/// remote command starts, so `-S none` disables control socket use
+/// entirely.
+///
+/// Pooled (`args.stream_ctl_path` is set), the override is ONLY
+/// `-S`/ControlPath and ControlMaster — never `-F none` or anything else —
+/// so every other ssh_config resolution for `args.ssh_target`
+/// (ProxyJump/ProxyCommand, GSSAPI, certificates, identity files, agent
+/// forwarding) rides along unchanged. `ControlMaster=no`, not `auto`: the
+/// streamer must never itself create a slot's master —
+/// `remote::ensure_master_locked` is the sole creator, always under its
+/// cross-process flock, and a streamer racing to create one outside that
+/// lock is exactly the stale-socket race the lock exists to prevent. With
+/// `no`, ssh only ever attaches to an already-listening master, falling back
+/// to an ordinary direct connection if none is listening or the master
+/// refuses (also how a `MaxSessions` refusal behaves) — never failing the
+/// pane, just leaving it unpooled for that connection. `ControlPersist` is
+/// dropped: it only affects a connection that might become a master, which
+/// this one by construction never does.
+fn ssh_stream_args(args: &Args) -> Vec<String> {
+    let mut v: Vec<String> = crate::remote::SSH_COMMON_OPTS.iter().map(|s| s.to_string()).collect();
+    match &args.stream_ctl_path {
+        Some(path) => v.extend(["-S".into(), path.clone(), "-o".into(), "ControlMaster=no".into()]),
+        None => v.extend(["-S".into(), "none".into()]),
+    }
+    v
 }
 
 fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx: mpsc::Sender<Msg>) -> Result<Session> {
@@ -268,7 +309,7 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
     let mut builder = match &args.container {
         None => {
             let mut c = tokio::process::Command::new("ssh");
-            c.args(ssh_stream_args(&args.ssh_target, &cmd));
+            c.args(ssh_stream_args(args)).arg(&args.ssh_target).arg(cmd);
             c
         }
         Some(ct) => {
@@ -1872,21 +1913,6 @@ mod tests {
         assert!(!proxy_survived, "ProxyCommand survived pane transport cleanup");
     }
 
-    #[test]
-    fn pane_ssh_stream_disables_configured_control_sockets() {
-        let argv = ssh_stream_args("work", "exec herdr terminal session observe w5:pM");
-
-        assert_eq!(
-            &argv[crate::remote::SSH_COMMON_OPTS.len()..],
-            [
-                "-S",
-                "none",
-                "work",
-                "exec herdr terminal session observe w5:pM",
-            ]
-        );
-    }
-
     /// Uncapped must stay byte-identical to the old `term_size()` call, or
     /// every existing headless-remote config silently changes behaviour.
     #[test]
@@ -2098,6 +2124,79 @@ mod tests {
         assert_eq!((a.cols, a.rows), (176, 66));
         assert!(parse_args(&["onlyone".to_string()]).is_err());
         assert!(parse_args(&["a".into(), "b".into(), "--visibility-file".into(), "x".into()]).is_err());
+    }
+
+    #[test]
+    fn stream_ctl_path_parses_separately_from_ctl_path() {
+        let argv: Vec<String> = [
+            "work",
+            "w9:p1",
+            "--ctl-path",
+            "/state/work.ctl",
+            "--stream-ctl-path",
+            "/state/work-s0.ctl",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let a = parse_args(&argv).unwrap();
+        assert_eq!(a.ctl_path.as_deref(), Some("/state/work.ctl"));
+        assert_eq!(a.stream_ctl_path.as_deref(), Some("/state/work-s0.ctl"));
+    }
+
+    #[test]
+    fn ssh_stream_args_only_add_multiplexing_options_when_pooled() {
+        let mut args = parse_args(&["work".into(), "w9:p1".into()]).unwrap();
+        let common: Vec<String> = crate::remote::SSH_COMMON_OPTS.iter().map(|s| s.to_string()).collect();
+        let unpooled = ssh_stream_args(&args);
+        // Unpooled, a stream must not inherit a ControlPath from ~/.ssh/config:
+        // a stale shared master can hang it before the remote command starts.
+        let mut expected_unpooled = common.clone();
+        expected_unpooled.extend(["-S".to_string(), "none".into()]);
+        assert_eq!(unpooled, expected_unpooled);
+
+        args.stream_ctl_path = Some("/state/work-s0.ctl".into());
+        let pooled = ssh_stream_args(&args);
+        let mut expected = common;
+        expected.extend(["-S".to_string(), "/state/work-s0.ctl".into(), "-o".into(), "ControlMaster=no".into()]);
+        assert_eq!(pooled, expected);
+        // ControlMaster=no, not auto: the streamer must never create a
+        // master itself, only attach to one the daemon already brought up
+        // under its cross-process lock
+        assert!(!pooled.iter().any(|a| a == "ControlMaster=auto"));
+        // no ControlPersist at all: it only matters for a connection that
+        // might become a master, which this one by construction never does
+        assert!(!pooled.iter().any(|a| a.starts_with("ControlPersist")));
+        // never -F none: ambient ssh_config (ProxyJump, identity files, ...)
+        // must keep resolving normally
+        assert!(!pooled.iter().any(|a| a == "-F"));
+        // never -S none either, once pooled: that would disable control
+        // sockets outright instead of attaching to the pool's socket
+        assert!(!pooled.windows(2).any(|w| w == ["-S", "none"]));
+    }
+
+    /// `spawn_session` appends `ssh_target` then the remote command after
+    /// `ssh_stream_args`'s own argv, unconditionally and in that order — this
+    /// checks the full argv a real ssh invocation sees, for both modes.
+    #[test]
+    fn ssh_stream_full_argv_order_matches_direct_and_pooled_modes() {
+        let full = |args: &Args| -> Vec<String> {
+            let mut v = ssh_stream_args(args);
+            v.push(args.ssh_target.clone());
+            v.push("exec herdr terminal session observe w5:pM".into());
+            v
+        };
+        let mut args = parse_args(&["work".into(), "w9:p1".into()]).unwrap();
+
+        let direct = full(&args);
+        assert_eq!(direct[direct.len() - 4..], ["-S", "none", "work", "exec herdr terminal session observe w5:pM"]);
+
+        args.stream_ctl_path = Some("/state/work-s0.ctl".into());
+        let pooled = full(&args);
+        assert_eq!(
+            pooled[pooled.len() - 6..],
+            ["-S", "/state/work-s0.ctl", "-o", "ControlMaster=no", "work", "exec herdr terminal session observe w5:pM"]
+        );
     }
 
     // --- birth size trust (#23) ---

--- a/src/pick.rs
+++ b/src/pick.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 use serde_json::{json, Value};
 
 use crate::api::ApiClient;
-use crate::config::{load_config, parse_config, remote_herdr_expr, HostConfig};
+use crate::config::{load_config, load_config_for_env, parse_config, remote_herdr_expr, HostConfig};
 use crate::remote::{version_supported, RemoteHost, SSH_COMMON_OPTS};
 use crate::util::{err, Env, Result};
 
@@ -39,7 +39,7 @@ async fn open_popup(api: &ApiClient, env: &Env) -> Result<()> {
     // tracks the longest row (name + its dim subtitle) so targets and the cwd
     // hint aren't truncated the moment they matter.
     let cwd = invoking_cwd();
-    let (n_hosts, widest) = match load_config(&env.config_search) {
+    let (n_hosts, widest) = match load_config_for_env(env) {
         Ok(c) => {
             let w = c
                 .hosts
@@ -198,7 +198,7 @@ pub async fn intercept(env: Env, what: &str) -> Result<()> {
     // event — so there is nothing here a user would want to opt out of that
     // they would not rather have fixed. An unreadable config still stops us,
     // because without hosts we cannot tell a mirror workspace from any other.
-    let Ok(config) = load_config(&env.config_search) else { return Ok(()) };
+    let Ok(config) = load_config_for_env(&env) else { return Ok(()) };
     // Nothing to recreate the object on if the daemon cannot act: with it
     // stopped or paused we would close the local tab, create a real one on the
     // remote, and no mirror would ever come back — the failure being silent
@@ -565,7 +565,7 @@ fn tilde(path: &str) -> String {
 pub fn menu(rt: &tokio::runtime::Runtime, env: Env) -> Result<()> {
     // a broken hosts.toml must not brick the picker: local creation needs no
     // hosts, so degrade to a local-only menu and show why
-    let (hosts, default_host, config_note) = match load_config(&env.config_search) {
+    let (hosts, default_host, config_note) = match load_config_for_env(&env) {
         Ok(c) => {
             let d = c.default_host().map(|h| h.name.clone());
             (c.hosts, d, None)
@@ -989,7 +989,7 @@ async fn add_machine(env: &Env, existing: &[HostConfig]) -> Result<Nav> {
     // Re-read rather than reuse the probe's hand-built config, so the workspace
     // opened now uses exactly the HostConfig every later run will parse. It also
     // proves the block just appended round-trips.
-    let cfg = load_config(&env.config_search)?;
+    let cfg = load_config_for_env(env)?;
     let Some(added) = cfg.hosts.iter().find(|h| h.name == target).cloned() else {
         return Err(crate::util::err(format!(
             "{target} was written to hosts.toml but did not parse back"

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,6 +1,8 @@
 // ssh transport for the DAEMON's own traffic (remote CLI execs + API-socket
-// forward) over one ControlMaster per host. Pane streams deliberately use
-// their own direct connections instead (see pane.rs).
+// forward) over one ControlMaster per host, plus (opt-in) pre-creation of
+// per-slot masters that pooled pane streams may attach to (see pane.rs).
+// Pane streams never create a master themselves; unpooled or unattached
+// streams simply run direct.
 
 use std::fs;
 use std::os::unix::fs::FileTypeExt;
@@ -11,7 +13,6 @@ use std::time::Duration;
 use serde::Deserialize;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
-use tokio::time::timeout;
 
 use crate::api::ApiClient;
 use crate::config::{ApiTransport, HostConfig};
@@ -48,16 +49,39 @@ struct SshOutput {
     err: String,
 }
 
-async fn ssh(args: &[String], timeout_ms: u64) -> SshOutput {
-    let mut command = Command::new("ssh");
-    command
-        .args(args)
+/// Spawn `cmd` and wait up to `timeout_ms`, draining stdout/stderr
+/// concurrently with the wait (the same reason `Command::output` does —
+/// otherwise a child that fills its pipe buffer before exiting deadlocks
+/// against a parent that isn't reading yet).
+///
+/// `cmd` is spawned as the leader of its own process group (`process_group(0)`)
+/// so a `ProxyCommand` or other ssh descendant can be reaped too: on timeout
+/// this kills the whole group, not just the direct child, then explicitly
+/// waits for the child before returning rather than relying on `kill_on_drop`
+/// alone. `kill_on_drop` only *requests* termination when the `Child` drops,
+/// asynchronously, with no guarantee it has actually happened by the time
+/// this function's caller proceeds — e.g. to remove and recreate the very
+/// control socket a still-alive timed-out `ssh -f -N` might still be racing
+/// to bind. `kill_on_drop` stays set too, as a backstop for any path that
+/// drops `child` without reaching the explicit kill below (a panic, an early
+/// return added later, ...).
+///
+/// Must not simply wrap the wait in `tokio::time::timeout`: that combinator
+/// wins by dropping the losing future, which would drop `child` itself
+/// (moved into the wait) and lose the handle needed to kill it explicitly.
+/// `tokio::select!` on a plain (non-`move`) async block instead only
+/// *borrows* `child` in the racing branch, so it survives in this function's
+/// own scope for the timeout arm to act on.
+async fn run_with_timeout(mut cmd: Command, timeout_ms: u64, timeout_err: &str) -> SshOutput {
+    let mut child = match cmd
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .process_group(0);
-    let mut child = match command.spawn() {
-        Ok(child) => child,
+        .kill_on_drop(true)
+        .process_group(0)
+        .spawn()
+    {
+        Ok(c) => c,
         Err(e) => {
             return SshOutput {
                 code: 1,
@@ -66,48 +90,50 @@ async fn ssh(args: &[String], timeout_ms: u64) -> SshOutput {
             }
         }
     };
-    let process_group = child.id().map(|id| id as i32);
-    let mut stdout = child.stdout.take().expect("piped ssh stdout");
-    let mut stderr = child.stderr.take().expect("piped ssh stderr");
-    let mut out = Vec::new();
-    let mut err_output = Vec::new();
-    let collect = async {
-        let (status, stdout_result, stderr_result) = tokio::join!(
-            child.wait(),
-            stdout.read_to_end(&mut out),
-            stderr.read_to_end(&mut err_output)
+    // `process_group(0)` makes the child its own group leader, so its pgid
+    // equals its pid and this also covers the child itself, not just its
+    // descendants.
+    let pgid = child.id().map(|id| id as i32);
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let mut stderr = child.stderr.take().expect("piped stderr");
+    let mut out_buf = Vec::new();
+    let mut err_buf = Vec::new();
+
+    let wait_and_drain = async {
+        let (_, _, status) = tokio::join!(
+            stdout.read_to_end(&mut out_buf),
+            stderr.read_to_end(&mut err_buf),
+            child.wait()
         );
-        stdout_result?;
-        stderr_result?;
         status
     };
 
-    match timeout(Duration::from_millis(timeout_ms), collect).await {
-        Ok(Ok(status)) => SshOutput {
-            code: status.code().unwrap_or(1),
-            out: String::from_utf8_lossy(&out).into_owned(),
-            err: String::from_utf8_lossy(&err_output).into_owned(),
+    tokio::select! {
+        status = wait_and_drain => match status {
+            Ok(status) => SshOutput {
+                code: status.code().unwrap_or(1),
+                out: String::from_utf8_lossy(&out_buf).into_owned(),
+                err: String::from_utf8_lossy(&err_buf).into_owned(),
+            },
+            Err(e) => SshOutput { code: 1, out: String::new(), err: e.to_string() },
         },
-        Ok(Err(e)) => SshOutput {
-            code: 1,
-            out: String::new(),
-            err: e.to_string(),
-        },
-        Err(_) => {
-            if let Some(process_group) = process_group {
-                // ProxyCommand and any other ssh descendants share this group.
-                // Killing only the direct child leaves those descendants behind.
-                unsafe { libc::kill(-process_group, libc::SIGKILL) };
+        _ = tokio::time::sleep(Duration::from_millis(timeout_ms)) => {
+            match pgid {
+                // ProxyCommand and any other ssh descendants share this group;
+                // killing only the direct child would leave those behind.
+                Some(pgid) => { unsafe { libc::kill(-pgid, libc::SIGKILL) }; }
+                None => { let _ = child.start_kill(); }
             }
-            // Reap the direct child before a reconnect starts another ssh tree.
             let _ = child.wait().await;
-            SshOutput {
-                code: 1,
-                out: String::new(),
-                err: "ssh timeout".into(),
-            }
+            SshOutput { code: 1, out: String::new(), err: timeout_err.into() }
         }
     }
+}
+
+async fn ssh(args: &[String], timeout_ms: u64) -> SshOutput {
+    let mut cmd = Command::new("ssh");
+    cmd.args(args);
+    run_with_timeout(cmd, timeout_ms, "ssh timeout").await
 }
 
 fn remove_stale_control_socket(path: &Path) -> Result<()> {
@@ -133,6 +159,211 @@ fn remove_stale_control_socket(path: &Path) -> Result<()> {
             path.display()
         ))
     })
+}
+
+/// Timeouts for the daemon's own `<host>.ctl` control-plane master: this
+/// bootstraps the whole host connection, so it can afford to wait.
+const CONTROL_MASTER_CHECK_TIMEOUT_MS: u64 = 15000;
+const CONTROL_MASTER_START_TIMEOUT_MS: u64 = 20000;
+
+/// Timeouts for a stream-pool slot master. Deliberately much shorter than the
+/// control-plane master's: the daemon is the sole creator of these (see
+/// pane.rs::ssh_stream_args — streamers attach with `ControlMaster=no` and
+/// fall back to a direct connection if a live master isn't already there),
+/// so a hung/unreachable attempt must not be allowed to stall a host's whole
+/// reconciliation loop anywhere near as long as bootstrapping the connection
+/// itself is allowed to.
+const STREAM_MASTER_CHECK_TIMEOUT_MS: u64 = 4000;
+const STREAM_MASTER_START_TIMEOUT_MS: u64 = 8000;
+
+/// Finite, not `yes`: an idle pool slot (its assigned panes all closed, or a
+/// config/target change stopped using it) must eventually let its master
+/// exit on its own, rather than every slot ever assigned accumulating into a
+/// permanent background ssh process nothing still uses.
+const STREAM_MASTER_CONTROL_PERSIST: &str = "10m";
+
+async fn master_check(ctl_path: &Path, target: &str, timeout_ms: u64) -> bool {
+    let check = vec![
+        "-S".into(),
+        ctl_path.display().to_string(),
+        "-o".into(),
+        "BatchMode=yes".into(),
+        "-O".into(),
+        "check".into(),
+        target.to_string(),
+    ];
+    ssh(&check, timeout_ms).await.code == 0
+}
+
+/// Start an ssh ControlMaster listening at `ctl_path` for `target` and verify
+/// it actually came up, used both for the daemon's own `<host>.ctl` master
+/// (`RemoteHost::ensure_master`) and for a stream-pool slot master
+/// (`ensure_stream_master`) — same check/stale-socket/start/verify sequence
+/// either way, just parameterized on the control path, how long the master
+/// persists with no client attached, and the timeouts to apply.
+async fn start_master(
+    ctl_path: &Path,
+    target: &str,
+    control_persist: &str,
+    check_timeout_ms: u64,
+    start_timeout_ms: u64,
+) -> Result<()> {
+    // OpenSSH falls back to a standalone connection when ControlPath exists
+    // but no master is listening. With -f -N that silently leaks one process
+    // per retry, while every later -O command keeps targeting the dead socket.
+    remove_stale_control_socket(ctl_path)?;
+    let mut start: Vec<String> = vec!["-M".into(), "-S".into(), ctl_path.display().to_string()];
+    start.extend(SSH_COMMON_OPTS.iter().map(|s| s.to_string()));
+    start.extend([
+        "-o".into(),
+        format!("ControlPersist={control_persist}"),
+        "-f".into(),
+        "-N".into(),
+        target.to_string(),
+    ]);
+    let res = ssh(&start, start_timeout_ms).await;
+    if res.code != 0 {
+        return Err(err(format!(
+            "ssh master to {target} failed: {}",
+            nonempty(&res.err, res.code)
+        )));
+    }
+    if !master_check(ctl_path, target, check_timeout_ms).await {
+        return Err(err(format!(
+            "ssh master to {target} did not create a usable control socket"
+        )));
+    }
+    Ok(())
+}
+
+/// A dedicated sibling file whose flock (never its contents, which are never
+/// read) is the cross-process lock for one control-master path — not the
+/// control socket itself, so nothing about opening/holding this lock has to
+/// reason about socket bind/connect semantics.
+fn cross_process_lock_path(ctl_path: &Path) -> PathBuf {
+    let mut name = ctl_path.as_os_str().to_owned();
+    name.push(".lock");
+    PathBuf::from(name)
+}
+
+/// Whether `ensure_master_locked` found a master already listening, or had
+/// to (re)start one — `RemoteHost::ensure_master` needs to know which, to
+/// decide whether its cached API-socket forward is still valid.
+enum MasterState {
+    AlreadyAlive,
+    Started,
+}
+
+/// Bring up (or confirm) the ControlMaster at `ctl_path`, serialized across
+/// every process on this host via `filelock::acquire_async` so a concurrent
+/// caller — another tokio task in this same daemon (converge's fresh-pane
+/// pre-create vs. the local-server zombie-heal sweep), or a wholly separate
+/// `herdr-mirror` invocation (a manual `once` racing the daemon) — can't
+/// unlink a master a concurrent attempt just brought up. The shared layer
+/// behind both `RemoteHost::ensure_master` (control-plane `<host>.ctl`) and
+/// `ensure_stream_master` (pool slots) — same
+/// check/lock/re-check/start/verify sequence either way, just parameterized
+/// on the control path, how long the master persists with no client
+/// attached, and the timeouts to apply.
+///
+/// Lock order: this lock is always the INNERMOST one held — see
+/// `filelock`'s module doc for the required ordering against the per-host
+/// state lock (`state.rs`) and `daemon.lock`.
+async fn ensure_master_locked(
+    ctl_path: &Path,
+    target: &str,
+    control_persist: &str,
+    check_timeout_ms: u64,
+    start_timeout_ms: u64,
+) -> Result<MasterState> {
+    // Fast path without the lock: the common case (already alive) shouldn't
+    // pay for lock acquisition at all.
+    if master_check(ctl_path, target, check_timeout_ms).await {
+        return Ok(MasterState::AlreadyAlive);
+    }
+    let lock_path = cross_process_lock_path(ctl_path);
+    let _guard =
+        crate::filelock::acquire_async(&lock_path, Duration::from_millis(check_timeout_ms)).await?;
+    // Re-check now that this path is ours alone across every process on this
+    // host: a concurrent attempt may have brought up a live master while we
+    // waited for the lock, and unlinking-and-restarting on top of it would
+    // tear down exactly the master that attempt just created.
+    if master_check(ctl_path, target, check_timeout_ms).await {
+        return Ok(MasterState::AlreadyAlive);
+    }
+    start_master(
+        ctl_path,
+        target,
+        control_persist,
+        check_timeout_ms,
+        start_timeout_ms,
+    )
+    .await?;
+    Ok(MasterState::Started)
+}
+
+/// Pre-create the ControlMaster for one ssh stream-pool slot, so the
+/// streamers that will share it (attaching with `ControlMaster=no`, see
+/// pane.rs::ssh_stream_args) find an already-listening master instead of
+/// each falling back to its own direct connection. The daemon is the sole
+/// creator of stream-pool masters — a streamer never starts one itself —
+/// so this call is what makes pooling actually happen; a streamer whose
+/// slot has no live master here simply runs direct until it does.
+pub(crate) async fn ensure_stream_master(
+    state_dir: &Path,
+    cfg: &HostConfig,
+    slot: u32,
+) -> Result<()> {
+    let path = stream_control_path(state_dir, &cfg.name, &cfg.target, slot);
+    ensure_master_locked(
+        &path,
+        &cfg.target,
+        STREAM_MASTER_CONTROL_PERSIST,
+        STREAM_MASTER_CHECK_TIMEOUT_MS,
+        STREAM_MASTER_START_TIMEOUT_MS,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Ensure every slot in `slots` has a master, concurrently rather than one at
+/// a time: sequential attempts turn one hung/unreachable slot into a delay
+/// that multiplies by the number of slots, which is exactly what previously
+/// let a broken host stall reconciliation for minutes (see the `stream_pool`
+/// module docs). Bounded by `slots`' own size — realistically a handful, one
+/// per `ssh_streams_per_connection`-sized group of mirrored panes — not an
+/// unbounded or ever-growing set.
+///
+/// Returns one result per slot so the caller can log and/or drive its own
+/// retry backoff; a task that fails to complete at all (panics or is
+/// cancelled) is logged here directly, since it has no slot number to
+/// attribute a returned result to.
+pub(crate) async fn ensure_stream_masters_concurrent(
+    state_dir: &Path,
+    cfg: &HostConfig,
+    slots: impl IntoIterator<Item = u32>,
+    log: &Logger,
+) -> Vec<(u32, Result<()>)> {
+    let mut set = tokio::task::JoinSet::new();
+    for slot in slots {
+        let state_dir = state_dir.to_path_buf();
+        let cfg = cfg.clone();
+        set.spawn(async move {
+            let res = ensure_stream_master(&state_dir, &cfg, slot).await;
+            (slot, res)
+        });
+    }
+    let mut results = Vec::new();
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok(pair) => results.push(pair),
+            Err(e) => log.log(&format!(
+                "[{}] a stream-pool master pre-create task did not complete: {e}",
+                cfg.name
+            )),
+        }
+    }
+    results
 }
 
 pub struct RemoteHost {
@@ -167,44 +398,49 @@ pub struct RemoteHost {
     log: Logger,
 }
 
-/// FNV-1a, truncated to 8 hex chars.
+/// Base directory + filename stem for a host's control-plane sockets
+/// (`.ctl`, `-api.sock`, `-api-exec.sock`), the stem bounded so the longest
+/// one still fits sockaddr_un.
 ///
-/// NOT `DefaultHasher`: this value lands in a path the daemon and every
-/// streamer must derive identically, and it has to survive a toolchain
-/// upgrade. std's hasher is explicitly unstable across Rust releases, so a
-/// bump would silently move every long-named host's socket and orphan its live
-/// ControlMaster. FNV-1a is a published algorithm, so the crate's output is
-/// fixed by spec rather than by implementation detail. Not a security boundary
-/// — it only has to separate a user's own host names, and `socket_stem_hash_is_stable`
-/// pins the exact value so a future swap cannot move anyone's sockets unnoticed.
+/// Two disjoint cases, corresponding to `util::is_safe_path_component`:
 ///
-/// Hashes the raw bytes rather than going through `Hash for str`, which appends
-/// a terminator byte and would give a different (still stable, but arbitrary)
-/// value.
-fn short_hash(s: &str) -> String {
-    use std::hash::Hasher;
-
-    let mut hasher = fnv::FnvHasher::default();
-    hasher.write(s.as_bytes());
-    format!("{:08x}", hasher.finish() as u32)
+/// - A safe host name (the common case — nothing is reserved, an `h#`-
+///   prefixed one included) lives at the root of `state_dir` and behaves
+///   exactly as it did before this crate ever hashed anything: verbatim if
+///   it fits the budget, else a truncated readable prefix plus
+///   `legacy_socket_hash` — the original, unprefixed 32-bit hash, preserved
+///   byte-for-byte. An existing install with an overlong-but-safe host name
+///   must not get a new `.ctl` path (and so a new ControlMaster + API
+///   forward) on an otherwise-unrelated upgrade; only a host name that was
+///   never safely representable at all moves.
+/// - An unsafe host name (never valid pre-upgrade, so there is nothing to
+///   stay compatible with) lives under `util::unsafe_host_artifacts_dir`
+///   instead, with its fixed-length 64-bit hash stem — no truncation is
+///   needed there at all, and directory separation (not a reserved
+///   filename prefix) is what keeps it from ever aliasing a root-level safe
+///   stem, however that stem looks.
+fn control_socket_base(state_dir: &std::path::Path, host_name: &str) -> (PathBuf, String) {
+    if !crate::util::is_safe_path_component(host_name) {
+        let dir = crate::util::unsafe_host_artifacts_dir(state_dir);
+        let _ = crate::util::ensure_private_dir(&dir);
+        return (dir, crate::util::unsafe_host_stem(host_name));
+    }
+    let budget = socket_path_budget(state_dir);
+    let stem = if host_name.len() <= budget {
+        host_name.to_string()
+    } else {
+        legacy_degrade_with_hash(host_name, host_name, budget)
+    };
+    (state_dir.to_path_buf(), stem)
 }
 
-/// Filename stem shared by a host's three sockets, bounded so the longest one
-/// still fits sockaddr_un.
-///
-/// Truncation alone is not enough: two hosts sharing a long prefix (exactly the
-/// naming style that overflows the limit in the first place) would collide, and
-/// a collision is silent and dangerous rather than loud. `ensure_master` probes
-/// the ControlPath before creating a master, so host B would find host A's live
-/// master and run every ssh command — including remote-invoke plugin actions —
-/// on the wrong machine; the docker relay would unlink the other host's live
-/// socket and take over the path. So anything truncated carries a hash of the
-/// FULL name.
-///
-/// Names that already fit are returned verbatim, which is what keeps existing
-/// installs on byte-identical paths across this upgrade (no orphaned masters,
-/// no migration). Only names that were already too long to work at all move.
-fn socket_stem(state_dir: &std::path::Path, host_name: &str) -> String {
+/// sockaddr_un byte budget for a root-level (safe host name) control-plane
+/// socket stem. Not needed for an unsafe name's `.h/`-nested stem (fixed
+/// length regardless of host name) or for any stream-pool socket (see
+/// `streams_dir`/`stream_stem_base`, similarly fixed-length) — those are
+/// instead checked directly against their REAL constructed path by
+/// `validate_socket_path_budget`, since neither ever truncates to fit.
+fn socket_path_budget(state_dir: &std::path::Path) -> usize {
     use std::os::unix::ffi::OsStrExt;
 
     // macOS reserves one byte of sockaddr_un's 104-byte path for NUL; Linux
@@ -212,50 +448,239 @@ fn socket_stem(state_dir: &std::path::Path, host_name: &str) -> String {
     // hosts.toml is portable. Overhead is the worst case across the three
     // suffixes (`-api-exec.sock`, 14) plus OpenSSH's mux temp suffix on the
     // ControlPath (a dot and 11 chars); 21 keeps a little slack.
-    const MAX_SOCKET_PATH_BYTES: usize = 103;
     const CONTROL_SOCKET_OVERHEAD: usize = 21;
 
     let directory_bytes = state_dir.as_os_str().as_bytes().len() + 1;
-    let budget = MAX_SOCKET_PATH_BYTES.saturating_sub(directory_bytes + CONTROL_SOCKET_OVERHEAD);
-    if host_name.len() <= budget {
-        return host_name.into();
-    }
+    MAX_SOCKET_PATH_BYTES.saturating_sub(directory_bytes + CONTROL_SOCKET_OVERHEAD)
+}
 
-    // Degrade in defined steps rather than collapsing to a shared stem: prefix
-    // plus hash while both fit, then hash alone. Below that even the hash can't
-    // fit, which means the state dir path itself is too long for any socket —
-    // return the hash anyway so hosts stay distinct and let the bind fail
-    // loudly, rather than handing every host one shared path.
-    let hash = short_hash(host_name);
+/// The portable sockaddr_un byte budget every actual Unix socket path this
+/// crate creates must fit: macOS reserves one byte of its 104-byte
+/// sockaddr_un for NUL, Linux allows 108, and using the tighter bound on
+/// both keeps a hosts.toml portable between them.
+pub(crate) const MAX_SOCKET_PATH_BYTES: usize = 103;
+
+/// OpenSSH creates a temporary file alongside the real ControlPath during
+/// mux setup, named with this many extra bytes appended — a live socket
+/// that itself fits `MAX_SOCKET_PATH_BYTES` can still fail to bind if this
+/// leaves no room for that temp file. Applies to a ControlPath (the
+/// control-plane `.ctl` and every stream-pool socket) but not the plain
+/// API-forward/exec sockets, which OpenSSH never touches.
+pub(crate) const CONTROL_MUX_TEMP_SUFFIX_BYTES: usize = 17;
+
+/// The socket families this host's `HostKind`/`api_transport` can actually
+/// reach at runtime (see `RemoteHost::new`/`connect_ssh_api`/`connect_api`),
+/// each as (label, real path, extra bytes OpenSSH's mux temp file needs
+/// beyond the live socket itself — 0 for a socket ssh never puts under
+/// mux). A pure, directly-testable enumeration so "does this host's
+/// config actually reach this socket" is checked against the real enums,
+/// not duplicated/guessed inline:
+/// - docker: only its relay socket, which reuses the plain `-api.sock`
+///   path (no ControlMaster, no mux suffix, no exec relay — docker never
+///   opens either).
+/// - ssh: always the ControlMaster (`.ctl`, plus the mux temp suffix); the
+///   API-forward socket unless `api_transport = "exec"` pins the exec
+///   relay exclusively, and the API-exec socket unless `api_transport =
+///   "socket"` pins the forward exclusively (`"auto"`, the default, can
+///   reach both).
+/// - ssh with pooling on (`ssh_streams_per_connection > 1`): also one
+///   representative stream-pool slot (also a ControlMaster, so also plus
+///   the mux suffix). `util::stream_namespace_hash` folds only host+target
+///   into a fixed-length hash, and slot is a separate fixed-width suffix
+///   (see `stream_control_path`), so every slot's path is the identical
+///   length regardless of which one this is.
+fn reachable_control_sockets(
+    state_dir: &std::path::Path,
+    cfg: &HostConfig,
+) -> Vec<(&'static str, PathBuf, usize)> {
+    let (dir, stem) = control_socket_base(state_dir, &cfg.name);
+    if cfg.kind.is_docker() {
+        return vec![(
+            "Docker relay socket",
+            dir.join(format!("{stem}-api.sock")),
+            0,
+        )];
+    }
+    let mut sockets = vec![(
+        "control-plane socket (.ctl)",
+        dir.join(format!("{stem}.ctl")),
+        CONTROL_MUX_TEMP_SUFFIX_BYTES,
+    )];
+    if cfg.api_transport != ApiTransport::Exec {
+        sockets.push((
+            "API forward socket",
+            dir.join(format!("{stem}-api.sock")),
+            0,
+        ));
+    }
+    if cfg.api_transport != ApiTransport::Socket {
+        sockets.push((
+            "API exec socket",
+            dir.join(format!("{stem}-api-exec.sock")),
+            0,
+        ));
+    }
+    if cfg.ssh_streams_per_connection > 1 {
+        sockets.push((
+            "stream-pool socket",
+            stream_control_path(state_dir, &cfg.name, &cfg.target, 0),
+            CONTROL_MUX_TEMP_SUFFIX_BYTES,
+        ));
+    }
+    sockets
+}
+
+/// Validate every actual Unix socket path this host's connections will use
+/// (see `reachable_control_sockets`) against the portable budget above —
+/// the same limit `control_socket_base`'s root-level truncation already
+/// respects for a SAFE name, but not automatically enforced for an unsafe
+/// name's fixed-length `.h/`-nested stem or any `.s/`-nested stream-pool
+/// socket, since neither one ever truncates to fit. A `state_dir` deep
+/// enough to blow this budget would otherwise fail only at actual
+/// ssh/docker bind time — silently, and far from its actionable cause
+/// (`state_dir` itself, or this one host's name).
+pub(crate) fn validate_socket_path_budget(
+    state_dir: &std::path::Path,
+    cfg: &HostConfig,
+) -> Result<()> {
+    for (label, path, mux_suffix) in reachable_control_sockets(state_dir, cfg) {
+        check_socket_path_budget(&cfg.name, label, &path, mux_suffix)?;
+    }
+    Ok(())
+}
+
+fn check_socket_path_budget(
+    host_name: &str,
+    label: &str,
+    path: &std::path::Path,
+    mux_suffix: usize,
+) -> Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let len = path.as_os_str().as_bytes().len() + mux_suffix;
+    if len > MAX_SOCKET_PATH_BYTES {
+        return Err(err(format!(
+            "hosts.toml: \"{host_name}\"'s {label} path is {len} bytes ({}{}), over the \
+             {MAX_SOCKET_PATH_BYTES}-byte portable Unix socket limit — use a shorter state_dir \
+             or host name",
+            path.display(),
+            if mux_suffix > 0 {
+                format!(" plus a {mux_suffix}-byte OpenSSH mux suffix")
+            } else {
+                String::new()
+            }
+        )));
+    }
+    Ok(())
+}
+
+/// The pre-widening 32-bit FNV-1a hash, preserved byte-for-byte: this is
+/// what `control_socket_base` uses for a safe-but-overlong host name
+/// specifically so that path does not move on this upgrade. Do not change
+/// this function — change `util::short_hash` (the 64-bit hash every other
+/// path in this crate uses) instead.
+pub(crate) fn legacy_socket_hash(s: &str) -> String {
+    use std::hash::Hasher;
+
+    let mut hasher = fnv::FnvHasher::default();
+    hasher.write(s.as_bytes());
+    format!("{:08x}", hasher.finish() as u32)
+}
+
+/// Degrade `readable` to fit `budget` bytes: keep a prefix of it plus
+/// `legacy_socket_hash` of `hash_input`, so two names that overflow the
+/// budget identically (the exact case that motivates truncating at all)
+/// still diverge. Below that even the hash can't fit, which means the state
+/// dir path itself is too long for any socket — return the hash alone so
+/// hosts stay distinct and let the bind fail loudly, rather than handing
+/// every host one shared path.
+///
+/// Only ever called from `control_socket_base`'s safe-host-name branch —
+/// `readable` is therefore always safe to use verbatim as a path component
+/// here.
+fn legacy_degrade_with_hash(readable: &str, hash_input: &str, budget: usize) -> String {
+    let hash = legacy_socket_hash(hash_input);
     let keep = budget.saturating_sub(hash.len() + 1);
-    let mut end = keep.min(host_name.len());
-    while !host_name.is_char_boundary(end) {
+    let mut end = keep.min(readable.len());
+    while !readable.is_char_boundary(end) {
         end -= 1;
     }
-    let prefix = host_name[..end].trim_end_matches('-');
+    let prefix = readable[..end].trim_end_matches('-');
     if prefix.is_empty() {
-        return hash;
+        hash
+    } else {
+        format!("{prefix}-{hash}")
     }
-    format!("{prefix}-{hash}")
 }
 
 pub(crate) fn control_path(state_dir: &std::path::Path, host_name: &str) -> PathBuf {
-    state_dir.join(format!("{}.ctl", socket_stem(state_dir, host_name)))
+    let (dir, stem) = control_socket_base(state_dir, host_name);
+    dir.join(format!("{stem}.ctl"))
+}
+
+/// Private subdirectory for every stream-pool socket (`stream_control_path`):
+/// entirely new sockets with no pre-pooling path on disk to stay compatible
+/// with, kept structurally apart from the root-level control-plane sockets
+/// right next to it (and from `util::unsafe_host_artifacts_dir`) rather than
+/// distinguished by a reserved filename prefix — the same reasoning as
+/// `unsafe_host_artifacts_dir`, and what actually stops a stream socket from
+/// aliasing a different host's control-plane socket (both would otherwise
+/// end in `.ctl` at the same root).
+/// Private subdirectory for every stream-pool socket (`stream_control_path`):
+/// entirely new sockets with no pre-pooling path on disk to stay compatible
+/// with, kept structurally apart from the root-level control-plane sockets
+/// right next to it (and from `util::unsafe_host_artifacts_dir`) rather than
+/// distinguished by a reserved filename prefix — the same reasoning as
+/// `unsafe_host_artifacts_dir`, and what actually stops a stream socket from
+/// aliasing a different host's control-plane socket (both would otherwise
+/// end in `.ctl` at the same root). Named `.s`, not `.streams`, for the
+/// same budget reason `unsafe_host_artifacts_dir` is `.h`.
+fn streams_dir(state_dir: &std::path::Path) -> PathBuf {
+    state_dir.join(".s")
+}
+
+/// Control socket for one ssh stream-pool slot (see `stream_pool`): a private
+/// mux master shared by up to `ssh_streams_per_connection` pane streams,
+/// distinct from both the daemon's own `<host>.ctl` control-plane master and
+/// from every pane's data connection when pooling is off.
+///
+/// Always lives under `streams_dir`, named `<namespace>-<slot:08x>.ctl`:
+/// `namespace` is `util::stream_namespace_hash(host, target)` (16 hex
+/// chars, no readable host-name prefix), and `slot` is hex-encoded to a
+/// fixed 8 digits so the filename's length never depends on how large a
+/// slot index gets — `ssh_streams_per_connection` bounds pane count per
+/// slot, not the number of slots a host can ever reach, so nothing about
+/// slot width can be assumed small. `config::load_config_for_env` validates
+/// this fixed length once, for one representative slot, rather than
+/// needing to re-check per slot width. `config::validate_unique_stream_namespaces`
+/// checks every configured pooled host's namespace (not per slot — the
+/// namespace alone determines any collision) for the residual
+/// (astronomically unlikely) case of two hashing alike.
+pub(crate) fn stream_control_path(
+    state_dir: &std::path::Path,
+    host_name: &str,
+    target: &str,
+    slot: u32,
+) -> PathBuf {
+    let dir = streams_dir(state_dir);
+    let _ = crate::util::ensure_private_dir(&dir);
+    let namespace = crate::util::stream_namespace_hash(host_name, target);
+    dir.join(format!("{namespace}-{slot:08x}.ctl"))
 }
 
 impl RemoteHost {
     pub fn new(cfg: &HostConfig, state_dir: &std::path::Path) -> RemoteHost {
-        let stem = socket_stem(state_dir, &cfg.name);
+        let (dir, stem) = control_socket_base(state_dir, &cfg.name);
         RemoteHost {
-            ctl_path: state_dir.join(format!("{stem}.ctl")),
-            fwd_sock: state_dir.join(format!("{stem}-api.sock")),
+            ctl_path: dir.join(format!("{stem}.ctl")),
+            fwd_sock: dir.join(format!("{stem}-api.sock")),
             transport_hint: cfg.api_transport,
             cfg: cfg.clone(),
             forwarded: false,
             container: None,
             relay: None,
             exec_relay: None,
-            exec_sock: state_dir.join(format!("{stem}-api-exec.sock")),
+            exec_sock: dir.join(format!("{stem}-api-exec.sock")),
             last_api_transport: None,
             log: Logger::new(state_dir, false),
         }
@@ -286,7 +711,10 @@ impl RemoteHost {
         let Some(id) = ids.first().cloned() else {
             // a stopped devcontainer is the resting state, not a fault; the
             // daemon matches this marker to back off gently
-            return Err(err(format!("{DORMANT}: no running container for {}", self.cfg.target)));
+            return Err(err(format!(
+                "{DORMANT}: no running container for {}",
+                self.cfg.target
+            )));
         };
         if ids.len() > 1 {
             // reachable without an attacker: a compose devcontainer can put the
@@ -299,7 +727,10 @@ impl RemoteHost {
         }
         // re-probe on every (re)connect: a rebuilt container may differ
         crate::docker::probe_socat(&bin, &id).await?;
-        self.container = Some(crate::docker::Container { id, docker_bin: bin });
+        self.container = Some(crate::docker::Container {
+            id,
+            docker_bin: bin,
+        });
         Ok(())
     }
 
@@ -313,44 +744,19 @@ impl RemoteHost {
     }
 
     pub async fn ensure_master(&mut self) -> Result<()> {
-        let mut check = self.base_args();
-        check.extend(["-O".into(), "check".into(), self.cfg.target.clone()]);
-        if ssh(&check, 15000).await.code == 0 {
-            return Ok(());
-        }
-        self.forwarded = false;
-        // OpenSSH falls back to a standalone connection when ControlPath exists
-        // but no master is listening. With -f -N that silently leaks one process
-        // per retry, while every later -O command keeps targeting the dead socket.
-        remove_stale_control_socket(&self.ctl_path)?;
-        let mut start: Vec<String> = vec![
-            "-M".into(),
-            "-S".into(),
-            self.ctl_path.display().to_string(),
-        ];
-        start.extend(SSH_COMMON_OPTS.iter().map(|s| s.to_string()));
-        start.extend([
-            "-o".into(),
-            "ControlPersist=yes".into(),
-            "-f".into(),
-            "-N".into(),
-            self.cfg.target.clone(),
-        ]);
-        let res = ssh(&start, 20000).await;
-        if res.code != 0 {
-            return Err(err(format!(
-                "ssh master to {} failed: {}",
-                self.cfg.target,
-                nonempty(&res.err, res.code)
-            )));
-        }
-        let verified = ssh(&check, 15000).await;
-        if verified.code != 0 {
-            return Err(err(format!(
-                "ssh master to {} did not create a usable control socket: {}",
-                self.cfg.target,
-                nonempty(&verified.err, verified.code)
-            )));
+        let state = ensure_master_locked(
+            &self.ctl_path,
+            &self.cfg.target,
+            "yes",
+            CONTROL_MASTER_CHECK_TIMEOUT_MS,
+            CONTROL_MASTER_START_TIMEOUT_MS,
+        )
+        .await?;
+        if matches!(state, MasterState::Started) {
+            // API-socket forwards registered on the master that just failed
+            // its check are gone with it; the caller must re-add them now
+            // that a fresh master is up
+            self.forwarded = false;
         }
         Ok(())
     }
@@ -376,7 +782,9 @@ impl RemoteHost {
             self.cfg.remote_bin.as_deref(),
             self.cfg.session.as_deref(),
         );
-        let out = self.exec(&format!("exec {} status --json", bin), 15000).await?;
+        let out = self
+            .exec(&format!("exec {} status --json", bin), 15000)
+            .await?;
         #[derive(Deserialize)]
         struct Client {
             version: Option<String>,
@@ -401,7 +809,11 @@ impl RemoteHost {
             .unwrap_or_else(|| "unknown".into());
         let running = parsed.server.as_ref().and_then(|s| s.running) == Some(true);
         let socket = parsed.server.and_then(|s| s.socket).unwrap_or_default();
-        let mut status = RemoteStatus { socket, supported: false, reason: None };
+        let mut status = RemoteStatus {
+            socket,
+            supported: false,
+            reason: None,
+        };
         if !running {
             // Name the session, or this reads as "that machine's herdr is
             // down" while the default session is running perfectly and only
@@ -438,14 +850,29 @@ impl RemoteHost {
         // a dead process can leave the forward registered on the master with
         // its socket file unlinked — cancel before re-adding
         let mut cancel = self.base_args();
-        cancel.extend(["-O".into(), "cancel".into(), "-L".into(), spec.clone(), self.cfg.target.clone()]);
+        cancel.extend([
+            "-O".into(),
+            "cancel".into(),
+            "-L".into(),
+            spec.clone(),
+            self.cfg.target.clone(),
+        ]);
         let _ = ssh(&cancel, 15000).await;
         let _ = std::fs::remove_file(&self.fwd_sock);
         let mut fwd = self.base_args();
-        fwd.extend(["-O".into(), "forward".into(), "-L".into(), spec, self.cfg.target.clone()]);
+        fwd.extend([
+            "-O".into(),
+            "forward".into(),
+            "-L".into(),
+            spec,
+            self.cfg.target.clone(),
+        ]);
         let res = ssh(&fwd, 15000).await;
         if res.code != 0 {
-            return Err(err(format!("ssh socket forward failed: {}", nonempty(&res.err, res.code))));
+            return Err(err(format!(
+                "ssh socket forward failed: {}",
+                nonempty(&res.err, res.code)
+            )));
         }
         self.forwarded = true;
         Ok(self.fwd_sock.clone())
@@ -477,7 +904,13 @@ impl RemoteHost {
     async fn cancel_forward(&mut self, remote_socket: &str) {
         let spec = format!("{}:{}", self.fwd_sock.display(), remote_socket);
         let mut args = self.base_args();
-        args.extend(["-O".into(), "cancel".into(), "-L".into(), spec, self.cfg.target.clone()]);
+        args.extend([
+            "-O".into(),
+            "cancel".into(),
+            "-L".into(),
+            spec,
+            self.cfg.target.clone(),
+        ]);
         let _ = ssh(&args, 15000).await;
         let _ = std::fs::remove_file(&self.fwd_sock);
         self.forwarded = false;
@@ -527,9 +960,11 @@ impl RemoteHost {
     /// cost before this fallback existed.
     async fn connect_ssh_api(&mut self, remote_socket: &str) -> Result<ApiClient> {
         let configured = self.cfg.api_transport;
-        let start_with_socket =
-            (if configured == ApiTransport::Auto { self.transport_hint } else { configured })
-                != ApiTransport::Exec;
+        let start_with_socket = (if configured == ApiTransport::Auto {
+            self.transport_hint
+        } else {
+            configured
+        }) != ApiTransport::Exec;
 
         if start_with_socket {
             match self.try_socket_transport(remote_socket).await {
@@ -569,7 +1004,10 @@ impl RemoteHost {
             }
         };
         if !status.supported {
-            return Err(err(status.reason.clone().unwrap_or_else(|| "remote unsupported".into())));
+            return Err(err(status
+                .reason
+                .clone()
+                .unwrap_or_else(|| "remote unsupported".into())));
         }
         // ssh hosts hand back a connected client (its ping doubles as the
         // transport probe); the docker branch resolves a path and connects below
@@ -603,7 +1041,6 @@ impl RemoteHost {
         let api = ApiClient::connect(&sock).await?;
         Ok((api, status))
     }
-
 }
 
 fn nonempty(e: &str, code: i32) -> String {
@@ -626,7 +1063,11 @@ pub(crate) fn version_supported(version: &str) -> Option<bool> {
     // preview builds look like 0.7.1-preview.2026-06-30-<hash>
     let preview_ok = version
         .split_once("-preview.")
-        .map(|(_, rest)| rest.get(0..10).map(|d| d >= MIN_PREVIEW_BUILD).unwrap_or(false))
+        .map(|(_, rest)| {
+            rest.get(0..10)
+                .map(|d| d >= MIN_PREVIEW_BUILD)
+                .unwrap_or(false)
+        })
         .unwrap_or(false);
     Some(newer_than_base || preview_ok)
 }
@@ -635,15 +1076,82 @@ pub(crate) fn version_supported(version: &str) -> Option<bool> {
 mod tests {
     use super::*;
 
+    /// Same nonce-collision fix as `filelock::tests::test_path` (see its
+    /// comment), compacted to a single 8-hex-char hash: several of this
+    /// module's tests bind a real unix socket at this path, which leaves far
+    /// less budget than an ordinary file for entropy padding.
     fn test_path(name: &str) -> PathBuf {
-        let nonce = std::time::SystemTime::now()
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!(
-            "herdr-mirror-{name}-{}-{nonce}",
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let salt = &counter as *const u64 as usize;
+        let unique = crate::util::short_hash(&format!(
+            "{}-{nanos}-{counter}-{salt:x}",
             std::process::id()
-        ))
+        ));
+        std::env::temp_dir().join(format!("herdr-mirror-{name}-{unique}"))
+    }
+
+    /// The property `run_with_timeout` exists for: a timed-out child must be
+    /// definitively dead, not merely asked to die, before this function
+    /// returns — proven with a harmless standalone command instead of a
+    /// real ssh child. The command would touch a marker file after a delay
+    /// longer than the timeout; if the kill were only requested
+    /// (`kill_on_drop`'s async, best-effort drop-time behavior) rather than
+    /// awaited, the process could still be alive racing to create that
+    /// marker after this function returns — this waits well past that delay
+    /// and asserts the marker never appears.
+    #[tokio::test]
+    async fn run_with_timeout_definitively_kills_a_slow_child_before_returning() {
+        let marker = test_path("timeout-marker");
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", &format!("sleep 0.3 && touch {}", marker.display())]);
+
+        let result = run_with_timeout(cmd, 30, "timed out").await;
+        assert_eq!(result.err, "timed out");
+
+        // well past the 0.3s the child would have needed to reach `touch`
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        assert!(
+            !marker.exists(),
+            "a timed-out child must never reach its marker"
+        );
+        let _ = fs::remove_file(&marker);
+    }
+
+    /// A child that exits on its own well within the timeout is unaffected:
+    /// `run_with_timeout` must still return its real exit code and output,
+    /// not treat every call as a kill.
+    #[tokio::test]
+    async fn run_with_timeout_returns_real_output_for_a_fast_child() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "echo hi; exit 3"]);
+        let result = run_with_timeout(cmd, 2000, "timed out").await;
+        assert_eq!(result.code, 3);
+        assert_eq!(result.out.trim(), "hi");
+    }
+
+    // --- cross-process locking: `filelock`'s own tests cover exclusion,
+    // blocking acquire, and the async retry/timeout behavior generically;
+    // this only needs to cover what's specific to `cross_process_lock_path`
+    // itself (its naming). `master_check`/`start_master` shell out to a real
+    // `ssh` binary, so the full ensure-a-master flow isn't practical to
+    // exercise deterministically here (this crate has no mocking harness for
+    // that boundary, and the existing `ssh_relay::relay_reaches_real_ssh_host`
+    // test marks the same kind of real-ssh dependency `#[ignore]`). Live
+    // validation of the full concurrent-ensure race across real
+    // `herdr-mirror` invocations still needs a real host.
+
+    #[test]
+    fn cross_process_lock_path_is_a_sibling_of_the_control_path() {
+        let ctl = Path::new("/state/vps-s0-abcd1234.ctl");
+        let lock = cross_process_lock_path(ctl);
+        assert_eq!(lock, Path::new("/state/vps-s0-abcd1234.ctl.lock"));
     }
 
     fn ssh_host(name: &str) -> HostConfig {
@@ -659,6 +1167,7 @@ mod tests {
             max_rows: None,
             api_transport: ApiTransport::Auto,
             always_control: true,
+            ssh_streams_per_connection: 1,
         }
     }
 
@@ -667,10 +1176,20 @@ mod tests {
         let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
         let name = "remote-development-environment-with-a-very-long-name";
         let remote = RemoteHost::new(&ssh_host(name), &state_dir);
-        let stem = socket_stem(&state_dir, name);
+        let (dir, stem) = control_socket_base(&state_dir, name);
 
-        assert!(stem.len() < name.len(), "long name should have been shortened");
-        assert!(name.starts_with(stem.split('-').next().unwrap()), "readable prefix kept");
+        assert_eq!(
+            dir, state_dir,
+            "a safe name, however long, stays at the root"
+        );
+        assert!(
+            stem.len() < name.len(),
+            "long name should have been shortened"
+        );
+        assert!(
+            name.starts_with(stem.split('-').next().unwrap()),
+            "readable prefix kept"
+        );
         assert_eq!(
             remote.ctl_path.file_name().unwrap().to_string_lossy(),
             format!("{stem}.ctl")
@@ -679,6 +1198,302 @@ mod tests {
         assert!(remote.ctl_path.as_os_str().len() + 17 <= 103);
         assert!(remote.fwd_sock.as_os_str().len() <= 103);
         assert!(remote.exec_sock.as_os_str().len() <= 103);
+    }
+
+    #[test]
+    fn stream_control_path_is_stable_and_bounded() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let a = stream_control_path(&state_dir, "vps", "vps.example.com", 0);
+        let again = stream_control_path(&state_dir, "vps", "vps.example.com", 0);
+        assert_eq!(
+            a, again,
+            "the same host/target/slot must always derive the same path"
+        );
+        // must survive OpenSSH's 17-byte mux temp suffix within the portable bound
+        assert!(a.as_os_str().len() + 17 <= 103, "{}", a.display());
+
+        let long_name = "remote-development-environment-with-a-very-long-name";
+        let bounded = stream_control_path(&state_dir, long_name, "target.example.com", 3);
+        assert!(
+            bounded.as_os_str().len() + 17 <= 103,
+            "{}",
+            bounded.display()
+        );
+    }
+
+    /// `slot` is hex-encoded to a fixed 8 digits (see `stream_control_path`),
+    /// so the largest possible slot index must produce the exact same
+    /// filename length as slot 0 — the property `validate_socket_path_budget`
+    /// relies on to check only one representative slot rather than every
+    /// slot a host could ever reach.
+    #[test]
+    fn stream_control_path_is_the_same_length_for_slot_zero_and_u32_max() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let slot0 = stream_control_path(&state_dir, "vps", "vps.example.com", 0);
+        let slot_max = stream_control_path(&state_dir, "vps", "vps.example.com", u32::MAX);
+        assert_eq!(slot0.as_os_str().len(), slot_max.as_os_str().len());
+        assert_ne!(slot0, slot_max, "still a distinct socket");
+    }
+
+    /// Every slot of the same host/target must get its own socket — sharing
+    /// one would mean two independently-pooled connections fighting over a
+    /// single ControlMaster.
+    #[test]
+    fn stream_control_path_separates_slots_hosts_and_targets() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let slot0 = stream_control_path(&state_dir, "vps", "vps.example.com", 0);
+        let slot1 = stream_control_path(&state_dir, "vps", "vps.example.com", 1);
+        assert_ne!(slot0, slot1, "distinct slots must not share a socket");
+
+        let other_host = stream_control_path(&state_dir, "vps2", "vps.example.com", 0);
+        assert_ne!(slot0, other_host, "distinct hosts must not share a socket");
+
+        let other_target = stream_control_path(&state_dir, "vps", "other.example.com", 0);
+        assert_ne!(
+            slot0, other_target,
+            "distinct targets must not share a socket"
+        );
+
+        // also distinct from the host's own control-plane master and API
+        // forward sockets, which are unrelated masters entirely
+        assert_ne!(slot0, control_path(&state_dir, "vps"));
+    }
+
+    /// Long host names past the sockaddr_un budget must still keep slots
+    /// (and other hosts) apart, the same collision-proofing
+    /// `control_socket_base` already guarantees for the `.ctl` path.
+    #[test]
+    fn stream_control_path_never_collides_when_truncated() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let a = "prod-us-east-1-application-server-cluster-node-alpha";
+        let b = "prod-us-east-1-application-server-cluster-node-beta";
+        assert_ne!(
+            stream_control_path(&state_dir, a, "t", 0),
+            stream_control_path(&state_dir, b, "t", 0),
+        );
+        assert_ne!(
+            stream_control_path(&state_dir, a, "t", 0),
+            stream_control_path(&state_dir, a, "t", 1),
+        );
+    }
+
+    /// Golden comparison to origin/main behavior: a long, safe host name's
+    /// control-plane stem must be byte-for-byte what it was before this
+    /// feature ever touched hashing, so an existing install's ControlMaster
+    /// and API forward stay at their existing socket path on upgrade.
+    #[test]
+    fn socket_stem_matches_v0_4_1_baseline_for_a_long_safe_host_name() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let name = "prod-us-east-1-application-server-cluster-node-alpha";
+        let (dir, stem) = control_socket_base(&state_dir, name);
+        assert_eq!(dir, state_dir);
+        assert_eq!(stem, "prod-us-east-1-application-serve-cbd62d65");
+    }
+
+    fn state_dir_of_len(bytes: usize) -> PathBuf {
+        // An absolute path of exactly `bytes` bytes: 1 for the leading `/`
+        // plus `bytes - 1` filler bytes, so callers can hit an exact budget
+        // boundary without hand-counting a literal string.
+        PathBuf::from(format!("/{}", "a".repeat(bytes - 1)))
+    }
+
+    fn pooled_ssh_host(name: &str) -> HostConfig {
+        HostConfig {
+            ssh_streams_per_connection: 4,
+            ..ssh_host(name)
+        }
+    }
+
+    /// The current real install path, with the two hosts actually
+    /// documented in the README, must fit comfortably — this is the
+    /// baseline every budget test below is a variation of.
+    #[test]
+    fn validate_socket_path_budget_accepts_the_real_state_dir_with_azure_and_rdev() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        for host in [ssh_host("azure"), pooled_ssh_host("rdev")] {
+            validate_socket_path_budget(&state_dir, &host).unwrap();
+        }
+    }
+
+    /// The reviewer's exact failure mode: a `state_dir` nested deep enough
+    /// (as real user home/state directories on macOS routinely are) that
+    /// even a normal short host name can no longer fit a live ControlPath
+    /// once OpenSSH's mux temp suffix is accounted for. Must be rejected
+    /// here, at config load, with an actionable message — not left to fail
+    /// silently the first time `ssh` tries to bind it.
+    #[test]
+    fn validate_socket_path_budget_rejects_a_state_dir_too_deep_for_a_live_control_path() {
+        let state_dir = state_dir_of_len(90);
+        let err = validate_socket_path_budget(&state_dir, &ssh_host("prod"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("prod"), "{err}");
+        assert!(err.contains("103"), "{err}");
+    }
+
+    /// Exact boundary for an unsafe (`.h/`-nested) host name, whose stem is
+    /// a fixed 16 hex chars regardless of the raw name — the cleanest way
+    /// to pin the arithmetic without also depending on truncation. One byte
+    /// under the limit passes, one byte over fails, and the failure names
+    /// the actual over-budget path rather than just a byte count.
+    #[test]
+    fn validate_socket_path_budget_boundary_for_an_unsafe_host_name() {
+        let unsafe_host = ssh_host("a/b");
+        validate_socket_path_budget(&state_dir_of_len(62), &unsafe_host)
+            .expect("exactly at the 103-byte (minus 17-byte mux suffix) limit must pass");
+        let err = validate_socket_path_budget(&state_dir_of_len(63), &unsafe_host)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("a/b"), "{err}");
+    }
+
+    /// A pooled host's representative stream-pool socket sits one directory
+    /// deeper (`.s/` vs the control-plane's own root or `.h/`) with a longer
+    /// (16 vs up to 8 hex) hash, so it goes over budget at a shallower
+    /// `state_dir` than the control-plane socket alone would.
+    #[test]
+    fn validate_socket_path_budget_checks_the_representative_stream_socket_for_a_pooled_host() {
+        let state_dir = state_dir_of_len(70);
+        let unpooled = ssh_host("vps");
+        validate_socket_path_budget(&state_dir, &unpooled)
+            .expect("an unpooled host never opens a stream socket, so this depth still fits");
+
+        let pooled = pooled_ssh_host("vps");
+        let err = validate_socket_path_budget(&state_dir, &pooled)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("stream-pool"), "{err}");
+    }
+
+    fn labels(sockets: Vec<(&'static str, PathBuf, usize)>) -> Vec<&'static str> {
+        sockets.into_iter().map(|(label, _, _)| label).collect()
+    }
+
+    /// Docker never opens a ControlMaster, mux suffix, or exec relay at
+    /// all — only its relay, which reuses the plain (non-mux) `-api.sock`
+    /// path. `ssh_streams_per_connection` is meaningless for docker (see
+    /// `stream_pool`), so it must not add a stream-socket check either even
+    /// when config parsing lets it be set on a docker host.
+    #[test]
+    fn reachable_control_sockets_docker_checks_only_its_relay_socket() {
+        let state_dir = PathBuf::from("/state");
+        let mut docker = ssh_host("vps");
+        docker.kind = crate::config::HostKind::DockerContainer("box".into());
+        docker.ssh_streams_per_connection = 4;
+        assert_eq!(
+            labels(reachable_control_sockets(&state_dir, &docker)),
+            ["Docker relay socket"]
+        );
+    }
+
+    /// `api_transport = "socket"` pins the streamlocal forward exclusively
+    /// (see `connect_ssh_api`): the exec relay is never reached, so its
+    /// path must never be checked.
+    #[test]
+    fn reachable_control_sockets_socket_transport_checks_ctl_and_forward_only() {
+        let state_dir = PathBuf::from("/state");
+        let mut host = ssh_host("vps");
+        host.api_transport = ApiTransport::Socket;
+        assert_eq!(
+            labels(reachable_control_sockets(&state_dir, &host)),
+            ["control-plane socket (.ctl)", "API forward socket"]
+        );
+    }
+
+    /// `api_transport = "exec"` pins the exec relay exclusively: the
+    /// streamlocal forward is never reached, so its path must never be
+    /// checked.
+    #[test]
+    fn reachable_control_sockets_exec_transport_checks_ctl_and_exec_only() {
+        let state_dir = PathBuf::from("/state");
+        let mut host = ssh_host("vps");
+        host.api_transport = ApiTransport::Exec;
+        assert_eq!(
+            labels(reachable_control_sockets(&state_dir, &host)),
+            ["control-plane socket (.ctl)", "API exec socket"]
+        );
+    }
+
+    /// The default `api_transport = "auto"` can fall back from the
+    /// streamlocal forward to the exec relay at runtime, so both are
+    /// reachable and both must be checked.
+    #[test]
+    fn reachable_control_sockets_auto_transport_checks_both_api_paths() {
+        let state_dir = PathBuf::from("/state");
+        let host = ssh_host("vps");
+        assert_eq!(
+            host.api_transport,
+            ApiTransport::Auto,
+            "sanity: the default"
+        );
+        assert_eq!(
+            labels(reachable_control_sockets(&state_dir, &host)),
+            [
+                "control-plane socket (.ctl)",
+                "API forward socket",
+                "API exec socket"
+            ]
+        );
+    }
+
+    /// A pooled ssh host reaches one more socket than an unpooled one of
+    /// the same transport: its stream-pool master.
+    #[test]
+    fn reachable_control_sockets_pooled_ssh_adds_the_stream_socket() {
+        let state_dir = PathBuf::from("/state");
+        let host = pooled_ssh_host("vps");
+        assert_eq!(
+            labels(reachable_control_sockets(&state_dir, &host)),
+            [
+                "control-plane socket (.ctl)",
+                "API forward socket",
+                "API exec socket",
+                "stream-pool socket"
+            ]
+        );
+    }
+
+    /// A `state_dir` deep enough to reject every ssh host regardless of
+    /// `api_transport` (the ControlMaster's mux suffix makes `.ctl` the
+    /// tightest of all the families above — see `reachable_control_sockets`'
+    /// doc comment) must still accept a docker host at that identical
+    /// depth: it never opens a ControlMaster at all, only the shorter,
+    /// mux-suffix-free relay socket.
+    #[test]
+    fn validate_socket_path_budget_docker_accepts_a_depth_that_rejects_every_ssh_transport() {
+        let state_dir = state_dir_of_len(80);
+        for transport in [ApiTransport::Auto, ApiTransport::Socket, ApiTransport::Exec] {
+            let mut host = ssh_host("vps");
+            host.api_transport = transport;
+            let err = validate_socket_path_budget(&state_dir, &host)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("vps"), "{transport:?}: {err}");
+        }
+
+        let mut docker = ssh_host("vps");
+        docker.kind = crate::config::HostKind::DockerContainer("box".into());
+        validate_socket_path_budget(&state_dir, &docker)
+            .expect("docker's relay socket alone still fits at a depth that rejects ssh");
+    }
+
+    /// A realistic depth genuinely reachable by an ordinary hosts.toml
+    /// (well short of the reviewer's failure case above) must accept every
+    /// transport pinning and docker alike — the happy path every one of
+    /// the reachability variations above still needs to work for.
+    #[test]
+    fn validate_socket_path_budget_accepts_every_reachable_kind_and_transport_at_a_realistic_depth()
+    {
+        let state_dir = state_dir_of_len(70);
+        for transport in [ApiTransport::Auto, ApiTransport::Socket, ApiTransport::Exec] {
+            let mut host = ssh_host("vps");
+            host.api_transport = transport;
+            validate_socket_path_budget(&state_dir, &host)
+                .unwrap_or_else(|e| panic!("{transport:?}: {e}"));
+        }
+        let mut docker = ssh_host("vps");
+        docker.kind = crate::config::HostKind::DockerContainer("box".into());
+        validate_socket_path_budget(&state_dir, &docker).unwrap();
     }
 
     #[test]
@@ -693,11 +1508,15 @@ mod tests {
 
         // these differ only *past* the cut, so plain truncation collided
         let budget = 103 - state_dir.as_os_str().len() - 1 - 21;
-        assert_eq!(a[..budget], b[..budget], "names must be identical up to the cut");
+        assert_eq!(
+            a[..budget],
+            b[..budget],
+            "names must be identical up to the cut"
+        );
 
         assert_ne!(
-            socket_stem(&state_dir, a),
-            socket_stem(&state_dir, b),
+            control_socket_base(&state_dir, a).1,
+            control_socket_base(&state_dir, b).1,
             "distinct hosts must not share a socket stem"
         );
         assert_ne!(
@@ -707,21 +1526,18 @@ mod tests {
     }
 
     #[test]
-    fn socket_stem_hash_is_stable() {
-        // Golden values. These bytes are baked into live socket paths, so a
-        // change here silently relocates every long-named host's ControlMaster.
-        // If a hashing swap ever moves them, this must fail first.
-        assert_eq!(short_hash("vps"), "4f02d738");
-        assert_eq!(short_hash("prod-us-east-1-application-server-cluster-node-alpha"), "cbd62d65");
-    }
-
-    #[test]
     fn short_host_names_keep_their_exact_path() {
         // existing installs must not move to a new socket on upgrade, which
         // would orphan a live ControlMaster
         let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
-        assert_eq!(socket_stem(&state_dir, "vps"), "vps");
-        assert_eq!(socket_stem(&state_dir, "work"), "work");
+        assert_eq!(
+            control_socket_base(&state_dir, "vps"),
+            (state_dir.clone(), "vps".into())
+        );
+        assert_eq!(
+            control_socket_base(&state_dir, "work"),
+            (state_dir.clone(), "work".into())
+        );
         assert_eq!(
             control_path(&state_dir, "vps"),
             state_dir.join("vps.ctl"),
@@ -729,19 +1545,211 @@ mod tests {
         );
     }
 
+    /// The exact compatibility break a later review reported: an `h#`-
+    /// prefixed name is just an ordinary safe TOML table key (quoted), not
+    /// reserved for anything — it keeps its exact v0.4.1 root-level path,
+    /// same as any other safe name. Disjointness from a genuinely hashed
+    /// unsafe-name artifact comes from `unsafe_host_artifacts_dir`
+    /// (`.h/`), a real directory, not from excluding any particular
+    /// name.
+    #[test]
+    fn an_h_hash_prefixed_host_name_keeps_its_v0_4_1_root_level_path() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        assert_eq!(
+            control_socket_base(&state_dir, "h#prod"),
+            (state_dir.clone(), "h#prod".into())
+        );
+        assert_eq!(
+            control_path(&state_dir, "h#prod"),
+            state_dir.join("h#prod.ctl")
+        );
+    }
+
+    #[test]
+    fn legacy_socket_hash_matches_v0_4_1_baseline() {
+        // Golden values, unchanged since before this crate hashed anything
+        // wider than 32 bits: this function must never move, or a long safe
+        // host name's `.ctl` path moves on every future upgrade too.
+        assert_eq!(legacy_socket_hash("vps"), "4f02d738");
+        assert_eq!(
+            legacy_socket_hash("prod-us-east-1-application-server-cluster-node-alpha"),
+            "cbd62d65"
+        );
+    }
+
+    /// A genuine (found by brute-force search, not synthetic) 32-bit
+    /// FNV-1a collision between two short, plain, safe host names: both
+    /// stay verbatim at the root under any realistic budget, so their
+    /// control-plane paths never actually collide despite the hash match.
+    #[test]
+    fn legacy_socket_hash_has_a_known_real_collision() {
+        assert_eq!(
+            legacy_socket_hash("host10579"),
+            legacy_socket_hash("host343082")
+        );
+        assert_eq!(legacy_socket_hash("host10579"), "350e55f1");
+
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        assert_ne!(
+            control_path(&state_dir, "host10579"),
+            control_path(&state_dir, "host343082")
+        );
+    }
+
+    /// Regression: a host name is a user-chosen TOML table key, not a
+    /// validated filename. A raw `/` or an embedded NUL must never reach a
+    /// root-level socket path with a mid-filename component boundary —
+    /// every unsafe name's derived path must live under the private
+    /// `unsafe_host_artifacts_dir` subdirectory instead, and the same
+    /// unsafe name must always degrade to the identical (safe) stem there.
+    /// `.`/`..`/empty are NOT unsafe here — see
+    /// `dot_and_empty_host_names_stay_at_the_root_like_v0_4_1` below.
+    #[test]
+    fn socket_paths_stay_contained_for_unsafe_host_names() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let hosts_dir = crate::util::unsafe_host_artifacts_dir(&state_dir);
+        for unsafe_name in ["../../escape", "a/b", "/etc/passwd"] {
+            let ctl = control_path(&state_dir, unsafe_name);
+            assert_eq!(
+                ctl.parent(),
+                Some(hosts_dir.as_path()),
+                "{unsafe_name} -> {}",
+                ctl.display()
+            );
+            let stream = stream_control_path(&state_dir, unsafe_name, "target", 0);
+            assert!(
+                stream.starts_with(&state_dir),
+                "{unsafe_name} stream path {} must stay within state_dir",
+                stream.display()
+            );
+            assert_eq!(
+                control_path(&state_dir, unsafe_name),
+                ctl,
+                "the same unsafe name must always degrade to the same stem"
+            );
+        }
+    }
+
+    /// The exact compatibility break a later review reported: every
+    /// artifact appends a suffix before joining (`.ctl`, `-map.json`, ...),
+    /// so a host named `""`/`"."`/`".."` never reaches `Path::join` as a
+    /// bare special component — `format!("{stem}.ctl")` produces the
+    /// literal filenames `.ctl`/`..ctl`/`...ctl`, not "here"/"parent".
+    /// These names must stay at the root with their exact v0.4.1 path, not
+    /// be diverted into `.h/`.
+    #[test]
+    fn dot_and_empty_host_names_stay_at_the_root_like_v0_4_1() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        assert_eq!(control_path(&state_dir, ""), state_dir.join(".ctl"));
+        assert_eq!(control_path(&state_dir, "."), state_dir.join("..ctl"));
+        assert_eq!(control_path(&state_dir, ".."), state_dir.join("...ctl"));
+        // a backslash is an ordinary character on macOS/Linux, not a
+        // separator, so it stays safe too
+        assert_eq!(control_path(&state_dir, "a\\b"), state_dir.join("a\\b.ctl"));
+    }
+
+    /// A hashed (unsafe-name) socket path can never coincide with an
+    /// unrelated, ordinary verbatim safe host name's path — the exact
+    /// defect an earlier review reported. Directory separation, not a
+    /// reserved prefix, is what guarantees it here: the two simply live in
+    /// different directories regardless of what either stem looks like.
+    #[test]
+    fn hashed_socket_paths_never_collide_with_an_ordinary_verbatim_name() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let unsafe_name = "x/EaL2b7VcKy";
+        let hashed_path = control_path(&state_dir, unsafe_name);
+        assert!(hashed_path.starts_with(crate::util::unsafe_host_artifacts_dir(&state_dir)));
+
+        // a lookalike safe name that could be mistaken for a hash keeps its
+        // own, verbatim, root-level, non-colliding path
+        let lookalike_safe_name = "92f037a4";
+        assert_eq!(
+            control_path(&state_dir, lookalike_safe_name),
+            state_dir.join("92f037a4.ctl")
+        );
+        assert_ne!(hashed_path, control_path(&state_dir, lookalike_safe_name));
+    }
+
+    /// The exact cross-family alias an independent review reported: `alpha`'s
+    /// stream-pool socket for slot 0 must never be reachable at the same
+    /// path as a distinct host literally named to look like that stream
+    /// stem — old naming echoed the host name into the stream stem
+    /// (`alpha-s0-<hash>`) at the SAME root as control-plane sockets, so a
+    /// second host named exactly that string got the identical `.ctl` path
+    /// as `alpha`'s slot-0 stream socket. Stream sockets now live under a
+    /// disjoint `.s/` directory with no readable host-name prefix at
+    /// all, so no root-level (or even `.h/`-nested) control-plane path
+    /// can ever land there.
+    #[test]
+    fn reported_cross_family_alias_no_longer_reproduces() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        // the "lookalike" is the exact stream stem: namespace hash plus its
+        // fixed-width hex slot suffix, the whole filename stem sans `.ctl`
+        let lookalike_host_name = format!(
+            "{}-{:08x}",
+            crate::util::stream_namespace_hash("alpha", "alpha.example.com"),
+            0u32
+        );
+        assert!(
+            crate::util::is_safe_path_component(&lookalike_host_name),
+            "sanity: otherwise a safe component"
+        );
+
+        let stream_path = stream_control_path(&state_dir, "alpha", "alpha.example.com", 0);
+        let lookalike_control_path = control_path(&state_dir, &lookalike_host_name);
+        assert_ne!(stream_path, lookalike_control_path);
+        // the lookalike name is just an ordinary safe name (nothing is
+        // reserved) — it keeps its own root-level path too
+        assert_eq!(
+            lookalike_control_path,
+            state_dir.join(format!("{lookalike_host_name}.ctl"))
+        );
+    }
+
+    /// General form of the same property: no control-plane path (`.ctl` for
+    /// any host, root-level or under `.h/`) can ever equal any
+    /// stream-pool path (any host, target, slot, always under `.s/`)
+    /// — the two live in structurally disjoint directories, and an ordinary
+    /// safe host name is never diverted from the root.
+    #[test]
+    fn control_and_stream_paths_never_collide_across_many_names() {
+        let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
+        let host_names = [
+            "alpha",
+            "beta-host",
+            "h#prod",
+            "a/b",
+            "..",
+            "x/EaL2b7VcKy",
+            "prod-us-east-1-application-server-cluster-node-alpha",
+        ];
+        for host in host_names {
+            let ctl = control_path(&state_dir, host);
+            for target in ["alpha.example.com", "other.example.com"] {
+                for slot in 0..3 {
+                    let stream = stream_control_path(&state_dir, host, target, slot);
+                    assert_ne!(ctl, stream, "host={host} target={target} slot={slot}");
+                }
+            }
+        }
+    }
+
     #[test]
     fn socket_stem_survives_multibyte_names_and_a_tiny_budget() {
         let state_dir = PathBuf::from("/Users/example/.local/state/herdr-mirror");
         // truncation must land on a char boundary, never split a code point
         let name = "höst-nàme-with-ünicode-and-a-very-long-tail-that-overflows";
-        let stem = socket_stem(&state_dir, name);
+        let stem = control_socket_base(&state_dir, name).1;
         assert!(stem.is_char_boundary(stem.len()));
 
         // a state dir long enough to eat the whole budget still yields distinct
         // stems rather than one shared path
         let deep = PathBuf::from("/Users/example/".to_string() + &"d".repeat(80));
-        assert_ne!(socket_stem(&deep, "alpha-host-name"), socket_stem(&deep, "beta-host-name"));
-        assert!(!socket_stem(&deep, "alpha-host-name").is_empty());
+        assert_ne!(
+            control_socket_base(&deep, "alpha-host-name").1,
+            control_socket_base(&deep, "beta-host-name").1
+        );
+        assert!(!control_socket_base(&deep, "alpha-host-name").1.is_empty());
     }
 
     #[tokio::test]
@@ -805,9 +1813,18 @@ mod tests {
         assert_eq!(version_supported("0.7.2"), Some(true));
         assert_eq!(version_supported("0.8.0"), Some(true));
         assert_eq!(version_supported("1.0.0"), Some(true));
-        assert_eq!(version_supported("0.7.1-preview.2026-06-30-3459798b606d"), Some(true));
-        assert_eq!(version_supported("0.7.1-preview.2026-07-04-aaaa"), Some(true));
-        assert_eq!(version_supported("0.7.1-preview.2026-06-29-aaaa"), Some(false));
+        assert_eq!(
+            version_supported("0.7.1-preview.2026-06-30-3459798b606d"),
+            Some(true)
+        );
+        assert_eq!(
+            version_supported("0.7.1-preview.2026-07-04-aaaa"),
+            Some(true)
+        );
+        assert_eq!(
+            version_supported("0.7.1-preview.2026-06-29-aaaa"),
+            Some(false)
+        );
         assert_eq!(version_supported("garbage"), None);
     }
 }

--- a/src/remote_action.rs
+++ b/src/remote_action.rs
@@ -44,7 +44,7 @@ use std::io::IsTerminal;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
-use crate::config::{load_config, HostConfig};
+use crate::config::{load_config_for_env, HostConfig};
 use crate::mirror::fetch_snapshot;
 use crate::remote::RemoteHost;
 use crate::state::load_state;
@@ -231,7 +231,7 @@ async fn invoke(env: &Env, spec: &str) -> Result<()> {
 
     let ctx = invocation_context();
     // Same deliberate non-`?` as run(): the local fallback needs no host config.
-    let config = load_config(&env.config_search);
+    let config = load_config_for_env(env);
     let resolved = config.as_ref().ok().and_then(|c| resolve_context(env, &c.hosts, &ctx));
 
     let Some(resolved) = resolved else {
@@ -292,7 +292,7 @@ async fn run(env: &Env, kind: &str, direction: Option<&str>) -> Result<()> {
     // these actions are meant to be bound over herdr's native new_tab/split.
     // Hard-failing here would kill that key for anyone who hasn't written
     // hosts.toml yet, with an error about SSH hosts they never asked for.
-    let config = load_config(&env.config_search);
+    let config = load_config_for_env(env);
     let resolved =
         config.as_ref().ok().and_then(|c| resolve_context(env, &c.hosts, &ctx));
 
@@ -401,7 +401,7 @@ async fn run(env: &Env, kind: &str, direction: Option<&str>) -> Result<()> {
 /// the invocation context like `remote-tab`/`remote-split` do, so a key bound
 /// inside a mirror workspace hides/shows whichever connection it's pressed in.
 async fn resolve_host(env: &Env, host_arg: Option<&str>) -> Result<HostConfig> {
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(env)?;
     if let Some(name) = host_arg {
         return config.hosts.iter().find(|h| h.name == name).cloned().ok_or_else(|| {
             let known: Vec<&str> = config.hosts.iter().map(|h| h.name.as_str()).collect();
@@ -427,9 +427,15 @@ pub async fn show_cmd(env: Env, host_arg: Option<&str>) -> Result<()> {
 
 async fn hide(env: &Env, host_arg: Option<&str>) -> Result<()> {
     let host = resolve_host(env, host_arg).await?;
-    let already = crate::state::is_hidden(&env.state_dir, &host.name);
-    crate::state::set_hidden(&env.state_dir, &host.name, true)
-        .map_err(|e| err(format!("could not mark {} hidden: {e}", host.name)))?;
+    let already = {
+        let _lock = crate::state::lock_host(&env.state_dir, &host.name)
+            .await
+            .map_err(|e| err(format!("could not lock state for {}: {e}", host.name)))?;
+        let already = crate::state::is_hidden(&env.state_dir, &host.name);
+        crate::state::set_hidden(&env.state_dir, &host.name, true)
+            .map_err(|e| err(format!("could not mark {} hidden: {e}", host.name)))?;
+        already
+    };
     // The daemon does the closing (mirror::apply_hidden): it owns the close
     // tracker, and an unmarked close is read back as user intent, which
     // close-through then aims at the remote once `show` rebuilds the mirrors
@@ -467,7 +473,7 @@ async fn show(env: &Env, host_arg: Option<&str>) -> Result<()> {
     // VISIBLE — a hidden one has no mapped workspace to resolve against — so a
     // context hit that is not hidden must fall through to "show everything",
     // or the key bound inside one mirror can never bring back another host.
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(env)?;
     let ctx = invocation_context();
     if let Some(host) = resolve_context(env, &config.hosts, &ctx).map(|r| r.host) {
         if crate::state::is_hidden(&env.state_dir, &host.name) {
@@ -477,7 +483,10 @@ async fn show(env: &Env, host_arg: Option<&str>) -> Result<()> {
     show_all(env).await
 }
 
-fn clear_hidden(env: &Env, host: &HostConfig) -> Result<bool> {
+async fn clear_hidden(env: &Env, host: &HostConfig) -> Result<bool> {
+    let _lock = crate::state::lock_host(&env.state_dir, &host.name)
+        .await
+        .map_err(|e| err(format!("could not lock state for {}: {e}", host.name)))?;
     if !crate::state::is_hidden(&env.state_dir, &host.name) {
         return Ok(false);
     }
@@ -487,7 +496,7 @@ fn clear_hidden(env: &Env, host: &HostConfig) -> Result<bool> {
 }
 
 async fn show_one(env: &Env, host: &HostConfig) -> Result<()> {
-    if !clear_hidden(env, host)? {
+    if !clear_hidden(env, host).await? {
         println!("{} is not hidden", host.name);
         return Ok(());
     }
@@ -496,10 +505,10 @@ async fn show_one(env: &Env, host: &HostConfig) -> Result<()> {
 }
 
 async fn show_all(env: &Env) -> Result<()> {
-    let config = load_config(&env.config_search)?;
+    let config = load_config_for_env(env)?;
     let mut shown = Vec::new();
     for h in &config.hosts {
-        if clear_hidden(env, h)? {
+        if clear_hidden(env, h).await? {
             shown.push(h.name.clone());
         }
     }
@@ -531,7 +540,7 @@ mod cwd_live_tests {
         let root = std::path::PathBuf::from(std::env::var("PR89_LIVE_ROOT").unwrap());
         let fixture: Value = serde_json::from_str(&std::fs::read_to_string(root.join("fixture.json")).unwrap()).unwrap();
         let env = Env {config_search: vec![root.clone()],state_dir:root.clone(),local_socket:root.join("unused.sock")};
-        let config = load_config(&env.config_search).unwrap();
+        let config = crate::config::load_config(&env.config_search).unwrap();
         let host = &config.hosts[0];
         let mut remote = RemoteHost::new(host, &root);
         let (api, _) = remote.connect_api().await.unwrap();
@@ -542,7 +551,17 @@ mod cwd_live_tests {
         api.request("tab.create", json!({"workspace_id":ws,"cwd":fixture["other"],"focus":true})).await.unwrap();
         let mut state = crate::state::HostState::default();
         state.workspaces.insert(ws.into(), crate::state::WsEntry {local_id:"local-ws".into(), tombstone:None,root_tab_local_id:None,last_remote_label:None});
-        state.panes.insert(pane.into(), crate::state::PaneEntry {local_id:"local-pane".into(),tombstone:None,seq:0,reported:None});
+        state.panes.insert(
+            pane.into(),
+            crate::state::PaneEntry {
+                local_id: "local-pane".into(),
+                tombstone: None,
+                seq: 0,
+                reported: None,
+                stream_slot: None,
+                workspace_id: None,
+            },
+        );
         crate::state::save_state(&root,&host.name,&state).unwrap();
         std::env::set_var("HERDR_PLUGIN_CONTEXT_JSON", r#"{"workspace_id":"local-ws","focused_pane_id":"local-pane"}"#);
         for kind in ["tab", "workspace", "split"] {

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,6 +8,7 @@
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -25,6 +26,27 @@ pub struct PaneEntry {
     /// when the remote agent goes away, or it sticks forever
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reported: Option<String>,
+    /// ssh stream-pool slot this pane's data stream is assigned to (see
+    /// `stream_pool`). `None` on every pane when pooling is off (the
+    /// default), and on any pane created before this field existed — a
+    /// pre-pooling `*-map.json` has no `streamSlot` key at all and deserializes
+    /// here exactly as it always did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_slot: Option<u32>,
+    /// Remote workspace this pane belongs to, set once when the pane is
+    /// first created/observed and never moved after — a pane doesn't change
+    /// workspace. Exists so a pane can still be recognized as belonging to a
+    /// (now) tombstoned workspace after it goes missing from a later,
+    /// transient/partial remote snapshot: without this, that association is
+    /// only ever visible in the exact pass that observed both the pane and
+    /// its workspace_id together, and `stream_pool_candidates`'s existing
+    /// "keep a once-off-missing pane's slot" restraint would otherwise let
+    /// it keep consuming pool capacity indefinitely once its workspace is
+    /// gone. `None` on any pane created before this field existed — a
+    /// pre-existing `*-map.json` has no `workspaceId` key and deserializes
+    /// here exactly as it always did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_id: Option<String>,
 }
 
 impl PaneEntry {
@@ -97,7 +119,8 @@ pub struct HostState {
 /// success having done nothing. A marker file has no such race: it is written by
 /// one process and only ever read by the others. Same shape as `daemon.paused`.
 pub fn hidden_path(state_dir: &Path, host: &str) -> PathBuf {
-    state_dir.join(format!("{host}.hidden"))
+    let (dir, stem) = crate::util::host_artifact_base(state_dir, host);
+    dir.join(format!("{stem}.hidden"))
 }
 
 pub fn is_hidden(state_dir: &Path, host: &str) -> bool {
@@ -133,7 +156,10 @@ pub fn set_hidden(state_dir: &Path, host: &str, hidden: bool) -> std::io::Result
 /// and the next streamer to start collected it, which was the replacement pane,
 /// reporting a move that had already finished.
 fn pane_hint_path(state_dir: &Path, local_pane_id: &str) -> PathBuf {
-    state_dir.join(format!(".hint-{}", crate::util::sane_component(local_pane_id)))
+    state_dir.join(format!(
+        ".hint-{}",
+        crate::util::sane_component(local_pane_id)
+    ))
 }
 
 pub fn set_pane_hint(state_dir: &Path, local_pane_id: &str, msg: &str) {
@@ -159,7 +185,8 @@ pub fn take_pane_hint(state_dir: &Path, local_pane_id: &str) -> Option<String> {
 }
 
 pub fn state_path(state_dir: &Path, host: &str) -> PathBuf {
-    state_dir.join(format!("{host}-map.json"))
+    let (dir, stem) = crate::util::host_artifact_base(state_dir, host);
+    dir.join(format!("{stem}-map.json"))
 }
 
 pub fn load_state(state_dir: &Path, host: &str) -> HostState {
@@ -169,10 +196,84 @@ pub fn load_state(state_dir: &Path, host: &str) -> HostState {
         .unwrap_or_default()
 }
 
+/// Write-then-rename, never an in-place truncate: `load_state` (and
+/// `status`, which reads this same file with no lock at all) must only ever
+/// see either the complete old content or the complete new content, never a
+/// partial write torn by a crash or a racing reader. The temp name is unique
+/// per call (pid + a nanosecond nonce), so a write that fails cleans up
+/// exactly the one file it created — never a glob over the state dir, which
+/// could delete a concurrent writer's own in-flight temp file. Created with
+/// mode 0600 regardless of umask: a pane's remote target/command in this
+/// state is not secret from its own owner, but there is no reason to leave it
+/// group/world-readable either, and umask can only narrow 0600 further, never
+/// widen it.
 pub fn save_state(state_dir: &Path, host: &str, state: &HostState) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
     std::fs::create_dir_all(state_dir)?;
-    std::fs::write(state_path(state_dir, host), serde_json::to_string_pretty(state)?)?;
+    let (dir, stem) = crate::util::host_artifact_base(state_dir, host);
+    let final_path = dir.join(format!("{stem}-map.json"));
+    let json = serde_json::to_string_pretty(state)?;
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    // Same directory as `final_path` — required for the rename below to be
+    // atomic (a cross-directory rename is not guaranteed to be, and for an
+    // unsafe host name `dir` is `.h/`, not `state_dir` itself).
+    let tmp_path = dir.join(format!(
+        ".{stem}-map.json.tmp-{}-{nonce}",
+        std::process::id()
+    ));
+    let result: std::io::Result<()> = (|| {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp_path)?;
+        f.write_all(json.as_bytes())?;
+        f.sync_all()?;
+        std::fs::rename(&tmp_path, &final_path)
+    })();
+    if let Err(e) = result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e.into());
+    }
     Ok(())
+}
+
+/// How long a converge/`once`/restore attempt waits for another holder of
+/// this host's state lock before giving up. Bounds contention against a
+/// wedged peer; the lock is held for as long as the transaction actually
+/// needs once acquired (this only bounds the WAIT to acquire it).
+pub const HOST_LOCK_BUDGET: Duration = Duration::from_secs(30);
+
+fn host_lock_path(state_dir: &Path, host: &str) -> PathBuf {
+    let (dir, stem) = crate::util::host_artifact_base(state_dir, host);
+    dir.join(format!("{stem}.state.lock"))
+}
+
+/// Acquire this host's per-host state-transaction lock: every code path that
+/// loads, mutates, and saves `<host>-map.json` (converge, status-flush,
+/// hide/show, mark-unknown, teardown, `once`) must hold this for the WHOLE
+/// load → mutate → save span, or the daemon and a separately-invoked `once`
+/// can each load a stale copy and one's save silently discards the other's
+/// changes. Distinct from the ssh master-socket lock in `remote.rs` — see
+/// `filelock`'s module doc for the required acquisition order between them
+/// (this one first, never the reverse).
+pub async fn lock_host(state_dir: &Path, host: &str) -> Result<crate::filelock::FileLock> {
+    std::fs::create_dir_all(state_dir)?;
+    crate::filelock::acquire_async(&host_lock_path(state_dir, host), HOST_LOCK_BUDGET).await
+}
+
+/// Same lock as `lock_host`, blocking the calling thread — for the rare
+/// synchronous call site (`cmd_restore`) that has no tokio runtime to run
+/// `lock_host` on. Bounded by the same `HOST_LOCK_BUDGET`, not an unbounded
+/// wait: a stuck holder must fail this loudly rather than hang the CLI.
+pub fn lock_host_blocking(state_dir: &Path, host: &str) -> Result<crate::filelock::FileLock> {
+    std::fs::create_dir_all(state_dir)?;
+    crate::filelock::acquire_blocking(&host_lock_path(state_dir, host), HOST_LOCK_BUDGET)
 }
 
 #[cfg(test)]
@@ -195,7 +296,10 @@ mod tests {
 }"#;
         let state: HostState = serde_json::from_str(ts).unwrap();
         assert_eq!(state.workspaces["w9"].local_id, "w1234");
-        assert_eq!(state.workspaces["w9"].root_tab_local_id.as_deref(), Some("t99"));
+        assert_eq!(
+            state.workspaces["w9"].root_tab_local_id.as_deref(),
+            Some("t99")
+        );
         assert!(state.workspaces["wB"].is_tombstoned());
         // a tab mapped before label history existed loads with none, which the
         // resolver reads as "remote wins once"
@@ -211,6 +315,414 @@ mod tests {
         assert!(out.contains("rootTabLocalId"));
         // absent options stay absent
         assert!(!out.contains("\"reported\":null"));
+    }
+
+    /// A pre-pooling (v0.4.1) `*-map.json` has no `streamSlot` key on any
+    /// pane at all — this must load as `None`, not fail to parse.
+    #[test]
+    fn pre_pooling_state_loads_with_no_stream_slot() {
+        let v0_4_1 = r#"{"panes": {"w9:p1": {"localId": "w1234:p1", "seq": 1}}}"#;
+        let state: HostState = serde_json::from_str(v0_4_1).unwrap();
+        assert_eq!(state.panes["w9:p1"].stream_slot, None);
+    }
+
+    /// A `*-map.json` written before `workspaceId` existed (v0.4.1, or this
+    /// feature's own earlier rounds) has no such key on any pane — this must
+    /// load as `None`, not fail to parse, exactly like `streamSlot` above.
+    #[test]
+    fn pre_workspace_tracking_state_loads_with_no_workspace_id() {
+        let legacy = r#"{"panes": {"w9:p1": {"localId": "w1234:p1", "seq": 1, "streamSlot": 2}}}"#;
+        let state: HostState = serde_json::from_str(legacy).unwrap();
+        assert_eq!(state.panes["w9:p1"].workspace_id, None);
+        assert_eq!(state.panes["w9:p1"].stream_slot, Some(2));
+    }
+
+    /// A `""`/`"."`/`".."`-named host's `*-map.json` written by a
+    /// pre-this-round daemon (which already put it at exactly this path,
+    /// since these names were never actually unsafe — see
+    /// `dot_and_empty_host_names_stay_at_the_root_like_v0_4_1`) must still
+    /// load, at the same path, on this version.
+    #[test]
+    fn legacy_state_for_a_dot_or_empty_host_name_still_loads() {
+        for host in ["", ".", ".."] {
+            let dir = tmpdir("legacy-dot-load");
+            let path = state_path(&dir, host);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &path,
+                r#"{"panes": {"w9:p1": {"localId": "w1234:p1", "seq": 1}}}"#,
+            )
+            .unwrap();
+            let state = load_state(&dir, host);
+            assert_eq!(state.panes["w9:p1"].local_id, "w1234:p1", "{host:?}");
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+
+    /// `streamSlot` round-trips like every other optional field: present when
+    /// assigned, omitted (not `null`) when not, so an unpooled host's state
+    /// file stays untouched by the feature's existence.
+    #[test]
+    fn stream_slot_serializes_only_when_assigned() {
+        let mut entry = PaneEntry {
+            local_id: "l1".into(),
+            tombstone: None,
+            seq: 0,
+            reported: None,
+            stream_slot: None,
+            workspace_id: None,
+        };
+        let out = serde_json::to_string(&entry).unwrap();
+        assert!(!out.contains("streamSlot"), "{out}");
+
+        entry.stream_slot = Some(3);
+        let out = serde_json::to_string(&entry).unwrap();
+        assert!(out.contains("\"streamSlot\":3"), "{out}");
+        let reparsed: PaneEntry = serde_json::from_str(&out).unwrap();
+        assert_eq!(reparsed.stream_slot, Some(3));
+    }
+
+    /// `workspaceId` round-trips the same way: present once observed,
+    /// omitted (not `null`) before that.
+    #[test]
+    fn workspace_id_serializes_only_when_known() {
+        let mut entry = PaneEntry {
+            local_id: "l1".into(),
+            tombstone: None,
+            seq: 0,
+            reported: None,
+            stream_slot: None,
+            workspace_id: None,
+        };
+        let out = serde_json::to_string(&entry).unwrap();
+        assert!(!out.contains("workspaceId"), "{out}");
+
+        entry.workspace_id = Some("w1".into());
+        let out = serde_json::to_string(&entry).unwrap();
+        assert!(out.contains("\"workspaceId\":\"w1\""), "{out}");
+        let reparsed: PaneEntry = serde_json::from_str(&out).unwrap();
+        assert_eq!(reparsed.workspace_id, Some("w1".into()));
+    }
+
+    /// Same nonce-collision fix as `filelock::tests::test_path`: pid + nanos
+    /// alone is not enough under a genuinely parallel full-suite run.
+    fn tmpdir(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let salt = &counter as *const u64 as usize;
+        let unique = crate::util::short_hash(&format!(
+            "{}-{nanos}-{counter}-{salt:x}",
+            std::process::id()
+        ));
+        let dir = std::env::temp_dir().join(format!("hm-state-{tag}-{unique}"));
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn save_state_round_trips_and_leaves_no_temp_file_behind() {
+        let dir = tmpdir("save-clean");
+        let mut state = HostState::default();
+        state.panes.insert(
+            "p1".into(),
+            PaneEntry {
+                local_id: "l1".into(),
+                tombstone: None,
+                seq: 0,
+                reported: None,
+                stream_slot: Some(2),
+                workspace_id: None,
+            },
+        );
+        save_state(&dir, "h", &state).unwrap();
+        let reloaded = load_state(&dir, "h");
+        assert_eq!(reloaded.panes["p1"].stream_slot, Some(2));
+
+        let names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(!names.iter().any(|n| n.contains(".tmp-")), "{names:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn save_state_writes_a_private_map_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tmpdir("save-mode");
+        save_state(&dir, "h", &HostState::default()).unwrap();
+        let mode = std::fs::metadata(state_path(&dir, "h"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "the renamed map file must keep the temp file's private mode"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A failed save (here: the final path is sabotaged into a directory, so
+    /// the atomic rename itself fails) must clean up exactly its own temp
+    /// file and never touch anything else in the state dir.
+    #[test]
+    fn save_state_cleans_up_its_own_temp_file_on_failure() {
+        let dir = tmpdir("save-fail");
+        std::fs::create_dir_all(state_path(&dir, "h")).unwrap(); // sabotage: rename onto a dir fails
+        assert!(save_state(&dir, "h", &HostState::default()).is_err());
+        let names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert!(!names.iter().any(|n| n.contains(".tmp-")), "{names:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The property atomicity exists for: a reader must never observe a
+    /// torn/partial write, only ever the complete old or complete new
+    /// content — proven by racing a reader against many rapid saves.
+    #[test]
+    fn concurrent_readers_never_observe_a_torn_write() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let dir = tmpdir("torn-write");
+        save_state(&dir, "h", &HostState::default()).unwrap();
+        let path = state_path(&dir, "h");
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader_path = path.clone();
+        let reader_stop = stop.clone();
+        let reader = std::thread::spawn(move || {
+            while !reader_stop.load(Ordering::Relaxed) {
+                if let Ok(content) = std::fs::read_to_string(&reader_path) {
+                    assert!(
+                        serde_json::from_str::<HostState>(&content).is_ok(),
+                        "torn read: {content}"
+                    );
+                }
+            }
+        });
+        for i in 0..200 {
+            let mut s = HostState::default();
+            s.panes.insert(
+                format!("p{i}"),
+                PaneEntry {
+                    local_id: format!("l{i}"),
+                    tombstone: None,
+                    seq: i,
+                    reported: None,
+                    stream_slot: None,
+                    workspace_id: None,
+                },
+            );
+            save_state(&dir, "h", &s).unwrap();
+        }
+        stop.store(true, Ordering::Relaxed);
+        reader.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The actual correctness property `lock_host`/`lock_host_blocking` exist
+    /// for: two concurrent holders of the same host's lock must never be
+    /// inside the locked section together.
+    #[tokio::test]
+    async fn lock_host_excludes_concurrent_holders() {
+        let dir = tmpdir("host-lock");
+        let _first = lock_host(&dir, "h").await.unwrap();
+        let second = tokio::time::timeout(Duration::from_millis(200), lock_host(&dir, "h")).await;
+        assert!(
+            second.is_err() || second.unwrap().is_err(),
+            "a second holder must not acquire while the first is held"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Regression for the hide/show race: `apply_hidden` (mirror.rs) peeks
+    /// the hidden marker lock-free, then must re-check it AFTER acquiring
+    /// the host lock before deciding to close anything — `clear_hidden`
+    /// (remote_action.rs, `show`) clearing the marker under the same lock
+    /// must never be invisible to an `apply_hidden` pass already queued
+    /// behind it. This exercises the exact lock/re-check protocol both call
+    /// sites use, with the real `lock_host`/`is_hidden`/`set_hidden`
+    /// primitives — no ApiClient is needed for this decision, only for the
+    /// RPC calls after it, which is why this is deterministic here.
+    #[tokio::test]
+    async fn hidden_marker_race_is_resolved_by_lock_and_recheck() {
+        let dir = tmpdir("hide-show-race");
+        set_hidden(&dir, "h", true).unwrap();
+
+        // apply_hidden's lock-free peek, before it ever tries to acquire the lock
+        assert!(
+            is_hidden(&dir, "h"),
+            "peek must see the marker before the race plays out"
+        );
+
+        // `show` wins the lock first and holds it while it clears the marker
+        let show_lock = lock_host(&dir, "h").await.unwrap();
+        let apply_hidden_attempt = tokio::spawn({
+            let dir = dir.clone();
+            async move {
+                let _lock = lock_host(&dir, "h").await.unwrap();
+                // re-check, exactly like apply_hidden does once it holds the lock
+                is_hidden(&dir, "h")
+            }
+        });
+        // give the spawned attempt a moment to start waiting on the lock `show` holds
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        set_hidden(&dir, "h", false).unwrap(); // show's mutation, still under show_lock
+        drop(show_lock); // release — only now can the queued attempt proceed
+
+        let rechecked_hidden = apply_hidden_attempt.await.unwrap();
+        assert!(
+            !rechecked_hidden,
+            "the post-lock re-check must see show's clear, not the stale peek"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lock_host_blocking_and_lock_host_use_the_same_lock_file() {
+        let dir = tmpdir("host-lock-shared");
+        let _held = lock_host_blocking(&dir, "h").unwrap();
+        // a nonblocking attempt on the identical path must see it as taken
+        assert!(crate::filelock::try_lock_nb(&host_lock_path(&dir, "h"))
+            .unwrap()
+            .is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Regression: a host name is a user-chosen TOML table key, not a
+    /// validated filename. Every host-derived path must stay contained
+    /// under the private `.h/` subdirectory for a name that is
+    /// `/`-separated — a raw `/` is the one thing no suffix can
+    /// neutralize, unlike `.`/`..`/empty (see
+    /// `dot_and_empty_host_names_stay_at_the_root_like_v0_4_1`).
+    #[test]
+    fn host_derived_paths_stay_contained_for_unsafe_host_names() {
+        let dir = tmpdir("contain");
+        let hosts_dir = crate::util::unsafe_host_artifacts_dir(&dir);
+        for unsafe_name in ["../../escape", "a/b", "/etc/passwd"] {
+            for path in [
+                hidden_path(&dir, unsafe_name),
+                state_path(&dir, unsafe_name),
+                host_lock_path(&dir, unsafe_name),
+            ] {
+                assert_eq!(
+                    path.parent(),
+                    Some(hosts_dir.as_path()),
+                    "{unsafe_name} -> {}",
+                    path.display()
+                );
+                assert!(
+                    path.starts_with(&dir),
+                    "{unsafe_name} -> {} must stay within state_dir",
+                    path.display()
+                );
+            }
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The private `.h/` subdirectory itself must be created mode 0700,
+    /// not left to whatever umask the process happens to run under.
+    #[test]
+    fn unsafe_host_artifacts_dir_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tmpdir("contain-mode");
+        let _ = hidden_path(&dir, "a/b"); // side effect: creates .h/
+        let hosts_dir = crate::util::unsafe_host_artifacts_dir(&dir);
+        let mode = std::fs::metadata(&hosts_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Ordinary host names must keep the exact paths every existing install
+    /// already uses on disk — only a name that could otherwise escape or
+    /// nest outside `state_dir` may move.
+    #[test]
+    fn host_derived_paths_are_unchanged_for_ordinary_host_names() {
+        let dir = tmpdir("no-migrate");
+        assert_eq!(hidden_path(&dir, "azure"), dir.join("azure.hidden"));
+        assert_eq!(state_path(&dir, "rdev"), dir.join("rdev-map.json"));
+        assert_eq!(host_lock_path(&dir, "rdev"), dir.join("rdev.state.lock"));
+    }
+
+    /// The exact compatibility break a later review reported: a host
+    /// literally named `h#prod` (a safe, single-component TOML table key,
+    /// quoted) is not reserved for anything — it keeps its exact v0.4.1
+    /// root-level path, same as `azure`/`rdev` above.
+    #[test]
+    fn host_derived_paths_keep_an_h_hash_prefixed_name_at_the_root_too() {
+        let dir = tmpdir("no-migrate-h-hash");
+        assert_eq!(hidden_path(&dir, "h#prod"), dir.join("h#prod.hidden"));
+        assert_eq!(state_path(&dir, "h#prod"), dir.join("h#prod-map.json"));
+        assert_eq!(
+            host_lock_path(&dir, "h#prod"),
+            dir.join("h#prod.state.lock")
+        );
+    }
+
+    /// The exact compatibility break a later review reported: every
+    /// artifact appends a suffix before joining, so a host named
+    /// `""`/`"."`/`".."` (all syntactically valid, if unusual, quoted TOML
+    /// keys) never reaches `Path::join` as a bare special component —
+    /// these must stay at the root with their exact v0.4.1 path, not be
+    /// diverted into `.h/`. A backslash is likewise an ordinary character
+    /// on macOS/Linux, not a separator, so it stays safe too.
+    #[test]
+    fn dot_and_empty_host_names_stay_at_the_root_like_v0_4_1() {
+        let dir = tmpdir("no-migrate-dots");
+        assert_eq!(hidden_path(&dir, ""), dir.join(".hidden"));
+        assert_eq!(state_path(&dir, ""), dir.join("-map.json"));
+        assert_eq!(host_lock_path(&dir, ""), dir.join(".state.lock"));
+
+        assert_eq!(hidden_path(&dir, "."), dir.join("..hidden"));
+        assert_eq!(state_path(&dir, "."), dir.join(".-map.json"));
+        assert_eq!(host_lock_path(&dir, "."), dir.join("..state.lock"));
+
+        assert_eq!(hidden_path(&dir, ".."), dir.join("...hidden"));
+        assert_eq!(state_path(&dir, ".."), dir.join("..-map.json"));
+        assert_eq!(host_lock_path(&dir, ".."), dir.join("...state.lock"));
+
+        assert_eq!(hidden_path(&dir, "a\\b"), dir.join("a\\b.hidden"));
+    }
+
+    /// The exact bug an independent review reported: an unsafe host name's
+    /// hash must not coincide with a distinct, ordinary safe host name that
+    /// happens to look like a hash. Directory separation (not a reserved
+    /// prefix) is why: the two are never even candidates to collide, since
+    /// they live in different directories regardless of stem text.
+    #[test]
+    fn state_paths_do_not_collide_for_the_reported_pair() {
+        let dir = tmpdir("no-collide");
+        let unsafe_name = "x/EaL2b7VcKy";
+        let lookalike_safe_name = "92f037a4";
+        assert_ne!(
+            state_path(&dir, unsafe_name),
+            state_path(&dir, lookalike_safe_name)
+        );
+        assert_ne!(
+            hidden_path(&dir, unsafe_name),
+            hidden_path(&dir, lookalike_safe_name)
+        );
+        assert_ne!(
+            host_lock_path(&dir, unsafe_name),
+            host_lock_path(&dir, lookalike_safe_name)
+        );
+        assert_eq!(
+            state_path(&dir, lookalike_safe_name),
+            dir.join(format!("{lookalike_safe_name}-map.json"))
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -237,7 +749,10 @@ mod tests {
         // not the neighbour's: an unaddressed notice is what let the
         // REPLACEMENT pane announce a move that had already finished
         assert_eq!(take_pane_hint(&dir, "wBT:p3"), None);
-        assert_eq!(take_pane_hint(&dir, "wBT:p2").as_deref(), Some("closing the local tab"));
+        assert_eq!(
+            take_pane_hint(&dir, "wBT:p2").as_deref(),
+            Some("closing the local tab")
+        );
         // consumed, so a repaint doesn't resurrect it
         assert_eq!(take_pane_hint(&dir, "wBT:p2"), None);
         let _ = std::fs::remove_dir_all(&dir);
@@ -255,7 +770,10 @@ mod tests {
             .unwrap()
             .as_secs() as i64
             - 120;
-        let t = libc::timeval { tv_sec: secs, tv_usec: 0 };
+        let t = libc::timeval {
+            tv_sec: secs,
+            tv_usec: 0,
+        };
         let c = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
         assert_eq!(unsafe { libc::utimes(c.as_ptr(), [t, t].as_ptr()) }, 0);
         assert_eq!(take_pane_hint(&dir, "wBT:p2"), None);

--- a/src/stream_pool.rs
+++ b/src/stream_pool.rs
@@ -1,0 +1,232 @@
+// Pane-to-slot allocation for ssh stream pooling (`ssh_streams_per_connection`
+// in hosts.toml). A slot is one shared ssh ControlMaster connection; up to
+// `capacity` pane streams may multiplex sessions onto it (see remote.rs's
+// `stream_control_path` / `ensure_stream_master` for the sockets themselves).
+//
+// Deliberately not hash/modulo: that can't guarantee the per-slot capacity
+// bound (two pane ids can hash to the same slot however many are already
+// there), and it reshuffles every pane whenever the pane count changes.
+// `allocate` instead keeps every still-valid assignment exactly where it is
+// and only places panes that need a new home.
+
+use std::collections::{BTreeMap, HashMap};
+
+/// Assign every pane in `panes` to a slot in `[0, ceil(len/capacity))` so no
+/// slot ends up with more than `capacity` panes.
+///
+/// `panes` maps each live pane id to its current slot, if any — `None` for a
+/// pane that has never been assigned. Iteration order matters: callers pass a
+/// `BTreeMap` so retained assignments are decided in the same deterministic
+/// pane-id order on every call, which is what makes a converge pass's result
+/// reproducible independent of remote event ordering.
+///
+/// Two passes: first keep every assignment that still fits under its slot's
+/// capacity (processed in pane-id order, so if a slot is over capacity —
+/// stale state after `capacity` shrank, or corrupt state with too many panes
+/// crammed into one slot — only the first `capacity` panes by id keep it and
+/// the rest fall through). Second, first-fit every still-unassigned pane into
+/// the lowest-numbered slot with spare room, opening a new slot only once
+/// every existing one is full. This is what fills capacity a removed pane
+/// freed before growing the slot count, and what keeps a pure growth in
+/// `capacity` (same panes, larger N) from moving anyone: every existing
+/// assignment already fits and pass one keeps all of them.
+pub fn allocate(panes: &BTreeMap<String, Option<u32>>, capacity: usize) -> BTreeMap<String, u32> {
+    assert!(capacity >= 1, "stream pool capacity must be at least 1");
+    let mut occupancy: HashMap<u32, usize> = HashMap::new();
+    let mut result: BTreeMap<String, u32> = BTreeMap::new();
+    let mut unassigned: Vec<&String> = Vec::new();
+
+    // No legitimate allocation ever needs more slots than panes (worst case:
+    // capacity 1, one pane per slot), so a persisted slot at or past this
+    // bound is stale/corrupt — from a since-shrunk pane set, or hand-edited
+    // state — and is reassigned rather than trusted.
+    let max_valid_slot = panes.len() as u32;
+    for (pane, slot) in panes {
+        match slot {
+            Some(s) if *s < max_valid_slot && *occupancy.get(s).unwrap_or(&0) < capacity => {
+                *occupancy.entry(*s).or_insert(0) += 1;
+                result.insert(pane.clone(), *s);
+            }
+            _ => unassigned.push(pane),
+        }
+    }
+
+    let mut next_new_slot = occupancy.keys().max().map_or(0, |m| m + 1);
+    for pane in unassigned {
+        let slot = (0..next_new_slot)
+            .find(|s| *occupancy.get(s).unwrap_or(&0) < capacity)
+            .unwrap_or_else(|| {
+                let s = next_new_slot;
+                next_new_slot += 1;
+                s
+            });
+        *occupancy.entry(slot).or_insert(0) += 1;
+        result.insert(pane.clone(), slot);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh(ids: &[&str]) -> BTreeMap<String, Option<u32>> {
+        ids.iter().map(|s| (s.to_string(), None)).collect()
+    }
+
+    fn occupancy(assigned: &BTreeMap<String, u32>) -> BTreeMap<u32, usize> {
+        let mut counts: BTreeMap<u32, usize> = BTreeMap::new();
+        for slot in assigned.values() {
+            *counts.entry(*slot).or_insert(0) += 1;
+        }
+        counts
+    }
+
+    #[test]
+    fn no_slot_exceeds_capacity() {
+        let panes = fresh(&["p1", "p2", "p3", "p4", "p5", "p6", "p7"]);
+        let assigned = allocate(&panes, 3);
+        assert_eq!(assigned.len(), 7);
+        for count in occupancy(&assigned).values() {
+            assert!(*count <= 3, "{:?}", occupancy(&assigned));
+        }
+        // 7 panes at capacity 3 need 3 slots (3+3+1), not 7 (one per pane)
+        assert_eq!(occupancy(&assigned).len(), 3);
+    }
+
+    /// Also the proof that capacity is a per-slot pane-count bound, not a
+    /// slot count: capacity 2 still reaches slot index 2 (a 3rd slot) once
+    /// a 5th pane needs one, since `ceil(5/2) = 3` slots are needed however
+    /// small the configured capacity is (see `config::validate_unique_stream_namespaces`'s
+    /// doc comment for why that distinction rules out slot enumeration
+    /// there).
+    #[test]
+    fn fresh_panes_fill_the_lowest_slot_first() {
+        let panes = fresh(&["p1", "p2", "p3", "p4", "p5"]);
+        let assigned = allocate(&panes, 2);
+        // BTreeMap iteration is pane-id order, so p1..p5 fill 0,0,1,1,2
+        assert_eq!(assigned["p1"], 0);
+        assert_eq!(assigned["p2"], 0);
+        assert_eq!(assigned["p3"], 1);
+        assert_eq!(assigned["p4"], 1);
+        assert_eq!(assigned["p5"], 2);
+    }
+
+    /// A converge pass that changes nothing must reassign nothing — the whole
+    /// point of persisting slots instead of recomputing hash/modulo.
+    #[test]
+    fn stable_assignments_are_retained_across_reconciliation() {
+        let mut panes: BTreeMap<String, Option<u32>> = BTreeMap::new();
+        panes.insert("p1".into(), None);
+        panes.insert("p2".into(), None);
+        panes.insert("p3".into(), None);
+        let first = allocate(&panes, 2);
+
+        let again: BTreeMap<String, Option<u32>> =
+            first.iter().map(|(k, v)| (k.clone(), Some(*v))).collect();
+        let second = allocate(&again, 2);
+        assert_eq!(
+            first, second,
+            "an unchanged pane set must get the identical assignment back"
+        );
+    }
+
+    /// Growing capacity must not move a single existing pane: every retained
+    /// assignment already satisfies a larger cap, so pass one keeps all of
+    /// them and nothing reaches the first-fit pass.
+    #[test]
+    fn growing_capacity_moves_nobody() {
+        let panes = fresh(&["p1", "p2", "p3", "p4", "p5"]);
+        let at_two = allocate(&panes, 2);
+
+        let carried: BTreeMap<String, Option<u32>> =
+            at_two.iter().map(|(k, v)| (k.clone(), Some(*v))).collect();
+        let at_five = allocate(&carried, 5);
+        assert_eq!(at_two, at_five, "growth must not rebalance survivors");
+    }
+
+    /// Removing a pane must free its slot for the next unassigned pane before
+    /// any new slot opens.
+    #[test]
+    fn removal_frees_capacity_before_a_new_slot_opens() {
+        let panes = fresh(&["p1", "p2", "p3", "p4"]);
+        let assigned = allocate(&panes, 2); // p1,p2 -> 0; p3,p4 -> 1
+
+        // p2 leaves, p5 arrives
+        let mut next: BTreeMap<String, Option<u32>> = BTreeMap::new();
+        next.insert("p1".into(), Some(assigned["p1"]));
+        next.insert("p3".into(), Some(assigned["p3"]));
+        next.insert("p4".into(), Some(assigned["p4"]));
+        next.insert("p5".into(), None);
+        let reassigned = allocate(&next, 2);
+
+        assert_eq!(reassigned["p1"], assigned["p1"], "survivor must not move");
+        assert_eq!(reassigned["p3"], assigned["p3"], "survivor must not move");
+        assert_eq!(reassigned["p4"], assigned["p4"], "survivor must not move");
+        assert_eq!(
+            reassigned["p5"], assigned["p1"],
+            "p5 must fill p2's freed seat, not slot 2"
+        );
+        assert_eq!(occupancy(&reassigned).len(), 2, "no new slot needed");
+    }
+
+    /// Shrinking N must move only the panes that no longer fit, never a
+    /// pane that already satisfies the smaller cap.
+    #[test]
+    fn shrinking_capacity_moves_only_the_required_overflow() {
+        let panes = fresh(&["p1", "p2", "p3", "p4"]);
+        let at_four = allocate(&panes, 4); // all four in slot 0
+
+        let carried: BTreeMap<String, Option<u32>> =
+            at_four.iter().map(|(k, v)| (k.clone(), Some(*v))).collect();
+        let at_two = allocate(&carried, 2);
+
+        // pane-id order keeps the first two in slot 0; only the overflow moves
+        assert_eq!(at_two["p1"], 0);
+        assert_eq!(at_two["p2"], 0);
+        assert_eq!(at_two["p3"], 1);
+        assert_eq!(at_two["p4"], 1);
+    }
+
+    /// Stale/corrupt state can have more panes recorded against one slot than
+    /// the current capacity allows (e.g. hand-edited state, or a capacity
+    /// lowered while the daemon was stopped). Only the excess — by pane-id
+    /// order — may move; the allocator must not treat the whole slot as
+    /// invalid.
+    #[test]
+    fn over_capacity_state_only_bumps_the_excess() {
+        let mut panes: BTreeMap<String, Option<u32>> = BTreeMap::new();
+        panes.insert("p1".into(), Some(0));
+        panes.insert("p2".into(), Some(0));
+        panes.insert("p3".into(), Some(0));
+        let assigned = allocate(&panes, 2);
+        assert_eq!(assigned["p1"], 0);
+        assert_eq!(assigned["p2"], 0);
+        assert_ne!(assigned["p3"], 0, "p3 overflows slot 0's capacity of 2");
+        assert_eq!(assigned["p3"], 1);
+    }
+
+    /// A stale slot number that no longer exists at all (e.g. left over from
+    /// a much larger N) must not panic and must be treated as unassigned.
+    #[test]
+    fn a_wildly_out_of_range_stale_slot_is_reassigned() {
+        let mut panes: BTreeMap<String, Option<u32>> = BTreeMap::new();
+        panes.insert("p1".into(), Some(9999));
+        let assigned = allocate(&panes, 2);
+        assert_eq!(assigned["p1"], 0);
+    }
+
+    #[test]
+    fn empty_input_yields_no_assignments() {
+        assert!(allocate(&BTreeMap::new(), 4).is_empty());
+    }
+
+    #[test]
+    fn capacity_of_one_gives_every_pane_its_own_slot() {
+        let panes = fresh(&["p1", "p2", "p3"]);
+        let assigned = allocate(&panes, 1);
+        let mut slots: Vec<u32> = assigned.values().copied().collect();
+        slots.sort_unstable();
+        assert_eq!(slots, vec![0, 1, 2]);
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -69,7 +69,11 @@ impl Env {
                 PathBuf::from(sock)
             }
         };
-        Ok(Env { config_search, state_dir, local_socket })
+        Ok(Env {
+            config_search,
+            state_dir,
+            local_socket,
+        })
     }
 }
 
@@ -173,9 +177,11 @@ pub fn cli_link_state() -> CliLink {
 pub fn cli_link_problem() -> Option<String> {
     match cli_link_state() {
         CliLink::Missing => Some(format!("{} is missing", cli_link_path().display())),
-        CliLink::Dangling(t) => {
-            Some(format!("{} dangles (-> {})", cli_link_path().display(), t.display()))
-        }
+        CliLink::Dangling(t) => Some(format!(
+            "{} dangles (-> {})",
+            cli_link_path().display(),
+            t.display()
+        )),
         _ => None,
     }
 }
@@ -233,12 +239,19 @@ pub struct Logger {
 
 impl Logger {
     pub fn new(state_dir: &Path, also_stdout: bool) -> Logger {
-        Logger { file: state_dir.join("daemon.log"), also_stdout }
+        Logger {
+            file: state_dir.join("daemon.log"),
+            also_stdout,
+        }
     }
 
     pub fn log(&self, msg: &str) {
         let line = format!("{} {}\n", now_iso(), msg);
-        if let Ok(mut f) = fs::OpenOptions::new().create(true).append(true).open(&self.file) {
+        if let Ok(mut f) = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.file)
+        {
             let _ = f.write_all(line.as_bytes());
         }
         if self.also_stdout {
@@ -297,13 +310,151 @@ pub fn pid_alive(pid: i32) -> bool {
 /// took, and retype it when it didn't.
 /// Squash anything that isn't `[A-Za-z0-9]` so an id can name a file.
 pub fn sane_component(s: &str) -> String {
-    s.chars().map(|c| if c.is_ascii_alphanumeric() { c } else { '_' }).collect()
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// FNV-1a, 64-bit, as 16 hex chars.
+///
+/// NOT `DefaultHasher`: values derived from this land in paths the daemon
+/// and every streamer must derive identically, and it has to survive a
+/// toolchain upgrade. std's hasher is explicitly unstable across Rust
+/// releases, so a bump would silently move a host's socket and orphan its
+/// live ControlMaster. FNV-1a is a published algorithm, so the output is
+/// fixed by spec rather than by implementation detail. Full 64-bit output
+/// (not truncated to 32) keeps a real collision astronomically unlikely.
+/// `short_hash_is_stable` (below) pins the exact value so a future swap
+/// cannot move anyone's paths unnoticed. Not used for the control-plane
+/// `.ctl` socket of a long SAFE host name — see `remote::legacy_socket_hash`
+/// for why that one path stays on the original 32-bit value.
+///
+/// Hashes the raw bytes rather than going through `Hash for str`, which
+/// appends a terminator byte and would give a different (still stable, but
+/// arbitrary) value.
+pub fn short_hash(s: &str) -> String {
+    use std::hash::Hasher;
+
+    let mut hasher = fnv::FnvHasher::default();
+    hasher.write(s.as_bytes());
+    format!("{:016x}", hasher.finish())
+}
+
+/// Whether `s` is safe to use as a host-artifact stem at the root of
+/// `state_dir`: every artifact this crate derives from a host name (state
+/// map, hidden marker, host lock, atomic temp file, control-plane socket)
+/// always appends a suffix (`.ctl`, `-map.json`, `.hidden`, `.state.lock`)
+/// — and the atomic temp file a leading `.` too — before joining, so the
+/// bare stem is never the WHOLE path component by itself. That is what
+/// makes `.`/`..`/empty harmless here even though `Path::join` would
+/// resolve a BARE `.`/`..` component as "here"/"parent": `format!("{stem}.ctl")`
+/// with stem `.` or `..` produces the literal filenames `..ctl`/`...ctl`
+/// (or `.ctl` for an empty stem), never the actual one/two-character
+/// special components. A raw `/` is the one thing no suffix can
+/// neutralize — it embeds a component boundary in the MIDDLE of a
+/// filename, wherever it falls — and NUL is invalid in a Unix filename at
+/// all, so those two are the only bytes that require hashing away instead
+/// (see `unsafe_host_artifacts_dir`). A backslash is an ordinary character
+/// on this crate's only supported platforms (macOS/Linux), not a
+/// separator, so it does not need excluding either.
+///
+/// Nothing is reserved beyond that: an unusual-but-safe name (an
+/// `h#`-prefixed one, an empty one, a bare `.`/`..` one, all included) is
+/// exactly as safe as any other and stays at the root of `state_dir` with
+/// its untouched v0.4.1 path. Disjointness between a root-level safe name
+/// and an internal hashed artifact comes from directory structure
+/// (`unsafe_host_artifacts_dir`, `remote`'s `.s`) — see their doc comments
+/// — never from excluding any particular name.
+pub fn is_safe_path_component(s: &str) -> bool {
+    !s.contains('/') && !s.contains('\0')
+}
+
+/// Directory for every artifact derived from an UNSAFE host name (state
+/// map, hidden marker, host lock, atomic temp file, control-plane socket):
+/// a host name is a user-chosen TOML table key, so nothing stops it from
+/// containing a `/` or embedding a NUL, neither of which any suffix can
+/// keep contained to one literal filename (see `is_safe_path_component`).
+/// Named `.h`, not `.hosts`, to leave more of the sockaddr_un budget for
+/// the hashed stem itself once this is nested under `state_dir` (see
+/// `remote::control_socket_base`, which validates the result against that
+/// budget). Private (mode 0700, via `ensure_private_dir`) and, critically,
+/// structurally disjoint from every root-level safe-name path right next
+/// to it: two different directories can never produce the same full path
+/// no matter what either one's stem looks like, which is what makes this
+/// safe as the sole disjointness mechanism — no reserved filename prefix
+/// needed, and so no safe name (an `h#`-prefixed, empty, or dot-only one
+/// included) is ever diverted from its exact v0.4.1 path.
+pub fn unsafe_host_artifacts_dir(state_dir: &Path) -> PathBuf {
+    state_dir.join(".h")
+}
+
+/// Stable stem for an unsafe host name's artifacts within
+/// `unsafe_host_artifacts_dir`: its 64-bit hash. Two DIFFERENT unsafe host
+/// names sharing this stem would be a real (astronomically unlikely) 64-bit
+/// collision; `config::validate_unique_host_stems` checks for it at config
+/// load.
+pub fn unsafe_host_stem(host_name: &str) -> String {
+    short_hash(host_name)
+}
+
+/// Create `dir` (and its ancestors) with mode 0700 if it doesn't already
+/// exist: every internal-artifacts subdirectory (`unsafe_host_artifacts_dir`,
+/// `remote`'s `.s`) holds hashed-but-still-identifying material for hosts
+/// that couldn't safely live at the root, so it shouldn't be
+/// group/world-traversable even if `state_dir` itself is looser. A no-op,
+/// not an error, if the directory already exists (mirrors `create_dir_all`);
+/// mode only applies at creation, so a pre-existing directory's permissions
+/// are left alone.
+pub fn ensure_private_dir(dir: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(dir)
+}
+
+/// Base directory + filename stem for a host-derived artifact (state map,
+/// hidden marker, host lock, atomic temp file): the root of `state_dir`
+/// with the host name used verbatim when it's safe — the common case, and
+/// the one every existing install's paths already use, completely
+/// unmodified — or `unsafe_host_artifacts_dir` with its hashed stem
+/// otherwise. Config resolution additionally rejects two configured unsafe
+/// hosts whose hash collides outright (see
+/// `config::validate_unique_host_stems`), so that check is defense in
+/// depth, not the only guard against a real (astronomically unlikely)
+/// 64-bit collision. NOT used for the control-plane socket — see
+/// `remote::control_socket_base`, which has a separate, sockaddr_un-budget-
+/// aware path for a safe but overlong name.
+pub fn host_artifact_base(state_dir: &Path, host_name: &str) -> (PathBuf, String) {
+    if is_safe_path_component(host_name) {
+        (state_dir.to_path_buf(), host_name.to_string())
+    } else {
+        let dir = unsafe_host_artifacts_dir(state_dir);
+        let _ = ensure_private_dir(&dir);
+        (dir, unsafe_host_stem(host_name))
+    }
+}
+
+/// 64-bit hash identifying one host+target stream-pool namespace — the set
+/// of slot sockets a pooled ssh host's pane streams for one target can use
+/// — shared by `remote::stream_control_path` (which appends a fixed-width
+/// slot suffix on top, see there) and `config::validate_unique_stream_namespaces`
+/// (checked once per pooled host, not per slot: `ssh_streams_per_connection`
+/// is a per-slot pane-count *capacity*, not a slot count, so a config-time
+/// check can never enumerate "every slot" — the number of slots actually
+/// used depends on how many panes are open, not on this number, and can
+/// exceed it) — one implementation so the two can never drift on what "the
+/// same namespace" means.
+pub fn stream_namespace_hash(host_name: &str, target: &str) -> String {
+    short_hash(&format!("{host_name}\u{0}{target}"))
 }
 
 pub fn streamer_pid_path(state_dir: &Path, ssh_target: &str, pane_target: &str) -> PathBuf {
-    state_dir
-        .join("streamer-pids")
-        .join(format!("{}--{}.pid", sane_component(ssh_target), sane_component(pane_target)))
+    state_dir.join("streamer-pids").join(format!(
+        "{}--{}.pid",
+        sane_component(ssh_target),
+        sane_component(pane_target)
+    ))
 }
 
 /// A launch claim exists from the first local `pane.send_text` until the
@@ -311,7 +462,9 @@ pub fn streamer_pid_path(state_dir: &Path, ssh_target: &str, pane_target: &str) 
 /// that pane during this interval: the first streamer can already own stdin
 /// even when herdr's process snapshot still reports the shell.
 pub fn streamer_spawn_pending_path(state_dir: &Path, local_pane_id: &str) -> PathBuf {
-    state_dir.join("streamer-spawns").join(format!("{}.pending", sane_component(local_pane_id)))
+    state_dir
+        .join("streamer-spawns")
+        .join(format!("{}.pending", sane_component(local_pane_id)))
 }
 
 /// How long a `.pending` claim may block another launch. The retype loop is
@@ -340,7 +493,9 @@ pub enum StreamerSpawnClaim {
 /// pane). This addresses one by where it is showing it, which is the only handle
 /// a herdr event hook has: the hook is told a local pane id and nothing else.
 pub fn pane_pid_path(state_dir: &Path, local_pane_id: &str) -> PathBuf {
-    state_dir.join("pane-pids").join(format!("{}.pid", sane_component(local_pane_id)))
+    state_dir
+        .join("pane-pids")
+        .join(format!("{}.pid", sane_component(local_pane_id)))
 }
 
 pub fn streamer_alive(state_dir: &Path, ssh_target: &str, pane_target: &str) -> bool {
@@ -381,7 +536,11 @@ pub fn claim_streamer_spawn(
     }
     // one retry: a stale file we just unlinked can lose create_new to a racer
     for _ in 0..2 {
-        let mut claim = match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+        let mut claim = match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
             Ok(file) => file,
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
                 if pending_is_fresh(&path) {
@@ -524,7 +683,10 @@ mod tests {
             .unwrap()
             .as_secs() as libc::time_t;
         let cpath = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
-        let times = libc::utimbuf { actime: past, modtime: past };
+        let times = libc::utimbuf {
+            actime: past,
+            modtime: past,
+        };
         assert_eq!(unsafe { libc::utime(cpath.as_ptr(), &times) }, 0);
 
         assert_eq!(
@@ -558,6 +720,19 @@ mod tests {
     }
 
     #[test]
+    fn short_hash_is_stable() {
+        // Golden values. These bytes are baked into live socket/state paths,
+        // so a change here silently relocates every host derived from an
+        // unsafe or overlong name. If a hashing swap ever moves them, this
+        // must fail first.
+        assert_eq!(short_hash("vps"), "693e19194f02d738");
+        assert_eq!(
+            short_hash("prod-us-east-1-application-server-cluster-node-alpha"),
+            "18b2f02acbd62d65"
+        );
+    }
+
+    #[test]
     fn replacement_path_must_exist_and_be_executable() {
         let root = test_state_dir("replacement-exe");
         fs::create_dir_all(&root).unwrap();
@@ -566,5 +741,139 @@ mod tests {
         let reported = PathBuf::from(format!("{} (deleted)", candidate.display()));
         assert_eq!(resolve_reported_exe(&reported), None);
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn host_artifact_base_keeps_ordinary_names_at_the_root_verbatim() {
+        for name in ["azure", "rdev", "prod-us-east-1", "vps.example.com", "a_b"] {
+            let dir = tmpdir("artifact-base");
+            let (base, stem) = host_artifact_base(&dir, name);
+            assert_eq!(base, dir, "{name}");
+            assert_eq!(stem, name, "{name}");
+        }
+    }
+
+    /// The exact compatibility break a later review reported: an `h#`-
+    /// prefixed name is just an ordinary safe TOML table key (quoted), not a
+    /// reserved one — it keeps the exact v0.4.1 root-level path, same as any
+    /// other safe name.
+    #[test]
+    fn host_artifact_base_keeps_an_h_hash_prefixed_name_at_the_root_verbatim() {
+        let dir = tmpdir("artifact-base");
+        let (base, stem) = host_artifact_base(&dir, "h#prod");
+        assert_eq!(base, dir);
+        assert_eq!(stem, "h#prod");
+    }
+
+    #[test]
+    fn host_artifact_base_hashes_traversal_and_separator_names_under_the_private_subdir() {
+        let dir = tmpdir("artifact-base");
+        for unsafe_name in ["a/b", "/etc/passwd", "../../escape", "a/../b"] {
+            let (base, stem) = host_artifact_base(&dir, unsafe_name);
+            assert_eq!(base, unsafe_host_artifacts_dir(&dir), "{unsafe_name}");
+            assert!(is_safe_path_component(&stem), "{unsafe_name} -> {stem}");
+            assert_eq!(stem, unsafe_host_stem(unsafe_name), "{unsafe_name}");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The exact compatibility break a later review reported: `.`/`..`/
+    /// empty are NOT unsafe here — every artifact appends a suffix before
+    /// joining (see `is_safe_path_component`'s doc comment), so these stay
+    /// at the root with their host name used verbatim, same as any other
+    /// safe name.
+    #[test]
+    fn host_artifact_base_keeps_dot_and_empty_names_at_the_root_verbatim() {
+        let dir = tmpdir("artifact-base");
+        for name in ["", ".", ".."] {
+            let (base, stem) = host_artifact_base(&dir, name);
+            assert_eq!(base, dir, "{name:?}");
+            assert_eq!(stem, name, "{name:?}");
+        }
+    }
+
+    #[test]
+    fn host_artifact_base_keeps_unicode_names_at_the_root_verbatim() {
+        let dir = tmpdir("artifact-base");
+        let name = "réservé-hôte-日本語";
+        let (base, stem) = host_artifact_base(&dir, name);
+        assert_eq!(base, dir);
+        assert_eq!(stem, name);
+    }
+
+    #[test]
+    fn host_artifact_base_is_deterministic_for_distinct_unsafe_names() {
+        let dir = tmpdir("artifact-base");
+        assert_eq!(
+            host_artifact_base(&dir, "a/b"),
+            host_artifact_base(&dir, "a/b")
+        );
+        assert_ne!(
+            host_artifact_base(&dir, "a/b"),
+            host_artifact_base(&dir, "c/d")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The exact bug an earlier review reported (a plain, ordinary-looking
+    /// safe host name equal to another host's hashed stem) cannot reproduce
+    /// at all now: the two live in different directories, so their full
+    /// paths are never equal regardless of what either stem looks like.
+    #[test]
+    fn reported_collision_no_longer_reproduces() {
+        let dir = tmpdir("artifact-base");
+        let unsafe_name = "x/EaL2b7VcKy";
+        let lookalike_safe_name = "92f037a4";
+        let (unsafe_base, _unsafe_stem) = host_artifact_base(&dir, unsafe_name);
+        let (safe_base, safe_stem) = host_artifact_base(&dir, lookalike_safe_name);
+        assert_eq!(safe_base, dir);
+        assert_eq!(safe_stem, lookalike_safe_name);
+        assert_ne!(
+            unsafe_base, safe_base,
+            "different directories: can never collide"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The compatibility break a later review reported: a host literally
+    /// named to look like a hashed artifact (`h#...`) is still just a safe
+    /// name — it must never be diverted into `.h/`.
+    #[test]
+    fn a_name_that_looks_like_a_hashed_stem_still_stays_at_the_root() {
+        let dir = tmpdir("artifact-base");
+        let lookalike = "h#deadbeefdeadbeef";
+        let (base, stem) = host_artifact_base(&dir, lookalike);
+        assert_eq!(base, dir);
+        assert_eq!(stem, lookalike);
+    }
+
+    #[test]
+    fn ensure_private_dir_creates_mode_0700() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tmpdir("private-dir").join("nested").join("child");
+        ensure_private_dir(&dir).unwrap();
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "must not be group/world-traversable");
+        // idempotent: calling again on an existing dir must not error
+        ensure_private_dir(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(dir.parent().unwrap().parent().unwrap());
+    }
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let salt = &counter as *const u64 as usize;
+        let unique = short_hash(&format!(
+            "{}-{nanos}-{counter}-{salt:x}",
+            std::process::id()
+        ));
+        std::env::temp_dir().join(format!("hm-util-{tag}-{unique}"))
     }
 }


### PR DESCRIPTION
## Summary

Today every mirrored pane opens its own SSH transport. A host with many panes therefore creates many simultaneous SSH connections, repeating authentication, key exchange, keepalive, and network setup for streams that all have the same destination and lifetime. Besides the unnecessary connection overhead, this can make new pane streams intermittently fail during periods when existing streams remain healthy.

Configuring one ambient SSH `ControlMaster` is not a safe substitute: every long-lived pane consumes a server-side session channel from that connection, so a sufficiently large mirror can exhaust `MaxSessions` and prevent unrelated interactive or automation SSH clients from opening a session.

This change adds opt-in, bounded SSH stream connection pooling inside Herdr Mirror. Multiple pane streams share private masters up to a configurable capacity, then spill into additional masters. The pool is isolated from Mirror's control plane and from ordinary SSH usage, reducing connection count without allowing mirrored panes to starve unrelated clients.

When `ssh_streams_per_connection` is absent or set to `1`, pane streams retain v0.4.2's direct connection behavior, including its explicit protection from ambient SSH control sockets.

## How it works

- **Stable, capacity-aware assignment.** Each pane receives a persisted per-host stream slot. Existing assignments are retained when possible, freed capacity is reused, and a new master is added only when every existing slot is full.
- **Private, bounded masters.** The daemon is the sole creator of pool masters; one-shot (`once`) invocations only reuse an existing master or fall back to a direct connection. Cross-process file locking serializes master creation and recovery, while finite idle lifetime, retry backoff, and cancellation-safe subprocess handling prevent abandoned masters and SSH children.
- **Isolation.** Pool sockets live in a private namespace separate from the control-plane sockets and ordinary SSH configuration. Docker targets are unchanged because pooling applies only to SSH pane streams.
- **Direct-stream safety.** Unpooled pane streams use `-S none`, preserving v0.4.2's protection against stale ambient `ControlMaster` sockets. Pooled streams replace that only with their explicit private slot socket and use `ControlMaster=no`, so streamers cannot create a master.
- **Backward compatibility.** Existing unpooled state, socket paths, host names, and serialized mappings remain compatible. New state is written atomically with private file modes, and socket collisions and platform path-length limits are validated before connecting.
- **Visibility.** `herdr-mirror status` reports the configured per-connection capacity and intended occupancy of each slot.

## Testing

- Rebasing onto v0.4.3 retained its direct-stream isolation, replaced-binary handling, and process-group timeout cleanup while integrating the private-pool path.
- `cargo test --locked`: 336 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings` and `cargo check --locked --all-targets`: passed.
- Live validation of the feature revision before the v0.4.2 rebase against two independent SSH targets: one target held 4 pane streams on one master; a second grew from 10 to 11 streams and correctly allocated a second master at 10/10 and 1/10.
- Concurrent daemon and `once` reconciliation preserved master processes, socket identities, and state. Ordinary SSH sessions remained independent from the private pool.

## Caveats

- Current OpenSSH clients may fall back to a direct connection if an existing master cannot open another multiplexed session. A successful pane stream therefore does not by itself prove that it is using the pool.
- Reported occupancy is the persisted intended assignment, not a live health check of the underlying SSH connection.
- Changing `ssh_streams_per_connection` takes effect when the relevant streamer process is recreated; active streamers are not interrupted or retroactively reshuffled.
- Live validation did not deliberately terminate a master carrying active sessions. Timeout, cancellation, stale-socket, and recovery behavior is covered by automated tests.
