### PR TITLE
feat: stream only visible mirror panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ A remote can be another machine over **ssh**, or a **container** on this one
 
 > **How it works.** One Rust binary (`herdr-mirror`) with subcommand modes: a
 > `daemon` (control plane — reconciles remote workspaces into local mirrors
-> and pushes agent status) and one `pane` process per mirror pane (data plane
-> — streams the remote terminal).
+> and pushes agent status) and one `pane` wrapper per mirror pane (data plane
+> — streams a visible remote terminal).
 
 ## Requirements
 
@@ -133,11 +133,17 @@ the action locally, so one key covers both worlds. The plugin must be
 installed on whichever end runs it. See
 [Remote plugin keys](#remote-plugin-keys) for binding it.
 
-**Continuous streaming** — every mirror pane streams its remote pane live for
-its whole lifetime, each over its own connection, so panes are never
-blank and a busy pane can't contend with or drop another's stream. Sidebar
-agent status is daemon-driven, not stream-derived, so every agent's state stays
-live regardless of what any stream is doing.
+### Visible-pane streaming
+
+Every remote pane still has a local pane and a durable mapping, but by default
+only panes in the focused local workspace and tab keep a remote observe
+connection. A pane that leaves view waits 30 seconds before its stream pauses;
+focus it again and its wrapper reconnects immediately. While paused it shows
+`paused — focus to resume`. Sidebar agent status is daemon-driven, so every
+agent's state stays live regardless of which terminal streams are paused.
+
+Set `[stream].visible_only = false` to retain the legacy all-pane streaming
+behaviour, or change `[stream].pause_after_secs` to tune the grace period.
 
 ### Keybinds
 
@@ -314,6 +320,11 @@ dropped files need nothing). Uploads aren't cleaned up; `rm -rf
 # max_cols / max_rows    # cap the size control asks the remote for, so a
                          # machine with its own display keeps its geometry.
                          # A ceiling only, and never applies to watch-only.
+
+[stream]
+# visible_only = true    # default. Keep remote observe sessions only for panes
+                         # visible in the focused local workspace and tab.
+# pause_after_secs = 30  # grace period before an out-of-view pane pauses.
 
 [hosts.work]
 target = "work"

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,9 @@ use serde::Deserialize;
 
 use crate::util::{err, Result};
 
+const DEFAULT_VISIBLE_ONLY: bool = true;
+const DEFAULT_PAUSE_AFTER_SECS: u64 = 30;
+
 /// Shell expression for `exec <expr> <command> ...` on the remote.
 ///
 /// A configured path is used as-is (unquoted so remote-shell `~` expands).
