### PR TITLE
fix: focus forwarded plugin panes and preserve document headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ the action locally, so one key covers both worlds. The plugin must be
 installed on whichever end runs it. See
 [Remote plugin keys](#remote-plugin-keys) for binding it.
 
+When the action prints Herdr's focused `plugin_pane` JSON result, Mirror waits
+for that pane's mapping and focuses it locally. It follows the specific action's
+completion, not the remote server's global focus, and leaves your focus alone
+if you navigated away while the action started. Plugins should use a split with
+the translated target pane: remote overlays/popups are not mirrored as overlays.
+
 **Continuous streaming** — every mirror pane streams its remote pane live for
 its whole lifetime, each over its own connection, so panes are never
 blank and a busy pane can't contend with or drop another's stream. Sidebar

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -21,7 +21,13 @@ pub(crate) fn cw(ch: char) -> usize {
 /// the renderer, the prediction overlay and the selection overlay all call here
 /// rather than each keeping the formula.
 pub fn window_offset(grid: &Grid, out_rows: usize) -> usize {
-    let bottom = grid.content_bottom.max(grid.cursor_row);
+    // Observe frames may park a hidden cursor in their padded bottom row.
+    // It is not visible content: anchoring to it crops the top of document TUIs.
+    let bottom = if grid.cursor_visible {
+        grid.content_bottom.max(grid.cursor_row)
+    } else {
+        grid.content_bottom
+    };
     (bottom + 1).saturating_sub(out_rows)
 }
 
@@ -606,6 +612,20 @@ mod tests {
         // unchanged rows are not repainted
         let out3 = r.paint(&g, 5, 3);
         assert!(!out3.contains("last"));
+    }
+
+    #[test]
+    fn hidden_cursor_in_observe_padding_does_not_crop_the_document_header() {
+        let mut grid = Grid::new();
+        grid.resize(120, 50);
+        grid.apply("\x1b[2;1HDOC_HEADER\x1b[39;1Hdocument footer\x1b[50;1H\x1b[?25l");
+        let mut renderer = Renderer::new();
+        let output = renderer.paint(&grid, 67, 41);
+        assert!(output.contains("DOC_HEADER"));
+        assert!(output.contains("document footer"));
+        // A visible shell cursor below the text must still remain in view.
+        grid.apply("\x1b[50;1H\x1b[?25h");
+        assert_eq!(window_offset(&grid, 41), 9);
     }
 
     const LINK: &str = "\x1b]8;;https://example.com/x\x1b\\";

--- a/src/remote_action.rs
+++ b/src/remote_action.rs
@@ -50,6 +50,8 @@ use crate::remote::RemoteHost;
 use crate::state::load_state;
 use crate::util::{err, Env, Result};
 
+mod focus;
+
 #[derive(Debug, Default, Deserialize)]
 struct InvocationContext {
     workspace_id: Option<String>,
@@ -256,30 +258,46 @@ async fn invoke(env: &Env, spec: &str) -> Result<()> {
     let mut remote = RemoteHost::new(&resolved.host, &env.state_dir);
     let (api, _status) = remote.connect_api().await?;
 
-    // the remote action sees the REMOTE objects behind the invoking mirror,
-    // including the real cwd of the pane it will act on
-    let mut context = json!({ "invocation_source": "mirror" });
-    if let Some(ws) = &resolved.remote_ws_id {
-        context["workspace_id"] = json!(ws);
-    }
-    if let Some(pane_id) = &resolved.remote_pane_id {
-        context["focused_pane_id"] = json!(pane_id);
-        let snap = fetch_snapshot(&api).await?;
-        if let Some(pane) = snap.panes.iter().find(|p| &p.pane_id == pane_id) {
-            if let Some(cwd) = pane.foreground_cwd.clone().or_else(|| pane.cwd.clone()) {
-                context["focused_pane_cwd"] = json!(cwd);
-            }
-        }
-    }
+    // Resolve the whole location from the live remote pane. The remote's
+    // globally active tab may belong to a different workspace/client.
+    let snapshot = api.request("session.snapshot", json!({})).await?;
+    let context = remote_context(&snapshot["snapshot"], resolved.remote_pane_id.as_deref().unwrap())?;
     let params = json!({ "action_id": spec, "context": context });
-    api.request("plugin.action.invoke", params).await.map_err(|e| {
+    let invocation = api.request("plugin.action.invoke", params).await.map_err(|e| {
         err(format!(
             "remote invoke {spec} on {}: {e} (needs the plugin installed there, and a herdr with plugin.action.invoke)",
             resolved.host.name
         ))
     })?;
+    focus::follow(env, &ctx, &resolved.host.name, &api, &invocation).await?;
     println!("invoked {spec} on {}", resolved.host.name);
     Ok(())
+}
+
+fn remote_context(snapshot: &Value, pane_id: &str) -> Result<Value> {
+    let rows = |key: &str| snapshot[key].as_array().map(Vec::as_slice).unwrap_or(&[]);
+    let pane = rows("panes").iter().find(|p| p["pane_id"] == pane_id)
+        .ok_or_else(|| err(format!("remote pane {pane_id} disappeared before invoking the plugin")))?;
+    let ws = rows("workspaces").iter().find(|w| w["workspace_id"] == pane["workspace_id"]);
+    let tab = rows("tabs").iter().find(|t| t["tab_id"] == pane["tab_id"]);
+    // Herdr 0.8.2 backfills null/omitted fields from its global focus. Empty
+    // strings prevent a shell pane from inheriting another pane's agent/cwd.
+    let text = |v: &Value, key: &str| v[key].as_str().unwrap_or("").to_owned();
+    Ok(json!({
+        "invocation_source": "mirror",
+        "workspace_id": pane["workspace_id"],
+        "workspace_label": ws.map(|w| text(w, "label")).unwrap_or_default(),
+        "workspace_cwd": ws.map(|w| text(w, "cwd")).unwrap_or_default(),
+        "tab_id": pane["tab_id"],
+        "tab_label": tab.map(|t| text(t, "label")).unwrap_or_default(),
+        "focused_pane_id": pane_id,
+        "focused_pane_cwd": pane["foreground_cwd"].as_str().or(pane["cwd"].as_str()).unwrap_or(""),
+        "focused_pane_agent": text(pane, "agent"),
+        "focused_pane_status": text(pane, "agent_status"),
+        "selected_text": "",
+        "clicked_url": "",
+        "link_handler_id": "",
+    }))
 }
 
 async fn run(env: &Env, kind: &str, direction: Option<&str>) -> Result<()> {

--- a/src/remote_action/focus.rs
+++ b/src/remote_action/focus.rs
@@ -1,0 +1,100 @@
+//! Follow a forwarded plugin's explicit pane result, never the remote's global focus.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::time::{sleep, timeout};
+
+use super::InvocationContext;
+use crate::api::ApiClient;
+use crate::state::load_state;
+use crate::util::{err, Env, Result};
+
+/// `plugin.action.invoke` returns a running command log, not the pane it will
+/// open. Watch that exact log; another invocation may finish first. Plugins
+/// which don't print a focused `plugin_pane` result retain their old behavior.
+pub(super) async fn follow(
+    env: &Env,
+    context: &InvocationContext,
+    host: &str,
+    remote: &ApiClient,
+    invocation: &Value,
+) -> Result<()> {
+    let Some(log_id) = invocation.pointer("/log/log_id").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    let Some(plugin_id) = invocation.pointer("/log/plugin_id").and_then(Value::as_str) else {
+        return Ok(());
+    };
+    // Some actions are themselves long-running; keep them asynchronous after
+    // this bounded opportunity to follow a pane, rather than killing the action.
+    let completed = timeout(Duration::from_secs(15), completed_log(remote, plugin_id, log_id)).await;
+    let Ok(completed) = completed else { return Ok(()) };
+    let log = completed?;
+    if log["status"] == "failed" {
+        return Err(err(format!("remote plugin {plugin_id} failed on {host}; inspect {log_id}")));
+    }
+    let Some(pane_id) = focused_result(&log, plugin_id) else { return Ok(()) };
+    let local = ApiClient::connect(&env.local_socket).await?;
+    timeout(Duration::from_secs(15), focus_when_mapped(env, context, host, &local, &pane_id))
+        .await
+        .map_err(|_| err(format!("plugin opened {pane_id} on {host}, but its mirror did not appear; check the mirror daemon")))?
+}
+
+async fn completed_log(remote: &ApiClient, plugin_id: &str, log_id: &str) -> Result<Value> {
+    loop {
+        let response = remote.request("plugin.log.list", json!({"plugin_id": plugin_id, "limit": 200})).await?;
+        if let Some(log) = response["logs"].as_array().into_iter().flatten().find(|l| l["log_id"] == log_id) {
+            if log["status"] != "running" {
+                return Ok(log.clone());
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn focused_result(log: &Value, plugin_id: &str) -> Option<String> {
+    if log["status"] != "succeeded" {
+        return None;
+    }
+    let result: Value = serde_json::from_str(log["stdout"].as_str()?).ok()?;
+    let plugin_pane = result.pointer("/result/plugin_pane")?;
+    if plugin_pane["plugin_id"] != plugin_id || plugin_pane["pane"]["focused"] != true {
+        return None;
+    }
+    plugin_pane["pane"]["pane_id"].as_str().filter(|p| !p.is_empty()).map(str::to_owned)
+}
+
+async fn focus_when_mapped(
+    env: &Env,
+    context: &InvocationContext,
+    host: &str,
+    local: &ApiClient,
+    remote_pane: &str,
+) -> Result<()> {
+    let Some(source_pane) = &context.focused_pane_id else { return Ok(()) };
+    loop {
+        let snapshot = local.request("session.snapshot", json!({})).await?;
+        if snapshot["snapshot"]["focused_pane_id"] != *source_pane {
+            // Do not pull the user back after they navigate away during SSH or
+            // plugin startup. The new mirror remains available in its tab.
+            return Ok(());
+        }
+        let state = load_state(&env.state_dir, host);
+        if let Some(entry) = state.panes.get(remote_pane) {
+            if entry.is_tombstoned() {
+                return Ok(());
+            }
+            let exists = snapshot["snapshot"]["panes"].as_array().into_iter().flatten()
+                .any(|p| p["pane_id"] == entry.local_id);
+            if exists {
+                local.request("pane.focus", json!({"pane_id": entry.local_id})).await?;
+                return Ok(());
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/remote_action/focus/tests.rs
+++ b/src/remote_action/focus/tests.rs
@@ -1,0 +1,123 @@
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixListener;
+
+use super::*;
+use crate::state::{save_state, HostState, PaneEntry};
+
+fn pane_log(id: &str, pane: &str) -> Value {
+    json!({
+        "log_id": id, "plugin_id": "review", "status": "succeeded", "exit_code": 0,
+        "stdout": json!({"result":{"plugin_pane":{
+            "plugin_id":"review", "pane":{"pane_id":pane,"focused":true}
+        }}}).to_string()
+    })
+}
+
+async fn exercise(navigate_away: bool) -> Vec<String> {
+    let root = std::env::temp_dir().join(format!("mirror-action-focus-{}-{navigate_away}", std::process::id()));
+    std::fs::create_dir_all(&root).unwrap();
+    let socket = root.join("api.sock");
+    let listener = UnixListener::bind(&socket).unwrap();
+    let env = Env { config_search: vec![], state_dir: root.clone(), local_socket: socket.clone() };
+    let focused = Arc::new(Mutex::new(Vec::<String>::new()));
+    let server_focused = focused.clone();
+    let server_root = root.clone();
+    let server = tokio::spawn(async move {
+        let mut log_polls = 0;
+        let mut snapshots = 0;
+        loop {
+            let (socket, _) = listener.accept().await.unwrap();
+            let (read, mut write) = socket.into_split();
+            let line = BufReader::new(read).lines().next_line().await.unwrap().unwrap();
+            let request: Value = serde_json::from_str(&line).unwrap();
+            let result = match request["method"].as_str().unwrap() {
+                "ping" => json!({}),
+                "plugin.log.list" => {
+                    assert_eq!(request["params"]["plugin_id"], "review");
+                    log_polls += 1;
+                    let wanted = if log_polls == 1 {
+                        json!({"log_id":"wanted", "status":"running"})
+                    } else { pane_log("wanted", "remote-review") };
+                    // A different action finishes first and is newest in the log.
+                    json!({"logs":[wanted, pane_log("other", "unrelated-review")]})
+                }
+                "session.snapshot" => {
+                    snapshots += 1;
+                    if snapshots == 2 {
+                        let mut state = HostState::default();
+                        state.panes.insert("remote-review".into(), PaneEntry {
+                            local_id:"local-review".into(), tombstone:None, seq:0, reported:None,
+                        });
+                        save_state(&server_root, "host", &state).unwrap();
+                    }
+                    json!({"snapshot":{
+                        "focused_pane_id":if navigate_away {"user-chosen"} else {"source"},
+                        "panes":[{"pane_id":"source"},{"pane_id":"local-review"}]
+                    }})
+                }
+                "pane.focus" => {
+                    server_focused.lock().unwrap().push(request["params"]["pane_id"].as_str().unwrap().into());
+                    json!({})
+                }
+                other => panic!("unexpected API request {other}"),
+            };
+            write.write_all(format!("{}\n", json!({"id":request["id"],"result":result})).as_bytes()).await.unwrap();
+        }
+    });
+    let api = ApiClient::connect(&socket).await.unwrap();
+    follow(&env, &InvocationContext {workspace_id:Some("local-workspace".into()),focused_pane_id:Some("source".into())},
+        "host", &api, &json!({"log":{"log_id":"wanted","plugin_id":"review"}})).await.unwrap();
+    server.abort();
+    let _ = server.await;
+    std::fs::remove_dir_all(root).unwrap();
+    Arc::try_unwrap(focused).unwrap().into_inner().unwrap()
+}
+
+#[tokio::test]
+async fn follows_its_own_completed_action_after_the_mirror_mapping_arrives() {
+    assert_eq!(exercise(false).await, ["local-review"]);
+}
+
+#[tokio::test]
+async fn user_navigation_during_the_action_is_not_overridden() {
+    assert!(exercise(true).await.is_empty());
+}
+
+#[test]
+fn only_an_explicit_focused_pane_from_the_invoked_plugin_is_followed() {
+    let log = pane_log("wanted", "remote-review");
+    assert_eq!(focused_result(&log, "review").as_deref(), Some("remote-review"));
+    assert_eq!(focused_result(&log, "other-plugin"), None);
+    for stdout in [
+        "plain action output".to_owned(),
+        json!({"result":{"pane":{"pane_id":"not-a-plugin-pane","focused":true}}}).to_string(),
+        json!({"result":{"plugin_pane":{"plugin_id":"review","pane":{"pane_id":"background","focused":false}}}}).to_string(),
+    ] {
+        let mut background = log.clone();
+        background["stdout"] = json!(stdout);
+        assert_eq!(focused_result(&background, "review"), None);
+    }
+}
+
+#[test]
+fn context_comes_from_the_invoking_remote_pane_even_when_global_focus_differs() {
+    let snapshot = json!({
+        "focused_workspace_id":"other", "focused_tab_id":"other-tab", "focused_pane_id":"other-pane",
+        "workspaces":[{"workspace_id":"remote-ws","cwd":"/project","label":"Project"}],
+        "tabs":[{"tab_id":"remote-tab","label":"Code"}],
+        "panes":[{"pane_id":"remote-pane","workspace_id":"remote-ws","tab_id":"remote-tab",
+            "cwd":"/project","foreground_cwd":"/project/docs","agent":"codex","agent_status":"done"}]
+    });
+    let context = super::super::remote_context(&snapshot, "remote-pane").unwrap();
+    assert_eq!(context["workspace_id"], "remote-ws");
+    assert_eq!(context["tab_id"], "remote-tab");
+    assert_eq!(context["workspace_cwd"], "/project");
+    assert_eq!(context["focused_pane_cwd"], "/project/docs");
+    assert_eq!(context["focused_pane_agent"], "codex");
+    assert!(super::super::remote_context(&snapshot, "closed-pane").is_err());
+    let mut shell = snapshot;
+    shell["panes"][0].as_object_mut().unwrap().remove("agent");
+    assert_eq!(super::super::remote_context(&shell, "remote-pane").unwrap()["focused_pane_agent"], "");
+}


### PR DESCRIPTION
## What changed

Forwarded plugin actions now receive their actual remote pane's workspace, tab, cwd and agent context. Mirror follows the exact asynchronous command log returned by `plugin.action.invoke`; if it prints a focused `plugin_pane` result, Mirror waits for that pane's mapping and focuses it locally while the user is still in the invoking pane. Background/non-pane actions keep their focus behavior, and long-running commands continue independently after the bounded wait.

The renderer also excludes hidden cursors from its bottom anchor. A 47-row observe frame with content through row 39 and a hidden cursor at row 47 should not crop a document heading out of a 41-row local pane.

Fixes #98. Remote overlay placement is handled separately in plannotator/plannotator-tui#62; plugins can use a targeted split with the translated pane ID.

## Validation

- `cargo test --locked`: 221 passed, 4 existing manual-environment tests ignored.
- `cargo clippy --all-targets -- -D warnings`: passed.
- Backport to the pinned 0.4.2 source: 207 tests passed, 4 ignored; Linux musl release built.
- Isolated two-server smoke with real Herdr 0.8.2 processes, a local SSH shim, packaged Mirror and Annotate, synthetic Markdown files and a synthetic Codex transcript: actual `prefix+o`, `Tab/j/Enter` file switching, `prefix+Shift+o`, and a repeated document open all reached the intended remote tab, gained local focus, rendered the expected content, and converged after close. The remote server's global focus was deliberately different before every invocation.
- Focus regressions cover another action finishing first, delayed mirror mapping, and user navigation during startup. The hidden-cursor regression failed before the renderer change.
- The installed packages also passed the shortcut, focus, rendering, file-switching and exact-reply checks over a real SSH connection between two Linux hosts, using an isolated remote Herdr fixture and Mirror's own API relay. The temporary sessions were removed afterward.
