### PR TITLE
Add takeover option: evict a stale remote controller on control

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,11 @@ dropped files need nothing). Uploads aren't cleaned up; `rm -rf
 # max_cols / max_rows    # cap the size control asks the remote for, so a
                          # machine with its own display keeps its geometry.
                          # A ceiling only, and never applies to watch-only.
+# takeover = false       # default. Set true to evict whoever holds a remote
+                         # pane's controller when a mirror takes control (an
+                         # orphaned ssh from a closed mirror, say) instead of
+                         # showing "control unavailable — viewing only". Leave
+                         # off for a host a human drives directly.
 
 [hosts.work]
 target = "work"
@@ -325,6 +330,7 @@ target = "work"
 # max_rows = 58                      # always_control = false
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
+# takeover = true                    # per-host override; see global above
 # enabled = true                     # false stops syncing this host without
                                      # deleting its config; mirrors stay put
 # api_transport = "auto"             # how to reach the remote API socket:

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,11 @@ pub struct HostConfig {
     /// the local pane so it fills). Default on; ideal for headless remotes. Turn
     /// off per host for a remote a human is actively using directly.
     pub always_control: bool,
+    /// Pass `--takeover` when entering control, evicting whoever holds the
+    /// remote pane's controller (typically an orphaned ssh from a closed
+    /// mirror pane) instead of failing twice and dropping to observe. Default
+    /// off: on a host a human drives directly this would evict them.
+    pub takeover: bool,
     /// Cap the size control asks the remote for. `None` = uncapped: fill the
     /// local pane, which is right for a headless remote nobody looks at.
     /// Control is authoritative on the remote, so on a host with its own
@@ -158,6 +163,7 @@ struct RawConfig {
     default_host: Option<String>,
     close_remote_on_local_close: Option<bool>,
     always_control: Option<bool>,
+    takeover: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
     // toml::Table (preserve_order) keeps declaration order — the first host
@@ -179,6 +185,7 @@ struct RawHost {
     session: Option<String>,
     enabled: Option<bool>,
     always_control: Option<bool>,
+    takeover: Option<bool>,
     max_cols: Option<usize>,
     max_rows: Option<usize>,
     api_transport: Option<String>,
@@ -261,6 +268,7 @@ pub fn load_config(candidates: &[PathBuf]) -> Result<MirrorConfig> {
 pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     let raw: RawConfig = toml::from_str(text)?;
     let global_always_control = raw.always_control.unwrap_or(true);
+    let global_takeover = raw.takeover.unwrap_or(false);
     // 0 is treated as unset rather than "clamp to nothing", same as an empty
     // remote_bin: a cap that would starve the remote of every column is a typo,
     // not an instruction. Warn rather than dropping it silently — and say that
@@ -318,6 +326,7 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             remote_bin: h.remote_bin.filter(|s| !s.is_empty()),
             session: h.session.filter(|s| !s.is_empty()),
             always_control: h.always_control.unwrap_or(global_always_control),
+            takeover: h.takeover.unwrap_or(global_takeover),
             max_cols: size_cap(h.max_cols).or(global_max_cols),
             max_rows: size_cap(h.max_rows).or(global_max_rows),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
@@ -373,6 +382,21 @@ mod tests {
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert_eq!(h.session, None); // default remote session
         assert!(h.always_control); // default on
+        assert!(!h.takeover); // default off
+    }
+
+    #[test]
+    fn takeover_global_default_and_per_host_override() {
+        let c = parse_config(
+            "takeover = true\n\
+             [hosts.a]\ntarget = \"a\"\n\
+             [hosts.b]\ntarget = \"b\"\ntakeover = false\n",
+        )
+        .unwrap();
+        let a = c.hosts.iter().find(|h| h.name == "a").unwrap();
+        let b = c.hosts.iter().find(|h| h.name == "b").unwrap();
+        assert!(a.takeover); // inherits global on
+        assert!(!b.takeover); // per-host override off
     }
 
     #[test]

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -447,6 +447,7 @@ pub(crate) fn cmd_for_pane(
     let remote_bin = host.remote_bin.clone();
     let session = host.session.clone();
     let always_control = host.always_control;
+    let takeover = host.takeover;
     let max_cols = host.max_cols;
     let max_rows = host.max_rows;
     let kind = host.kind.clone();
@@ -474,6 +475,9 @@ pub(crate) fn cmd_for_pane(
         }
         if always_control {
             argv.push("--always-control".into());
+        }
+        if takeover {
+            argv.push("--takeover".into());
         }
         // absent when uncapped, so the argv of an unconfigured host is unchanged
         if let Some(c) = max_cols {
@@ -1757,6 +1761,7 @@ mod tests {
             remote_bin: None,
             session: None,
             always_control: true,
+            takeover: false,
             max_cols: None,
             max_rows: None,
             api_transport: crate::config::ApiTransport::Auto,
@@ -1971,6 +1976,21 @@ mod tests {
             argv[1..],
             ["pane", "vps", "w1:p1", "--ctl-path", "/state/vps.ctl"]
         );
+    }
+
+    /// takeover is off by default, so an unconfigured host's argv is unchanged;
+    /// on, it reaches the pane parser.
+    #[test]
+    fn takeover_reaches_the_streamer_argv() {
+        let mut host = ssh_host();
+        host.always_control = false;
+        let off = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        assert!(!off.iter().any(|a| a == "--takeover"));
+
+        host.takeover = true;
+        let argv = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new())("w1:p1");
+        let parsed = crate::pane::parse_args(&argv[2..]).expect("pane must parse daemon argv");
+        assert!(parsed.takeover);
     }
 
     /// An uncapped host's argv must not grow, and a capped one must round-trip

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -66,6 +66,10 @@ pub struct Args {
     /// start and stay in control: writable, no idle release, and sized to the
     /// local pane so it fills. Set by the daemon from per-host config.
     pub always_control: bool,
+    /// ask herdr to evict the remote pane's current controller when entering
+    /// control (`terminal session control --takeover`). Set by the daemon from
+    /// per-host config.
+    pub takeover: bool,
     /// upper bound on the size control asks the remote for. `None` = uncapped
     /// (fill the local pane). Set by the daemon from per-host config; observe
     /// is never capped, since it doesn't resize anything.
@@ -99,6 +103,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
         session: None,
         control_idle_secs: 3600,
         always_control: false,
+        takeover: false,
         max_cols: None,
         max_rows: None,
         ctl_path: None,
@@ -127,6 +132,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                     next("--control-idle")?.parse().map_err(|_| err("--control-idle must be a number"))?
             }
             "--always-control" => args.always_control = true,
+            "--takeover" => args.takeover = true,
             // 0 is unset here for the same reason config treats it that way:
             // a zero cap would ask the remote for a zero-column terminal, which
             // herdr rejects outright, killing the session twice over and
@@ -255,11 +261,15 @@ fn spawn_session(args: &Args, mode: Mode, cols: usize, rows: usize, gen: u64, tx
         args.remote_bin.as_deref(),
         args.session.as_deref(),
     );
+    // a stale controller (an orphaned ssh from a closed mirror pane, say) makes
+    // control fail twice and drop the pane to observe; takeover evicts it
+    let takeover = if mode == Mode::Control && args.takeover { " --takeover" } else { "" };
     let cmd = format!(
-        "exec {} terminal session {} {} --cols {} --rows {}",
+        "exec {} terminal session {} {}{} --cols {} --rows {}",
         bin,
         mode.as_str(),
         sh_quote(&args.pane_target),
+        takeover,
         cols,
         rows
     );

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -659,6 +659,7 @@ mod tests {
             max_rows: None,
             api_transport: ApiTransport::Auto,
             always_control: true,
+            takeover: false,
         }
     }
 


### PR DESCRIPTION
## Problem

A mirror pane whose remote pane still has a controller attached (in my case an orphaned `ssh` from a mirror pane I had closed) fails control twice in a row and drops to `control unavailable — viewing only; type to retry`. Typing retries, but the stale controller is still there, so it never gets past it. Output is visible but the pane can't be driven.

## Fix

herdr's `terminal session control` already accepts `--takeover`. This plumbs it through as a config option:

```toml
takeover = true          # global
[hosts.work]
takeover = false         # per-host override
```

Default is **off**, so existing configs are unchanged and a host a human drives directly is never evicted. When on, the streamer passes `--takeover` only in control mode; observe is untouched.

Follows the `always_control` plumbing exactly: `HostConfig` → daemon `cmd_for_pane` argv → `pane::Args`. README documented in both the global and per-host sections.

## Tests

- `config`: default off, global default + per-host override
- `mirror`: flag absent from an unconfigured host's argv; round-trips through `pane::parse_args` when on
- `cargo test --release`: 218 passed

Verified live against three hosts running `herdr 0.8.2-preview`: previously stuck mirrors take control immediately after hide/show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ma2o3PVfR9mANth9X46aTr