@@ -129,6 +132,8 @@ pub struct MirrorConfig {
     /// also closes the matching object on the remote. Set false to make a local
     /// close only stop mirroring, leaving the remote — and any agent — running.
     pub close_remote_on_local_close: bool,
+    /// Which mapped panes retain a live remote observe session.
+    pub stream: crate::visibility::StreamPolicy,
     pub hosts: Vec<HostConfig>,
     /// which hosts.toml this came from. `None` when parsed from a string
     /// (tests). Logged at startup so "which config won?" is never a guess.
@@ -160,10 +165,18 @@ struct RawConfig {
     always_control: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
+    #[serde(default)]
+    stream: RawStream,
     // toml::Table (preserve_order) keeps declaration order — the first host
     // is the remote-create fallback, so order is user-visible
     #[serde(default)]
     hosts: toml::Table,
+}
+
+#[derive(Default, Deserialize)]
+struct RawStream {
+    visible_only: Option<bool>,
+    pause_after_secs: Option<u64>,
 }
 
 #[derive(Deserialize)]
@@ -348,6 +361,12 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
         autostart: raw.autostart.unwrap_or(true),
         default_host: raw.default_host,
         close_remote_on_local_close: raw.close_remote_on_local_close.unwrap_or(true),
+        stream: crate::visibility::StreamPolicy {
+            visible_only: raw.stream.visible_only.unwrap_or(DEFAULT_VISIBLE_ONLY),
+            pause_after: std::time::Duration::from_secs(
+                raw.stream.pause_after_secs.unwrap_or(DEFAULT_PAUSE_AFTER_SECS),
+            ),
+        },
         hosts,
         source: None,
         shadowed: Vec::new(),
@@ -373,6 +392,21 @@ mod tests {
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert_eq!(h.session, None); // default remote session
         assert!(h.always_control); // default on
+    }
+
+    #[test]
+    fn stream_policy_parses_and_defaults() {
+        let configured = parse_config(
+            "[stream]\nvisible_only = false\npause_after_secs = 7\n\
+             [hosts.work]\ntarget = \"work\"\n",
+        )
+        .unwrap();
+        assert!(!configured.stream.visible_only);
+        assert_eq!(configured.stream.pause_after, std::time::Duration::from_secs(7));
+
+        let defaults = parse_config("[hosts.work]\ntarget = \"work\"\n").unwrap();
+        assert!(defaults.stream.visible_only);
+        assert_eq!(defaults.stream.pause_after, std::time::Duration::from_secs(30));
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -13,12 +13,12 @@
 // arrive through one select loop, so converge and the status fast-path never
 // interleave.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{Read, Seek, Write};
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant as StdInstant};
 
 use serde_json::{json, Value};
 use tokio::signal::unix::{signal, SignalKind};
@@ -28,11 +28,12 @@ use tokio::time::Instant;
 use crate::api::{ApiClient, EventStream};
 use crate::config::{load_config, HostConfig};
 use crate::mirror::{
-    apply_remote_closes, converge, mark_unknown, mirror_source, push_pane_status, regroup_sidebar,
+    apply_remote_closes, converge, fetch_snapshot, mark_unknown, mirror_source, push_pane_status, regroup_sidebar,
     teardown, AgentInfo, ConvergeDeps,
 };
 use crate::state::{load_state, save_state, HostState};
 use crate::util::{err, now_iso, pid_alive, sleep_until_earliest, Env, Logger, Result};
+use crate::visibility::{self, PaneStreamState, StreamAction, StreamPolicy};
 
 // --- pidfile / pause marker ---
 
@@ -162,7 +163,189 @@ struct HostCtx {
     local: ApiClient,
     log: Logger,
     close_remote_on_local_close: bool,
+    stream_policy: StreamPolicy,
     closes: crate::closes::Closes,
+}
+
+/// Per-host, process-lifetime visibility bookkeeping. The desired stream state
+/// itself lives in pause files so a pane wrapper can survive daemon restarts;
+/// only the grace timestamp is intentionally ephemeral.
+#[derive(Default)]
+struct StreamTracker {
+    panes: HashMap<String, PaneStreamState>,
+    orphan_reap: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for StreamTracker {
+    fn drop(&mut self) {
+        if let Some(task) = self.orphan_reap.take() {
+            task.abort();
+        }
+    }
+}
+
+impl StreamTracker {
+    fn refresh(
+        &mut self,
+        state: &HostState,
+        state_dir: &std::path::Path,
+        policy: &StreamPolicy,
+        visible: &HashSet<String>,
+        now: StdInstant,
+    ) {
+        let mapped: HashSet<String> = state
+            .panes
+            .values()
+            .filter(|entry| !entry.is_tombstoned())
+            .map(|entry| entry.local_id.clone())
+            .collect();
+        self.panes.retain(|local_id, _| mapped.contains(local_id));
+        for local_id in mapped {
+            let stream = self.panes.entry(local_id.clone()).or_insert_with(|| PaneStreamState {
+                local_id: local_id.clone(),
+                streaming: !crate::util::streamer_paused(state_dir, &local_id),
+                hidden_since: None,
+            });
+            // The marker is the source of truth across daemon restarts and
+            // after a streamer is recreated by the zombie-heal path.
+            stream.streaming = !crate::util::streamer_paused(state_dir, &local_id);
+            if policy.visible_only && !visible.contains(&local_id) {
+                stream.hidden_since.get_or_insert(now);
+            } else {
+                stream.hidden_since = None;
+            }
+        }
+    }
+
+    fn tracked(&self) -> Vec<PaneStreamState> {
+        let mut tracked: Vec<PaneStreamState> = self.panes.values().cloned().collect();
+        tracked.sort_by(|left, right| left.local_id.cmp(&right.local_id));
+        tracked
+    }
+
+    fn set_streaming(&mut self, local_id: &str, streaming: bool) {
+        if let Some(stream) = self.panes.get_mut(local_id) {
+            stream.streaming = streaming;
+        }
+    }
+
+    /// One host-level delayed reaper naturally batches all detachments in a
+    /// focus transition. Do not await it from converge: cleanup is best-effort
+    /// and must not hold up normal mirror reconciliation.
+    fn schedule_orphan_reap(
+        &mut self,
+        log: Logger,
+        host_name: String,
+        reaper: crate::remote::OrphanReaper,
+    ) {
+        if self.orphan_reap.as_ref().is_some_and(|task| !task.is_finished()) {
+            return;
+        }
+        self.orphan_reap = Some(tokio::spawn(async move {
+            // Let sshd finish reparenting the remote observe child before its
+            // ppid is inspected. A disconnected link cannot be reaped here;
+            // the next successful connection runs its own early sweep.
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            if let Err(e) = reaper.reap_orphans().await {
+                log.log(&format!("[{host_name}] batched remote orphan reap failed: {e}"));
+            }
+        }));
+    }
+
+    fn cancel_orphan_reap(&mut self) {
+        if let Some(task) = self.orphan_reap.take() {
+            task.abort();
+        }
+    }
+}
+
+/// Apply visibility policy after a complete converge. The map remains intact:
+/// this only changes each wrapper's desired remote-session state, then wakes
+/// that wrapper to carry out the transition.
+async fn reconcile_streamers(
+    ctx: &HostCtx,
+    state: &HostState,
+    tracker: &mut StreamTracker,
+    remote_host: &crate::remote::RemoteHost,
+) -> Option<Instant> {
+    let local_snapshot = match fetch_snapshot(&ctx.local).await {
+        Ok(snapshot) => snapshot,
+        Err(e) => {
+            // Do not turn a transient local API failure into a mass pause. The
+            // next event/poll retries the decision with a fresh snapshot.
+            ctx.log.log(&format!("[{}] cannot read local focus for stream policy: {e}", ctx.host.name));
+            return None;
+        }
+    };
+    let visible = visibility::visible_local_panes(&local_snapshot);
+    let now = StdInstant::now();
+    tracker.refresh(state, &ctx.env_state_dir, &ctx.stream_policy, &visible, now);
+
+    let mut stopped = false;
+    for action in visibility::plan_streams(&ctx.stream_policy, true, &visible, &tracker.tracked(), now) {
+        let (local_id, paused) = match action {
+            StreamAction::Start(local_id) => (local_id, false),
+            StreamAction::Stop(local_id) => (local_id, true),
+        };
+        match crate::util::set_streamer_paused(&ctx.env_state_dir, &local_id, paused) {
+            Ok(()) => {
+                tracker.set_streaming(&local_id, !paused);
+                let _ = crate::util::poke_pane_streamer(&ctx.env_state_dir, &local_id);
+                if paused {
+                    stopped = true;
+                }
+            }
+            Err(e) => ctx.log.log(&format!(
+                "[{}] cannot {} streamer {local_id}: {e}",
+                ctx.host.name,
+                if paused { "pause" } else { "resume" }
+            )),
+        }
+    }
+
+    if stopped {
+        // A batch intentionally uses no pane filter: a focus move commonly
+        // pauses dozens of panes, but the ppid-1 and configured-session
+        // predicates still keep the remote command scoped to abandoned work.
+        tracker.schedule_orphan_reap(
+            ctx.log.clone(),
+            ctx.host.name.clone(),
+            remote_host.orphan_reaper(),
+        );
+    }
+
+    visibility::next_deadline(&ctx.stream_policy, &tracker.tracked()).map(Instant::from_std)
+}
+
+/// A disconnected host must not leave any remote observe client behind. This
+/// is intentionally unconditional: link loss overrides `visible_only = false`
+/// and skips the normal grace period.
+fn pause_host_streamers(ctx: &HostCtx, tracker: &mut StreamTracker) {
+    // Do not run a delayed normal-path reaper while the link is known down;
+    // the post-connect sweep recovers those remote orphans once reachable.
+    tracker.cancel_orphan_reap();
+    let state = load_state(&ctx.env_state_dir, &ctx.host.name);
+    for entry in state.panes.values().filter(|entry| !entry.is_tombstoned()) {
+        let local_id = &entry.local_id;
+        match crate::util::set_streamer_paused(&ctx.env_state_dir, local_id, true) {
+            Ok(()) => {
+                tracker
+                    .panes
+                    .entry(local_id.clone())
+                    .or_insert_with(|| PaneStreamState {
+                        local_id: local_id.clone(),
+                        streaming: false,
+                        hidden_since: None,
+                    })
+                    .streaming = false;
+                let _ = crate::util::poke_pane_streamer(&ctx.env_state_dir, local_id);
+            }
+            Err(e) => ctx.log.log(&format!(
+                "[{}] cannot pause streamer {local_id} after link loss: {e}",
+                ctx.host.name
+            )),
+        }
+    }
 }
 
 const BROADCAST_SUBS: &[&str] = &[
@@ -284,6 +467,8 @@ async fn run_connected(
     backoff_idx: &mut usize,
     remembered_transport: &mut Option<crate::config::ApiTransport>,
     exec_streak: &mut u32,
+    stream_tracker: &mut StreamTracker,
+    startup_reap_pending: &mut bool,
 ) -> Result<()> {
     let mut remote_host = crate::remote::RemoteHost::new(&ctx.host, &ctx.env_state_dir);
     // a fresh RemoteHost is built on every reconnect, so what worked last
@@ -292,6 +477,14 @@ async fn run_connected(
     // for the life of the daemon
     remote_host.hint_transport(*remembered_transport);
     let (remote, _status) = remote_host.connect_api().await?;
+    // The first successful connection is both the daemon-start sweep and a
+    // normal post-connect sweep. One command covers both; every reconnect
+    // repeats it to recover orphans that could not be reached during link loss.
+    let reap_phase = if *startup_reap_pending { "daemon-start" } else { "post-connect" };
+    if let Err(e) = remote_host.reap_orphans(None).await {
+        ctx.log.log(&format!("[{}] {reap_phase} orphan reap failed: {e}", ctx.host.name));
+    }
+    *startup_reap_pending = false;
     *remembered_transport = remember_transport(remote_host.last_api_transport, exec_streak);
     *backoff_idx = 0;
     let deps = ConvergeDeps {
@@ -301,6 +494,7 @@ async fn run_connected(
         state_dir: ctx.env_state_dir.clone(),
         log: ctx.log.clone(),
         close_remote_on_local_close: ctx.close_remote_on_local_close,
+        stream_policy: ctx.stream_policy.clone(),
         closes: ctx.closes.clone(),
     };
     // broadcast-only first: subscribing a since-dead pane id is rejected, so
@@ -308,6 +502,7 @@ async fn run_connected(
     let mut stream = remote.subscribe(sub_list(&[])).await?;
     let mut subscribed_key = String::from("<broadcast>");
     let state = converge(&deps).await?;
+    let mut stream_at = reconcile_streamers(ctx, &state, stream_tracker, &remote_host).await;
     resubscribe(ctx, &remote, &mut stream, &mut subscribed_key, &state).await?;
     ctx.log.log(&format!("[{}] connected and synced", ctx.host.name));
 
@@ -318,7 +513,7 @@ async fn run_connected(
     let mut pending_closes: Vec<String> = Vec::new();
 
     loop {
-        let sleep = sleep_until_earliest([converge_at, status_at, closes_at]);
+        let sleep = sleep_until_earliest([converge_at, status_at, closes_at, stream_at]);
         tokio::select! {
             ev = stream.next() => {
                 match ev {
@@ -355,6 +550,11 @@ async fn run_connected(
             }
             _ = sleep => {
                 let now = Instant::now();
+                if stream_at.is_some_and(|deadline| deadline <= now) {
+                    stream_at = None;
+                    // A grace expiry must not wait for unrelated remote traffic.
+                    converge_at.get_or_insert(now);
+                }
                 if status_at.is_some_and(|t| t <= now) {
                     status_at = None;
                     let pending = std::mem::take(&mut pending_status);
@@ -383,6 +583,7 @@ async fn run_connected(
                     )
                     .await;
                     let state = converge(&deps).await?;
+                    stream_at = reconcile_streamers(ctx, &state, stream_tracker, &remote_host).await;
                     // pane set may have changed
                     resubscribe(ctx, &remote, &mut stream, &mut subscribed_key, &state).await?;
                 }
@@ -407,6 +608,8 @@ async fn host_task(ctx: HostCtx, mut poke: mpsc::Receiver<()>) {
     // point of remembering at all (see `run_connected`)
     let mut remembered_transport: Option<crate::config::ApiTransport> = None;
     let mut exec_streak = 0u32;
+    let mut stream_tracker = StreamTracker::default();
+    let mut startup_reap_pending = true;
     loop {
         // Before dialling, and again after every failed dial: taking a hidden
         // host's mirrors down needs only the LOCAL api, so it must not wait on a
@@ -426,6 +629,8 @@ async fn host_task(ctx: HostCtx, mut poke: mpsc::Receiver<()>) {
             &mut backoff_idx,
             &mut remembered_transport,
             &mut exec_streak,
+            &mut stream_tracker,
+            &mut startup_reap_pending,
         )
         .await
         {
@@ -434,6 +639,7 @@ async fn host_task(ctx: HostCtx, mut poke: mpsc::Receiver<()>) {
         };
         mark_unknown(&ctx.local, &ctx.env_state_dir, &ctx.host.name, "mirror: connection lost")
             .await;
+        pause_host_streamers(&ctx, &mut stream_tracker);
         // starts_with, not contains: the marker is always emitted as a prefix,
         // while the error text can embed user strings (target, remote_bin). A
         // substring test would make an ssh host named `dormant-box` back off
@@ -594,6 +800,12 @@ async fn local_events_task(
     loop {
         let subs = vec![
             json!({ "type": "workspace.created" }),
+            // Focus events are named snake_case on the wire, but subscribe
+            // with the API's dotted event type just like every other hook.
+            // They fan out to every host below so visibility changes promptly.
+            json!({ "type": "workspace.focused" }),
+            json!({ "type": "tab.focused" }),
+            json!({ "type": "pane.focused" }),
             json!({ "type": "workspace.closed" }),
             json!({ "type": "pane.closed" }),
             // closing a TAB emits only tab_closed — no pane_closed for the
@@ -698,6 +910,7 @@ pub async fn cmd_run(env: Env) -> Result<()> {
             local: local.clone(),
             log: log.clone(),
             close_remote_on_local_close: config.close_remote_on_local_close,
+            stream_policy: config.stream.clone(),
             closes: closes.clone(),
         };
         tasks.push(tokio::spawn(host_task(ctx, rx)));
@@ -923,6 +1136,7 @@ pub async fn cmd_once(env: Env) -> Result<()> {
             state_dir: env.state_dir.clone(),
             log: log.clone(),
             close_remote_on_local_close: config.close_remote_on_local_close,
+            stream_policy: config.stream.clone(),
             // one-shot: no local event stream, so there is no authoritative
             // close signal — an empty tracker means this pass syncs but never
             // closes a remote object, which is the correct conservative default

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod select;
 mod ssh_relay;
 mod state;
 mod util;
+mod visibility;
 
 use util::{Env, Result};
 

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -24,8 +24,11 @@ pub struct WsInfo {
     pub workspace_id: String,
     #[serde(default)]
     pub label: String,
+    #[serde(default)]
     pub tab_count: Option<u64>,
+    #[serde(default)]
     pub pane_count: Option<u64>,
+    #[serde(default)]
     pub active_tab_id: Option<String>,
     /// custom metadata tokens the remote publishes. `default` on purpose: a
     /// pre-0.7.4 remote never sends this.
@@ -49,8 +52,11 @@ pub struct PaneInfo {
     /// unread today, but part of the pane wire shape — kept so the struct
     /// documents what the API actually returns
     #[allow(dead_code)]
+    #[serde(default)]
     pub label: Option<String>,
+    #[serde(default)]
     pub cwd: Option<String>,
+    #[serde(default)]
     pub foreground_cwd: Option<String>,
 }
 
@@ -126,11 +132,19 @@ pub struct LayoutSnapshot {
     #[allow(dead_code)]
     pub tab_id: String,
     #[serde(default)]
+    pub zoomed: bool,
+    #[serde(default)]
+    pub focused_pane_id: Option<String>,
+    #[serde(default)]
     pub panes: Vec<LayoutPaneSnapshot>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Snapshot {
+    #[serde(default)]
+    pub focused_workspace_id: Option<String>,
+    #[serde(default)]
+    pub focused_tab_id: Option<String>,
     #[serde(default)]
     pub workspaces: Vec<WsInfo>,
     #[serde(default)]
@@ -429,10 +443,39 @@ pub struct ConvergeDeps {
     pub log: Logger,
     /// mirror closing a workspace/pane locally onto the remote (see MirrorConfig)
     pub close_remote_on_local_close: bool,
+    /// Desired remote-session policy. New panes need their pause marker before
+    /// their wrapper is exec'd, otherwise an initially hidden pane races one
+    /// unnecessary observe connection into existence.
+    pub stream_policy: crate::visibility::StreamPolicy,
     /// event-confirmed local closes. Absence from the local snapshot is
     /// ambiguous (rebuild in flight, failed converge, server restart), so only a
     /// close event that wasn't our own may close the remote.
     pub closes: crate::closes::Closes,
+}
+
+/// Establish a newly-created pane wrapper's desired stream state before it is
+/// launched. A snapshot failure deliberately fails open: an older/temporary
+/// local API gap must not create a pane that can never show its remote.
+async fn prepare_streamer_pause(deps: &ConvergeDeps, local_pane_id: &str) {
+    let paused = if deps.stream_policy.visible_only {
+        match fetch_snapshot(&deps.local).await {
+            Ok(snapshot) => !crate::visibility::visible_local_panes(&snapshot).contains(local_pane_id),
+            Err(e) => {
+                deps.log.log(&format!(
+                    "cannot read local focus before launching streamer {local_pane_id}: {e}; starting visible"
+                ));
+                false
+            }
+        }
+    } else {
+        false
+    };
+    if let Err(e) = crate::util::set_streamer_paused(&deps.state_dir, local_pane_id, paused) {
+        deps.log.log(&format!(
+            "cannot set initial {} state for streamer {local_pane_id}: {e}",
+            if paused { "paused" } else { "running" }
+        ));
+    }
 }
 
 /// argv for one mirror pane: this same binary in `pane` mode. Panes without a
@@ -1221,6 +1264,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                 note_mapped(deps, state, &fresh);
                 for (local_id, rid) in &to_spawn {
                     // plain pane created above; exec the streamer into it
+                    prepare_streamer_pause(deps, local_id).await;
                     spawn_streamer_pane(&deps.local, &deps.state_dir, local_id, &cmd_for(rid), &deps.log).await;
                 }
             } else {
@@ -1284,6 +1328,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                         PaneEntry { local_id: local_id.clone(), tombstone: None, seq: 0, reported: None },
                     );
                     note_mapped(deps, state, std::slice::from_ref(&local_id));
+                    prepare_streamer_pause(deps, &local_id).await;
                     spawn_streamer_pane(&deps.local, &deps.state_dir, &local_id, &cmd_for(&place.pane), &deps.log)
                         .await;
                 }
@@ -1320,6 +1365,7 @@ async fn converge_inner(deps: &ConvergeDeps, state: &mut HostState) -> Result<()
                         PaneEntry { local_id: local_id.clone(), tombstone: None, seq: 0, reported: None },
                     );
                     note_mapped(deps, state, std::slice::from_ref(&local_id));
+                    prepare_streamer_pause(deps, &local_id).await;
                     spawn_streamer_pane(&deps.local, &deps.state_dir, &local_id, &cmd_for(&rp.pane_id), &deps.log)
                         .await;
                 }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -28,6 +28,7 @@
 // every message so stale ones are dropped.
 
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -448,11 +449,19 @@ impl RawMode {
     }
 }
 
+static STDOUT_BROKEN: AtomicBool = AtomicBool::new(false);
+
 fn write_stdout(s: &str) {
     use std::io::Write;
     let mut out = std::io::stdout().lock();
-    let _ = out.write_all(s.as_bytes());
-    let _ = out.flush();
+    let result = out.write_all(s.as_bytes()).and_then(|_| out.flush());
+    if result.is_err_and(|e| e.kind() == std::io::ErrorKind::BrokenPipe) {
+        STDOUT_BROKEN.store(true, Ordering::Release);
+    }
+}
+
+fn stdout_is_broken() -> bool {
+    STDOUT_BROKEN.load(Ordering::Acquire)
 }
 
 /// One SGR mouse event: ESC [ < btn ; col ; row (M|m). Returns (btn, col, row,
@@ -776,6 +785,10 @@ struct App {
 
     backoff_idx: usize,
     reconnect_at: Option<(Instant, Mode)>,
+    /// The daemon's pause marker is present. The wrapper remains alive in the
+    /// local pane so its mapping and recovery path survive, but it owns no
+    /// remote observe/control session in this state.
+    stream_paused: bool,
     /// consecutive quick control failures → fall back to observe
     control_failures: u32,
     control_sticky: bool,
@@ -895,6 +908,45 @@ impl App {
         self.hint_clear_at = None;
     }
 
+    /// Kill only the remote transport group. Never terminate this wrapper: it
+    /// is the process that keeps the local mirror pane and id mapping alive.
+    fn kill_session_immediately(&mut self) {
+        if let Some(session) = self.session.take() {
+            kill_session_process_group(session.process_group);
+        }
+    }
+
+    fn pause_streaming(&mut self) {
+        if self.stream_paused {
+            return;
+        }
+        self.stream_paused = true;
+        self.switching_to = None;
+        self.switch_at = None;
+        self.reconnect_at = None;
+        self.pending_input.clear();
+        self.control_sticky = false;
+        self.mode = Mode::Observe;
+        self.kill_session_immediately();
+        self.renderer.invalidate();
+        self.hint_sticky("paused — focus to resume");
+    }
+
+    async fn resume_streaming(&mut self) {
+        if !self.stream_paused {
+            return;
+        }
+        self.stream_paused = false;
+        self.backoff_idx = 0;
+        self.control_failures = 0;
+        self.control_sticky = false;
+        self.switching_to = None;
+        self.switch_at = None;
+        self.reconnect_at = None;
+        self.renderer.invalidate();
+        self.connect(initial_mode(self.args.always_control, term_size())).await;
+    }
+
     /// Kick a background poll of the remote pane's foreground process, throttled
     /// so a mouse burst doesn't spawn an ssh per event. The result arrives as
     /// Msg::Foreground and updates `remote_is_shell`.
@@ -997,6 +1049,9 @@ impl App {
     }
 
     async fn connect(&mut self, m: Mode) {
+        if self.stream_paused {
+            return;
+        }
         self.mode = m;
         // re-earn prediction confidence against the new session's frames
         self.predict = Predictor::new();
@@ -1069,6 +1124,9 @@ impl App {
 
 
     fn switch_mode(&mut self, m: Mode) {
+        if self.stream_paused {
+            return;
+        }
         // already settled or scheduled — don't restart. Without this guard,
         // fast typing during the 200ms connect gap would spawn one control
         // ssh per keystroke, all racing to attach the same terminal.
@@ -1126,14 +1184,14 @@ impl App {
         }
         if self.args.dump {
             let lines: Vec<String> = self.grid.text_lines().into_iter().filter(|l| !l.is_empty()).collect();
-            println!(
-                "--- frame seq={:?} full={:?} {}x{} ---\n{}",
+            write_stdout(&format!(
+                "--- frame seq={:?} full={:?} {}x{} ---\n{}\n",
                 frame.seq,
                 frame.full,
                 frame.width.unwrap_or(0),
                 frame.height.unwrap_or(0),
                 lines.join("\n")
-            );
+            ));
         } else {
             self.paint();
         }
@@ -1195,6 +1253,10 @@ impl App {
     /// first would silently swallow the second, and leave its markers in the
     /// tail to be forwarded raw at the remote.
     async fn handle_stdin(&mut self, chunk: Vec<u8>) {
+        if self.stream_paused {
+            self.hint_sticky("paused — focus to resume");
+            return;
+        }
         let mut chunk = chunk;
         loop {
             match split_paste(&mut self.paste_buf, chunk) {
@@ -1269,6 +1331,12 @@ impl App {
     }
 
     async fn handle_drop(&mut self, result: crate::paste::DropResult) {
+        if self.stream_paused {
+            self.paste_inflight = false;
+            self.paste_original = None;
+            self.paste_queue.clear();
+            return;
+        }
         self.paste_inflight = false;
         let original = self.paste_original.take();
         if let Some(text) = &result.text {
@@ -1483,6 +1551,9 @@ impl App {
     }
 
     async fn deliver_input(&mut self, buf: Vec<u8>) {
+        if self.stream_paused {
+            return;
+        }
         if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
             self.control_sticky = false;
             self.pending_input.push(buf);
@@ -1501,6 +1572,12 @@ impl App {
     }
 
     async fn handle_paste(&mut self, outcome: crate::paste::Outcome) {
+        if self.stream_paused {
+            self.paste_inflight = false;
+            self.paste_original = None;
+            self.paste_queue.clear();
+            return;
+        }
         self.paste_inflight = false;
         match outcome {
             crate::paste::Outcome::NoImage => self.deliver_input(vec![0x16]).await,
@@ -1568,6 +1645,12 @@ pub async fn run(args: Args) -> Result<()> {
         let _ = crate::state::take_pane_hint(&state_dir, id);
         PidfileGuard(path)
     });
+    // Check before opening the first ssh child. A newly-created, currently
+    // hidden pane still execs this wrapper (so mapping/recovery are unchanged)
+    // but must never attach an observe session even briefly.
+    let initially_paused = local_pane_id
+        .as_deref()
+        .is_some_and(|id| crate::util::streamer_paused(&state_dir, id));
     let raw = if tty {
         // 1002/1006: button-event mouse tracking with SGR encoding, so wheel and
         // clicks reach us instead of scrolling the hosting pane's scrollback
@@ -1622,6 +1705,7 @@ pub async fn run(args: Args) -> Result<()> {
         next_gen: 0,
         backoff_idx: 0,
         reconnect_at: None,
+        stream_paused: initially_paused,
         control_failures: 0,
         control_sticky: false,
         pending_input: Vec::new(),
@@ -1662,18 +1746,26 @@ pub async fn run(args: Args) -> Result<()> {
     let mut sigusr1 = signal(SignalKind::user_defined1())?;
     let mut sigwinch = signal(SignalKind::window_change())?;
 
-    app.connect(initial_mode(app.args.always_control, term_size())).await;
-    // the pane may have been laid out while the session was spawning; the signal
-    // for that is buffered above, but check directly too
-    if app.mode == Mode::Observe && initial_mode(app.args.always_control, term_size()) == Mode::Control
-    {
-        app.switch_mode(Mode::Control);
-    } else if app.args.always_control && app.mode == Mode::Observe {
-        // F3: otherwise the pane is inert with no explanation
-        app.hint("read-only until this pane is sized — type to take control");
+    if app.stream_paused {
+        app.hint_sticky("paused — focus to resume");
+    } else if !stdout_is_broken() {
+        app.connect(initial_mode(app.args.always_control, term_size())).await;
+        // the pane may have been laid out while the session was spawning; the signal
+        // for that is buffered above, but check directly too
+        if app.mode == Mode::Observe && initial_mode(app.args.always_control, term_size()) == Mode::Control
+        {
+            app.switch_mode(Mode::Control);
+        } else if app.args.always_control && app.mode == Mode::Observe {
+            // F3: otherwise the pane is inert with no explanation
+            app.hint("read-only until this pane is sized — type to take control");
+        }
     }
 
-    loop {
+    let stdout_broken = loop {
+        if stdout_is_broken() {
+            app.kill_session_immediately();
+            break true;
+        }
         // earliest pending deadline: mode-switch gap, reconnect, hint clear, idle release
         let idle_at = (app.mode == Mode::Control
             && app.switching_to.is_none()
@@ -1694,7 +1786,7 @@ pub async fn run(args: Args) -> Result<()> {
         tokio::select! {
             msg = rx.recv() => {
                 match msg {
-                    None => break,
+                    None => break false,
                     Some(Msg::Frame { gen, frame }) => app.handle_frame(gen, frame),
                     Some(Msg::SessionExit { gen, mode, reason, uptime }) => app.handle_exit(gen, mode, reason, uptime),
                     Some(Msg::Stdin(buf)) => app.handle_stdin(buf).await,
@@ -1721,27 +1813,34 @@ pub async fn run(args: Args) -> Result<()> {
                 // control_sticky means control was refused twice in a row and we
                 // told the user "type to retry" — a window drag must not turn
                 // that into a reconnect storm.
-                if app.args.always_control && app.mode == Mode::Observe && !app.control_sticky {
-                    app.switch_mode(Mode::Control);
-                }
-                if app.mode == Mode::Control {
-                    // capped like the initial connect: a local window drag must
-                    // not push a capped host past its ceiling either
-                    let (cols, rows) = app.control_size();
-                    app.send(json!({ "type": "terminal.resize", "cols": cols, "rows": rows })).await;
+                if !app.stream_paused {
+                    if app.args.always_control && app.mode == Mode::Observe && !app.control_sticky {
+                        app.switch_mode(Mode::Control);
+                    }
+                    if app.mode == Mode::Control {
+                        // capped like the initial connect: a local window drag must
+                        // not push a capped host past its ceiling either
+                        let (cols, rows) = app.control_size();
+                        app.send(json!({ "type": "terminal.resize", "cols": cols, "rows": rows })).await;
+                    }
                 }
                 app.paint();
             }
             _ = sigusr1.recv() => {
                 if let Some(id) = local_pane_id.as_deref() {
+                    if crate::util::streamer_paused(&state_dir, id) {
+                        app.pause_streaming();
+                    } else {
+                        app.resume_streaming().await;
+                    }
                     if let Some(msg) = crate::state::take_pane_hint(&state_dir, id) {
                         app.hint_for(&msg, Duration::from_secs(4));
                     }
                 }
             }
-            _ = sigterm.recv() => break,
-            _ = sigint.recv() => break,
-            _ = sighup.recv() => break,
+            _ = sigterm.recv() => break false,
+            _ = sigint.recv() => break false,
+            _ = sighup.recv() => break false,
             _ = sleep => {
                 let now = Instant::now();
                 if app.switch_at.is_some_and(|t| t <= now) {
@@ -1779,12 +1878,16 @@ pub async fn run(args: Args) -> Result<()> {
                 }
             }
         }
-    }
+        if stdout_is_broken() {
+            app.kill_session_immediately();
+            break true;
+        }
+    };
 
     // clean shutdown: release control if held, kill the whole local transport
     // tree (including any ProxyCommand), restore tty
     if let Some(mut s) = app.session.take() {
-        if s.mode == Mode::Control {
+        if !stdout_broken && s.mode == Mode::Control {
             let _ = s.stdin.write_all(b"{\"type\":\"terminal.release\"}\n").await;
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
@@ -2350,6 +2453,7 @@ mod tests {
             next_gen: 0,
             backoff_idx: 0,
             reconnect_at: None,
+            stream_paused: false,
             control_failures: 0,
             control_sticky: false,
             pending_input: Vec::new(),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -167,6 +167,41 @@ pub struct RemoteHost {
     log: Logger,
 }
 
+/// A small, cloneable view of an already-connected host for a detached
+/// best-effort orphan reap. It carries the established ControlMaster path (or
+/// resolved container) rather than creating another transport.
+#[derive(Clone)]
+pub(crate) struct OrphanReaper {
+    cfg: HostConfig,
+    ctl_path: PathBuf,
+    container: Option<crate::docker::Container>,
+}
+
+impl OrphanReaper {
+    pub async fn reap_orphans(&self) -> Result<()> {
+        let command = reap_orphans_command(self.cfg.session.as_deref(), None);
+        if let Some(container) = &self.container {
+            return container.exec(&command, 10_000).await.map(|_| ());
+        }
+        let args = vec![
+            "-S".into(),
+            self.ctl_path.display().to_string(),
+            "-o".into(),
+            "BatchMode=yes".into(),
+            self.cfg.target.clone(),
+            command,
+        ];
+        let result = ssh(&args, 10_000).await;
+        if result.code != 0 {
+            return Err(err(format!(
+                "ssh orphan reap failed: {}",
+                nonempty(&result.err, result.code)
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// FNV-1a, truncated to 8 hex chars.
 ///
 /// NOT `DefaultHasher`: this value lands in a path the daemon and every
@@ -243,6 +278,33 @@ pub(crate) fn control_path(state_dir: &std::path::Path, host_name: &str) -> Path
     state_dir.join(format!("{}.ctl", socket_stem(state_dir, host_name)))
 }
 
+/// Shell command which reaps only abandoned terminal-session observers.
+///
+/// A local ssh process can disappear while its remote `observe` child is
+/// reparented to init, so this deliberately selects *only* ppid 1. Session and
+/// pane filters narrow the cleanup without ever matching a healthy observer
+/// still parented by sshd.
+pub fn reap_orphans_command(session: Option<&str>, pane: Option<&str>) -> String {
+    let mut awk_vars = String::new();
+    let mut predicate = String::from("$2==1 && /terminal session observe/");
+    if let Some(session) = session {
+        awk_vars.push_str(&format!(
+            " -v session={}",
+            crate::pane::sh_quote(&format!("--session {session}"))
+        ));
+        predicate.push_str(" && index($0, session)");
+    }
+    if let Some(pane) = pane {
+        awk_vars.push_str(&format!(" -v pane={}", crate::pane::sh_quote(pane)));
+        predicate.push_str(" && index($0, pane)");
+    }
+    let program = format!("{predicate} {{print $1}}");
+    format!(
+        "ps -eo pid=,ppid=,args= 2>/dev/null | awk{awk_vars} {} | while read p; do kill \"$p\" 2>/dev/null; done",
+        crate::pane::sh_quote(&program)
+    )
+}
+
 impl RemoteHost {
     pub fn new(cfg: &HostConfig, state_dir: &std::path::Path) -> RemoteHost {
         let stem = socket_stem(state_dir, &cfg.name);
@@ -312,6 +374,16 @@ impl RemoteHost {
         ]
     }
 
+    /// A cloneable executor for a delayed cleanup task. It deliberately keeps
+    /// the current ControlMaster/container instead of forcing a second dial.
+    pub(crate) fn orphan_reaper(&self) -> OrphanReaper {
+        OrphanReaper {
+            cfg: self.cfg.clone(),
+            ctl_path: self.ctl_path.clone(),
+            container: self.container.clone(),
+        }
+    }
+
     pub async fn ensure_master(&mut self) -> Result<()> {
         let mut check = self.base_args();
         check.extend(["-O".into(), "check".into(), self.cfg.target.clone()]);
@@ -369,6 +441,16 @@ impl RemoteHost {
             )));
         }
         Ok(res.out)
+    }
+
+    /// Best-effort remote cleanup after a streamer transport is torn down.
+    /// `exec` reuses the daemon's ControlMaster for ssh hosts and its existing
+    /// container execution path for docker hosts; callers log failure rather
+    /// than making cleanup availability a connection failure.
+    pub async fn reap_orphans(&self, pane: Option<&str>) -> Result<()> {
+        self.exec(&reap_orphans_command(self.cfg.session.as_deref(), pane), 10_000)
+            .await
+            .map(|_| ())
     }
 
     pub async fn status(&self) -> Result<RemoteStatus> {
@@ -660,6 +742,38 @@ mod tests {
             api_transport: ApiTransport::Auto,
             always_control: true,
         }
+    }
+
+    #[test]
+    fn reap_command_always_scopes_to_orphaned_processes() {
+        let command = reap_orphans_command(None, None);
+        assert!(command.contains("$2==1"));
+        assert!(!command.contains("$2!=1"));
+    }
+
+    #[test]
+    fn reap_command_scopes_to_the_configured_session() {
+        let scoped = reap_orphans_command(Some("session-alpha"), None);
+        let unscoped = reap_orphans_command(None, None);
+        assert!(scoped.contains("--session session-alpha"));
+        assert!(!unscoped.contains("--session"));
+    }
+
+    #[test]
+    fn reap_command_quotes_a_session_name_safely() {
+        let command = reap_orphans_command(Some("blue room's session"), None);
+        assert!(command.contains("--session blue room"));
+        assert!(command.contains("'\\''"));
+        assert!(!command.contains("--session blue room's session;"));
+    }
+
+    #[test]
+    fn reap_command_narrows_to_one_pane_when_given() {
+        let narrowed = reap_orphans_command(None, Some("w1:p2"));
+        let broad = reap_orphans_command(None, None);
+        assert!(narrowed.contains("-v pane="));
+        assert!(narrowed.contains("w1:p2"));
+        assert!(!broad.contains("-v pane="));
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -314,6 +314,38 @@ pub fn streamer_spawn_pending_path(state_dir: &Path, local_pane_id: &str) -> Pat
     state_dir.join("streamer-spawns").join(format!("{}.pending", sane_component(local_pane_id)))
 }
 
+/// Desired stream state for one local mirror pane. Its existence means the
+/// pane wrapper must not retain an ssh/observe session.
+pub fn streamer_pause_path(state_dir: &Path, local_pane_id: &str) -> PathBuf {
+    state_dir.join("streamer-pause").join(format!("{}.pause", sane_component(local_pane_id)))
+}
+
+pub fn streamer_paused(state_dir: &Path, local_pane_id: &str) -> bool {
+    streamer_pause_path(state_dir, local_pane_id).exists()
+}
+
+/// Set one streamer's desired state. The caller sends SIGUSR1 after this write
+/// or removal so a live wrapper observes it immediately.
+pub fn set_streamer_paused(
+    state_dir: &Path,
+    local_pane_id: &str,
+    paused: bool,
+) -> std::io::Result<()> {
+    let path = streamer_pause_path(state_dir, local_pane_id);
+    if paused {
+        if let Some(dir) = path.parent() {
+            fs::create_dir_all(dir)?;
+        }
+        fs::write(path, "")
+    } else {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
 /// How long a `.pending` claim may block another launch. The retype loop is
 /// 3s+4s+4s; anything older is leftover from a crashed or abandoned attempt
 /// and must not freeze heal forever.
@@ -509,6 +541,15 @@ mod tests {
             StreamerSpawnClaim::Claimed
         );
         let _ = fs::remove_dir_all(state_dir);
+    }
+
+    #[test]
+    fn streamer_pause_path_is_sane_and_separate() {
+        let state_dir = test_state_dir("pause-path");
+        let pause = streamer_pause_path(&state_dir, "w1:p1/unsafe");
+        assert_eq!(pause, state_dir.join("streamer-pause").join("w1_p1_unsafe.pause"));
+        assert_eq!(pause.parent(), Some(state_dir.join("streamer-pause").as_path()));
+        assert_ne!(pause, streamer_spawn_pending_path(&state_dir, "w1:p1/unsafe"));
     }
 
     #[test]

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -1,0 +1,282 @@
+// Stream scheduling for mirrored panes.
+//
+// This module intentionally has no filesystem, API, or clock reads.  The
+// daemon owns those effects; keeping the decision here pure makes focus and
+// grace-period behaviour straightforward to test.
+
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+
+/// The stream policy loaded from `[stream]` in hosts.toml.
+#[derive(Debug, Clone)]
+pub struct StreamPolicy {
+    pub visible_only: bool,
+    pub pause_after: Duration,
+}
+
+/// The daemon's current knowledge of one mapped local pane.
+#[derive(Debug, Clone)]
+pub struct PaneStreamState {
+    pub local_id: String,
+    /// Whether its pause marker is absent, i.e. the streamer should have an
+    /// active remote session.
+    pub streaming: bool,
+    /// When it most recently became invisible. Cleared as soon as it returns
+    /// to the focused workspace/tab.
+    pub hidden_since: Option<Instant>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum StreamAction {
+    Start(String),
+    Stop(String),
+}
+
+/// Return the local panes which are visible in the currently focused view.
+///
+/// A missing focused workspace is an older-server shape, not evidence that no
+/// panes are visible. Keep every pane live in that case so an upgrade cannot
+/// silently pause an entire mirror fleet.
+pub fn visible_local_panes(snap: &crate::mirror::Snapshot) -> HashSet<String> {
+    let Some(focused_workspace_id) = snap.focused_workspace_id.as_deref() else {
+        return snap.panes.iter().map(|pane| pane.pane_id.clone()).collect();
+    };
+
+    let focused_tab_id = snap
+        .focused_tab_id
+        .as_deref()
+        .or_else(|| {
+            snap.workspaces
+                .iter()
+                .find(|workspace| workspace.workspace_id == focused_workspace_id)
+                .and_then(|workspace| workspace.active_tab_id.as_deref())
+        });
+    let Some(focused_tab_id) = focused_tab_id else {
+        return HashSet::new();
+    };
+
+    let panes_in_focused_view: HashSet<String> = snap
+        .panes
+        .iter()
+        .filter(|pane| {
+            pane.workspace_id == focused_workspace_id && pane.tab_id == focused_tab_id
+        })
+        .map(|pane| pane.pane_id.clone())
+        .collect();
+
+    if let Some(layout) = snap
+        .layouts
+        .iter()
+        .find(|layout| layout.tab_id == focused_tab_id && layout.zoomed)
+    {
+        return layout
+            .focused_pane_id
+            .as_ref()
+            .filter(|pane_id| panes_in_focused_view.contains(*pane_id))
+            .into_iter()
+            .cloned()
+            .collect();
+    }
+
+    panes_in_focused_view
+}
+
+/// Decide which pause-marker transitions are required now.
+pub fn plan_streams(
+    policy: &StreamPolicy,
+    link_up: bool,
+    visible: &HashSet<String>,
+    tracked: &[PaneStreamState],
+    now: Instant,
+) -> Vec<StreamAction> {
+    if !link_up {
+        return tracked
+            .iter()
+            .filter(|pane| pane.streaming)
+            .map(|pane| StreamAction::Stop(pane.local_id.clone()))
+            .collect();
+    }
+
+    if !policy.visible_only {
+        return tracked
+            .iter()
+            .filter(|pane| !pane.streaming)
+            .map(|pane| StreamAction::Start(pane.local_id.clone()))
+            .collect();
+    }
+
+    tracked
+        .iter()
+        .filter_map(|pane| {
+            if visible.contains(&pane.local_id) && !pane.streaming {
+                Some(StreamAction::Start(pane.local_id.clone()))
+            } else if !visible.contains(&pane.local_id)
+                && pane.streaming
+                && pane
+                    .hidden_since
+                    .is_some_and(|hidden_since| now.saturating_duration_since(hidden_since) >= policy.pause_after)
+            {
+                Some(StreamAction::Stop(pane.local_id.clone()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// The earliest pending visible-only grace expiry, if there is one.
+pub fn next_deadline(policy: &StreamPolicy, tracked: &[PaneStreamState]) -> Option<Instant> {
+    if !policy.visible_only {
+        return None;
+    }
+    tracked
+        .iter()
+        .filter(|pane| pane.streaming)
+        .filter_map(|pane| pane.hidden_since.and_then(|hidden_since| hidden_since.checked_add(policy.pause_after)))
+        .min()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn policy() -> StreamPolicy {
+        StreamPolicy { visible_only: true, pause_after: Duration::from_secs(30) }
+    }
+
+    fn snapshot_value() -> serde_json::Value {
+        json!({
+            "focused_workspace_id": "ws-alpha",
+            "focused_tab_id": "tab-alpha-1",
+            "protocol": "synthetic",
+            "version": "test",
+            "workspaces": [
+                {"workspace_id": "ws-alpha", "label": "alpha", "number": 1, "focused": true,
+                 "active_tab_id": "tab-alpha-1", "tab_count": 2, "pane_count": 3, "agent_status": "idle"},
+                {"workspace_id": "ws-beta", "label": "beta", "number": 2, "focused": false,
+                 "active_tab_id": "tab-beta-1", "tab_count": 2, "pane_count": 2, "agent_status": "idle"}
+            ],
+            "tabs": [
+                {"tab_id": "tab-alpha-1", "workspace_id": "ws-alpha", "label": "alpha-one", "number": 1, "focused": true, "pane_count": 2, "agent_status": "idle"},
+                {"tab_id": "tab-alpha-2", "workspace_id": "ws-alpha", "label": "alpha-two", "number": 2, "focused": false, "pane_count": 1, "agent_status": "idle"},
+                {"tab_id": "tab-beta-1", "workspace_id": "ws-beta", "label": "beta-one", "number": 1, "focused": false, "pane_count": 1, "agent_status": "idle"},
+                {"tab_id": "tab-beta-2", "workspace_id": "ws-beta", "label": "beta-two", "number": 2, "focused": false, "pane_count": 1, "agent_status": "idle"}
+            ],
+            "panes": [
+                {"pane_id": "w1:p1", "tab_id": "tab-alpha-1", "workspace_id": "ws-alpha", "focused": true, "cwd": "/tmp", "foreground_cwd": "/tmp", "terminal_title": "one"},
+                {"pane_id": "w1:p2", "tab_id": "tab-alpha-1", "workspace_id": "ws-alpha", "focused": false, "cwd": "/tmp", "foreground_cwd": "/tmp", "terminal_title": "two"},
+                {"pane_id": "w1:p3", "tab_id": "tab-alpha-2", "workspace_id": "ws-alpha", "focused": false, "cwd": "/tmp", "foreground_cwd": "/tmp", "terminal_title": "three"},
+                {"pane_id": "w2:p1", "tab_id": "tab-beta-1", "workspace_id": "ws-beta", "focused": false, "cwd": "/tmp", "foreground_cwd": "/tmp", "terminal_title": "four"},
+                {"pane_id": "w2:p2", "tab_id": "tab-beta-2", "workspace_id": "ws-beta", "focused": false, "cwd": "/tmp", "foreground_cwd": "/tmp", "terminal_title": "five"}
+            ],
+            "layouts": [
+                {"tab_id": "tab-alpha-1", "workspace_id": "ws-alpha", "zoomed": false, "focused_pane_id": "w1:p1",
+                 "area": {}, "panes": [
+                    {"pane_id": "w1:p1", "focused": true, "rect": {"x": 0, "y": 0, "width": 40, "height": 20}},
+                    {"pane_id": "w1:p2", "focused": false, "rect": {"x": 40, "y": 0, "width": 40, "height": 20}}
+                 ], "splits": []},
+                {"tab_id": "tab-alpha-2", "workspace_id": "ws-alpha", "zoomed": false, "focused_pane_id": "w1:p3",
+                 "area": {}, "panes": [{"pane_id": "w1:p3", "focused": false, "rect": {"x": 0, "y": 0, "width": 80, "height": 20}}], "splits": []},
+                {"tab_id": "tab-beta-1", "workspace_id": "ws-beta", "zoomed": false, "focused_pane_id": "w2:p1",
+                 "area": {}, "panes": [{"pane_id": "w2:p1", "focused": false, "rect": {"x": 0, "y": 0, "width": 80, "height": 20}}], "splits": []},
+                {"tab_id": "tab-beta-2", "workspace_id": "ws-beta", "zoomed": false, "focused_pane_id": "w2:p2",
+                 "area": {}, "panes": [{"pane_id": "w2:p2", "focused": false, "rect": {"x": 0, "y": 0, "width": 80, "height": 20}}], "splits": []}
+            ]
+        })
+    }
+
+    fn snapshot(value: serde_json::Value) -> crate::mirror::Snapshot {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn ids(values: &[&str]) -> HashSet<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn hidden_pane_survives_the_grace_window() {
+        let now = Instant::now();
+        let tracked = [PaneStreamState {
+            local_id: "local-hidden".into(),
+            streaming: true,
+            hidden_since: Some(now - Duration::from_secs(5)),
+        }];
+        assert_eq!(plan_streams(&policy(), true, &HashSet::new(), &tracked, now), Vec::<StreamAction>::new());
+    }
+
+    #[test]
+    fn hidden_pane_stops_after_the_grace_window() {
+        let now = Instant::now();
+        let tracked = [PaneStreamState {
+            local_id: "local-hidden".into(),
+            streaming: true,
+            hidden_since: Some(now - Duration::from_secs(31)),
+        }];
+        assert_eq!(
+            plan_streams(&policy(), true, &HashSet::new(), &tracked, now),
+            vec![StreamAction::Stop("local-hidden".into())]
+        );
+    }
+
+    #[test]
+    fn only_the_focused_workspace_and_active_tab_are_visible() {
+        let visible = visible_local_panes(&snapshot(snapshot_value()));
+        assert_eq!(visible, ids(&["w1:p1", "w1:p2"]));
+        assert!(!visible.contains("w2:p1"));
+        assert!(!visible.contains("w2:p2"));
+    }
+
+    #[test]
+    fn a_zoomed_tab_shows_only_the_zoomed_pane() {
+        let mut value = snapshot_value();
+        value["layouts"][0]["zoomed"] = json!(true);
+        value["layouts"][0]["focused_pane_id"] = json!("w1:p2");
+        assert_eq!(visible_local_panes(&snapshot(value)), ids(&["w1:p2"]));
+    }
+
+    #[test]
+    fn missing_focus_fields_keep_every_pane_visible() {
+        let mut value = snapshot_value();
+        value.as_object_mut().unwrap().remove("focused_workspace_id");
+        assert_eq!(
+            visible_local_panes(&snapshot(value)),
+            ids(&["w1:p1", "w1:p2", "w1:p3", "w2:p1", "w2:p2"])
+        );
+    }
+
+    #[test]
+    fn a_lost_link_stops_every_streamer_without_grace() {
+        let now = Instant::now();
+        let tracked = [
+            PaneStreamState { local_id: "local-visible".into(), streaming: true, hidden_since: None },
+            PaneStreamState {
+                local_id: "local-hidden".into(),
+                streaming: true,
+                hidden_since: Some(now - Duration::from_secs(1)),
+            },
+        ];
+        assert_eq!(
+            plan_streams(&policy(), false, &ids(&["local-visible"]), &tracked, now),
+            vec![StreamAction::Stop("local-visible".into()), StreamAction::Stop("local-hidden".into())]
+        );
+    }
+
+    #[test]
+    fn visible_only_off_never_stops_a_streamer() {
+        let now = Instant::now();
+        let policy = StreamPolicy { visible_only: false, pause_after: Duration::from_secs(30) };
+        let tracked = [
+            PaneStreamState {
+                local_id: "local-hidden-streaming".into(),
+                streaming: true,
+                hidden_since: Some(now - Duration::from_secs(31)),
+            },
+            PaneStreamState { local_id: "local-paused".into(), streaming: false, hidden_since: None },
+        ];
+        assert_eq!(
+            plan_streams(&policy, true, &HashSet::new(), &tracked, now),
+            vec![StreamAction::Start("local-paused".into())]
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Fixes the streaming pressure and abandoned remote observers described in [#96](https://github.com/nikok6/herdr-mirror/issues/96).

## Changes

Mirror mappings and local panes remain intact, while only panes visible in the focused local workspace/tab keep a stream; hidden panes pause after a configurable grace period and resume on focus. Stopping a streamer ends only its remote observe session; its local pane and mapping remain. Link loss pauses every host streamer immediately. Because remote observe can survive an sshd disappearance, teardown is followed by a best-effort batch reap of only ppid 1 observers scoped to the configured session; an unreachable host is swept on reconnect.

## Validation

`cargo clippy --all-targets -- -D warnings`, `cargo test --locked` (229 passed, 4 ignored), and release build pass. An isolated three-pane smoke observed 3 streams when visible, 1 when zoomed, 2 during a focus grace transition, 1 after expiry, and zero scoped ppid 1 observers.

## Settings

`[stream] visible_only = true` and `pause_after_secs = 30` are the defaults. Set `visible_only = false` to retain all-pane streaming.
