### PR TITLE
feat: local drag-select and double-click copy in mirror panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ Mirror panes adapt to what's running on the remote pane:
   dragged cells of the decoded frame and, on release, copies their text to your
   desktop clipboard through OSC 52. A remote app's own copy cannot reach you
   (herdr streams cells, not the app's clipboard writes), so the drag is owned
-  on this side; a press released in place is still forwarded as a click.
+  on this side; a press released in place is still forwarded as a click, and a
+  double-click copies the token under the pointer. Set `local_select = false`
+  (globally or per host) to forward drags to the remote app instead.
 
 herdr's streamed frames don't carry the app's mouse mode, so the plugin infers it
 from the remote pane's foreground process — anything that isn't a known shell is
@@ -279,6 +281,8 @@ shell and a TUI there's a brief lag before the mouse mode catches up.
 target = "work"
 # prefix = "work"                    # sidebar prefix (default: the host key)
 # remote_bin = "~/.local/bin/herdr"  # remote path if it's not on the remote PATH
+# local_select = false               # per-host override: forward drags to the
+                                     # remote TUI instead of selecting locally
 # always_control = false             # per-host override, e.g. a host you use
                                      # directly (don't drive its pane sizes)
 # enabled = true                     # false stops syncing this host without

--- a/README.md
+++ b/README.md
@@ -242,7 +242,12 @@ Mirror panes adapt to what's running on the remote pane:
 
 - at a **shell**, the mouse stays local — drag-select and copy work natively, and
   nothing leaks into the prompt;
-- in a **TUI** (vim, htop, lazygit, …), clicks and wheel forward to the app.
+- in a **TUI** (vim, htop, lazygit, Claude Code, …), clicks and wheel forward to
+  the app, and a plain left drag selects locally: the mirror highlights the
+  dragged cells of the decoded frame and, on release, copies their text to your
+  desktop clipboard through OSC 52. A remote app's own copy cannot reach you
+  (herdr streams cells, not the app's clipboard writes), so the drag is owned
+  on this side; a press released in place is still forwarded as a click.
 
 herdr's streamed frames don't carry the app's mouse mode, so the plugin infers it
 from the remote pane's foreground process — anything that isn't a known shell is

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,9 @@ pub struct HostConfig {
     /// the local pane so it fills). Default on; ideal for headless remotes. Turn
     /// off per host for a remote a human is actively using directly.
     pub always_control: bool,
+    /// plain left drags and double-clicks select locally in mirror panes
+    /// (default). Off forwards them to the remote app instead.
+    pub local_select: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -138,6 +141,7 @@ struct RawConfig {
     default_host: Option<String>,
     close_remote_on_local_close: Option<bool>,
     always_control: Option<bool>,
+    local_select: Option<bool>,
     // toml::Table (preserve_order) keeps declaration order — the first host
     // is the remote-create fallback, so order is user-visible
     #[serde(default)]
@@ -156,6 +160,7 @@ struct RawHost {
     remote_bin: Option<String>,
     enabled: Option<bool>,
     always_control: Option<bool>,
+    local_select: Option<bool>,
     api_transport: Option<String>,
 }
 
@@ -236,6 +241,7 @@ pub fn load_config(candidates: &[PathBuf]) -> Result<MirrorConfig> {
 pub fn parse_config(text: &str) -> Result<MirrorConfig> {
     let raw: RawConfig = toml::from_str(text)?;
     let global_always_control = raw.always_control.unwrap_or(true);
+    let global_local_select = raw.local_select.unwrap_or(true);
     let mut hosts: Vec<HostConfig> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
     for (name, value) in raw.hosts {
@@ -272,6 +278,7 @@ pub fn parse_config(text: &str) -> Result<MirrorConfig> {
             // empty string is treated as unset (auto PATH → ~/.local/bin/herdr)
             remote_bin: h.remote_bin.filter(|s| !s.is_empty()),
             always_control: h.always_control.unwrap_or(global_always_control),
+            local_select: h.local_select.unwrap_or(global_local_select),
             docker_bin: h.docker_bin.unwrap_or_else(|| "docker".into()),
             api_transport,
             kind,
@@ -324,6 +331,20 @@ mod tests {
         assert_eq!(h.prefix, "work");
         assert_eq!(h.remote_bin, None); // auto: PATH then ~/.local/bin/herdr
         assert!(h.always_control); // default on
+    }
+
+    #[test]
+    fn local_select_global_default_and_per_host_override() {
+        let c = parse_config("[hosts.a]\ntarget = \"a\"\n").unwrap();
+        assert!(c.hosts[0].local_select); // default on
+        let c = parse_config(
+            "local_select = false\n\
+             [hosts.a]\ntarget = \"a\"\n\
+             [hosts.b]\ntarget = \"b\"\nlocal_select = true\n",
+        )
+        .unwrap();
+        assert!(!c.hosts[0].local_select);
+        assert!(c.hosts[1].local_select);
     }
 
     #[test]

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use unicode_width::UnicodeWidthChar;
 
 /// Terminal display width of a char (CJK/Hangul are 2 columns).
-fn cw(ch: char) -> usize {
+pub(crate) fn cw(ch: char) -> usize {
     UnicodeWidthChar::width(ch).unwrap_or(1).max(1)
 }
 
@@ -118,6 +118,14 @@ impl Grid {
             .unwrap_or(0);
     }
 
+    /// First grid row shown in an `out_rows`-tall local pane. Bottom-anchored:
+    /// agent TUIs live at the bottom of the screen. Shared by the renderer and
+    /// every overlay so their coordinates agree.
+    pub fn window_offset(&self, out_rows: usize) -> usize {
+        let bottom = self.content_bottom.max(self.cursor_row);
+        (bottom + 1).saturating_sub(out_rows)
+    }
+
     pub fn text_lines(&self) -> Vec<String> {
         self.rows
             .iter()
@@ -205,8 +213,7 @@ impl Renderer {
     /// Build the ANSI to paint the grid into an out_cols × out_rows terminal.
     /// Bottom-anchored window: agent TUIs live at the bottom of the screen.
     pub fn paint(&mut self, grid: &Grid, out_cols: usize, out_rows: usize) -> String {
-        let bottom = grid.content_bottom.max(grid.cursor_row);
-        let offset_r = (bottom + 1).saturating_sub(out_rows);
+        let offset_r = grid.window_offset(out_rows);
         let mut out = String::from("\x1b[?2026h\x1b[?25l");
         // paint every local row (missing rows blank-fill), or the pane stays
         // blank before the first frame and the status row is unreachable

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod pane;
 mod predict;
 mod remote;
 mod remote_action;
+mod select;
 mod ssh_relay;
 mod state;
 mod util;

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -355,6 +355,7 @@ pub(crate) fn cmd_for_pane(
     let target = host.target.clone();
     let remote_bin = host.remote_bin.clone();
     let always_control = host.always_control;
+    let local_select = host.local_select;
     let kind = host.kind.clone();
     let docker_bin = host.docker_bin.clone();
     // daemon's ControlMaster socket for this host (see remote.rs); the streamer
@@ -375,6 +376,9 @@ pub(crate) fn cmd_for_pane(
         }
         if always_control {
             argv.push("--always-control".into());
+        }
+        if !local_select {
+            argv.push("--no-local-select".into());
         }
         // ssh only: the pane reuses the daemon's ControlMaster for cheap
         // foreground polls. Docker has no ControlMaster, and healing no longer
@@ -1510,8 +1514,21 @@ mod tests {
             prefix: "vps".into(),
             remote_bin: None,
             always_control: true,
+            local_select: true,
             api_transport: crate::config::ApiTransport::Auto,
         }
+    }
+
+    #[test]
+    fn ssh_pane_argv_carries_no_local_select_only_when_off() {
+        let mut host = ssh_host();
+        host.local_select = false;
+        let cmd = cmd_for_pane(&host, std::path::Path::new("/state"), &HashMap::new());
+        let argv = cmd("w1:p1");
+        assert_eq!(
+            argv[1..],
+            ["pane", "vps", "w1:p1", "--always-control", "--no-local-select", "--ctl-path", "/state/vps.ctl"]
+        );
     }
 
     fn leaf(pane_id: &str) -> LayoutNode {

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -40,6 +40,7 @@ use tokio::time::Instant;
 use crate::util::{err, Result};
 use crate::grid::{Grid, Renderer};
 use crate::predict::Predictor;
+use crate::select::{SelAction, Selection};
 
 // ---------------------------------------------------------------------------
 // args
@@ -489,6 +490,8 @@ struct App {
     hint_clear_at: Option<Instant>,
     /// predictive local echo — draws keystrokes optimistically, frame-verified
     predict: Predictor,
+    /// local drag-select over the decoded grid (see select.rs)
+    select: Selection,
     /// remote pane foreground: Some(true)=shell (keep mouse local, no garbage),
     /// Some(false)=TUI (forward clicks), None=unknown (fail safe to local).
     /// Refreshed lazily on mouse activity via `herdr pane process-info`.
@@ -520,14 +523,17 @@ impl App {
         if !self.tty {
             return;
         }
-        if self.predict.take_dirty() {
-            // cleared predictions may have left ghost chars — full repaint
+        if self.predict.take_dirty() | self.select.take_dirty() {
+            // cleared predictions may have left ghost chars, and a moved or
+            // cleared selection leaves stale reverse video — full repaint
             self.renderer.invalidate();
         }
         let (cols, rows) = term_size();
         let mut out = self.renderer.paint(&self.grid, cols, rows);
-        // inject the prediction overlay inside the synchronized-update block
-        let overlay = self.predict.overlay(&self.grid, cols, rows);
+        // inject the prediction and selection overlays inside the
+        // synchronized-update block
+        let mut overlay = self.predict.overlay(&self.grid, cols, rows);
+        overlay.push_str(&self.select.overlay(&self.grid, cols, rows));
         if !overlay.is_empty() {
             const SYNC_END: &str = "\x1b[?2026l";
             if let Some(pos) = out.rfind(SYNC_END) {
@@ -778,7 +784,59 @@ impl App {
         }
     }
 
+    /// Route left-button gestures through the local selection before anything
+    /// else sees them. Returns the input with selection events removed and a
+    /// press-released-in-place put back as one click gesture; a finished drag
+    /// copies to the clipboard here. Any keystroke drops a retained highlight.
+    fn route_selection(&mut self, buf: Vec<u8>) -> Vec<u8> {
+        if !self.tty {
+            return buf;
+        }
+        let (_, rows) = term_size();
+        let mut rest: Vec<u8> = Vec::with_capacity(buf.len());
+        let mut keyed = false;
+        let mut i = 0usize;
+        while i < buf.len() {
+            if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
+                let raw = &buf[i..i + len];
+                match self.select.on_mouse(btn, x, y, press, raw, &self.grid, rows) {
+                    SelAction::Pass => rest.extend_from_slice(raw),
+                    SelAction::Consumed => {}
+                    SelAction::Click(bytes) => rest.extend_from_slice(&bytes),
+                    SelAction::Copy(text) => self.copy_to_clipboard(&text),
+                }
+                i += len;
+            } else {
+                keyed = true;
+                rest.push(buf[i]);
+                i += 1;
+            }
+        }
+        if keyed {
+            self.select.clear();
+        }
+        if self.select.is_dirty() {
+            self.paint();
+        }
+        rest
+    }
+
+    /// OSC 52 to the hosting terminal: herdr relays it from a local pane the
+    /// same way it relays its own copies, so this lands on the desktop clipboard.
+    fn copy_to_clipboard(&mut self, text: &str) {
+        if text.trim().is_empty() {
+            return;
+        }
+        write_stdout(&format!("\x1b]52;c;{}\x07", B64.encode(text)));
+        let n = text.chars().count();
+        self.hint(&format!("copied {n} chars"));
+    }
+
     async fn handle_stdin(&mut self, buf: Vec<u8>) {
+        let buf = self.route_selection(buf);
+        if buf.is_empty() {
+            return;
+        }
         if self.mode == Mode::Observe || self.switching_to == Some(Mode::Observe) {
             // no quit key: the wrapper's lifecycle belongs to the hosting pane
             if has_mouse_seq(&buf) {
@@ -950,6 +1008,7 @@ pub async fn run(args: Args) -> Result<()> {
         last_input: Instant::now(),
         hint_clear_at: None,
         predict: Predictor::new(),
+        select: Selection::new(),
         remote_is_shell: None,
         fg_poll_at: None,
         settle_at: None,

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -63,6 +63,9 @@ pub struct Args {
     /// start and stay in control: writable, no idle release, and sized to the
     /// local pane so it fills. Set by the daemon from per-host config.
     pub always_control: bool,
+    /// own plain left drags and double-clicks locally (select.rs); off forwards
+    /// them to the remote app like any other click
+    pub local_select: bool,
     /// daemon's ssh ControlMaster socket for this host; foreground polls reuse it
     /// (`ssh -S <path>`) to skip a handshake. None → polls connect directly.
     ///
@@ -92,6 +95,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
         control_idle_secs: 3600,
         size_fixed: false,
         always_control: false,
+        local_select: true,
         ctl_path: None,
         container: None,
     };
@@ -120,6 +124,7 @@ pub fn parse_args(argv: &[String]) -> Result<Args> {
                     next("--control-idle")?.parse().map_err(|_| err("--control-idle must be a number"))?
             }
             "--always-control" => args.always_control = true,
+            "--no-local-select" => args.local_select = false,
             "--ctl-path" => args.ctl_path = Some(next("--ctl-path")?),
             "--container" => container_name = Some(next("--container")?),
             "--container-folder" => container_folder = Some(next("--container-folder")?),
@@ -789,9 +794,10 @@ impl App {
     /// press-released-in-place put back as one click gesture; a finished drag
     /// copies to the clipboard here. Any keystroke drops a retained highlight.
     fn route_selection(&mut self, buf: Vec<u8>) -> Vec<u8> {
-        if !self.tty {
+        if !self.tty || !self.args.local_select {
             return buf;
         }
+        let now = Instant::now().into_std();
         let (_, rows) = term_size();
         let mut rest: Vec<u8> = Vec::with_capacity(buf.len());
         let mut keyed = false;
@@ -799,7 +805,7 @@ impl App {
         while i < buf.len() {
             if let Some((btn, x, y, press, len)) = parse_mouse(&buf, i) {
                 let raw = &buf[i..i + len];
-                match self.select.on_mouse(btn, x, y, press, raw, &self.grid, rows) {
+                match self.select.on_mouse(btn, x, y, press, raw, &self.grid, rows, now) {
                     SelAction::Pass => rest.extend_from_slice(raw),
                     SelAction::Consumed => {}
                     SelAction::Click(bytes) => rest.extend_from_slice(&bytes),

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -268,8 +268,7 @@ impl Predictor {
         if !self.displaying() || self.pending.is_empty() {
             return String::new();
         }
-        let bottom = grid.content_bottom.max(grid.cursor_row);
-        let offset_r = (bottom + 1).saturating_sub(out_rows);
+        let offset_r = grid.window_offset(out_rows);
         let mut out = String::new();
         let mut last: Option<(usize, usize)> = None;
         for p in &self.pending {

--- a/src/select.rs
+++ b/src/select.rs
@@ -14,8 +14,12 @@
 // forwarded as one gesture, so TUI clicks keep working.
 
 use std::fmt::Write as _;
+use std::time::{Duration, Instant};
 
 use crate::grid::{cw, Grid};
+
+/// Two left presses on the same cell within this window are a double-click.
+const DOUBLE_CLICK: Duration = Duration::from_millis(400);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Pos {
@@ -32,7 +36,7 @@ pub enum SelAction {
     /// a press released in place: the held press plus its release, to forward
     /// as one click gesture
     Click(Vec<u8>),
-    /// a drag ended: copy this text
+    /// a drag ended or a token was double-clicked: copy this text
     Copy(String),
 }
 
@@ -48,6 +52,10 @@ pub struct Selection {
     head: Option<Pos>,
     dragging: bool,
     dirty: bool,
+    /// the previous left press, to recognize a double-click
+    last_press: Option<(Pos, Instant)>,
+    /// a double-click already acted; its release carries nothing
+    swallow_release: bool,
 }
 
 impl Selection {
@@ -67,6 +75,7 @@ impl Selection {
         raw: &[u8],
         grid: &Grid,
         out_rows: usize,
+        now: Instant,
     ) -> SelAction {
         let pos = Pos {
             row: (y.max(1) as usize - 1) + grid.window_offset(out_rows),
@@ -74,7 +83,22 @@ impl Selection {
         };
         match (btn, press) {
             (LEFT, true) => {
+                let double = self
+                    .last_press
+                    .is_some_and(|(p, at)| p == pos && now.duration_since(at) <= DOUBLE_CLICK);
                 self.clear();
+                self.last_press = Some((pos, now));
+                if double {
+                    // herdr copies a double-clicked token; do the same over the grid
+                    if let Some((c0, c1)) = token_span(grid, pos) {
+                        self.anchor = Some(Pos { row: pos.row, col: c0 });
+                        self.head = Some(Pos { row: pos.row, col: c1 });
+                        self.dirty = true;
+                        self.swallow_release = true;
+                        self.last_press = None;
+                        return SelAction::Copy(self.text(grid));
+                    }
+                }
                 self.pending_press = Some((pos, raw.to_vec()));
                 SelAction::Consumed
             }
@@ -101,6 +125,9 @@ impl Selection {
                 }
             }
             (LEFT, false) => {
+                if std::mem::take(&mut self.swallow_release) {
+                    return SelAction::Consumed;
+                }
                 if let Some((_, mut bytes)) = self.pending_press.take() {
                     bytes.extend_from_slice(raw);
                     return SelAction::Click(bytes);
@@ -128,6 +155,7 @@ impl Selection {
         self.anchor = None;
         self.head = None;
         self.dragging = false;
+        self.swallow_release = false;
     }
 
     pub fn is_dirty(&self) -> bool {
@@ -234,6 +262,29 @@ impl Selection {
     }
 }
 
+/// Inclusive column span of the whitespace-delimited token under `pos`, if any.
+fn token_span(grid: &Grid, pos: Pos) -> Option<(usize, usize)> {
+    let cells = grid.rows.get(pos.row)?;
+    let ch_at = |c: usize| cells.get(c).and_then(|c| c.as_ref()).map(|c| c.ch);
+    // the spacer after a wide char is None; treat it as part of that char
+    let is_token = |c: usize| match ch_at(c) {
+        Some(ch) => !ch.is_whitespace(),
+        None => c > 0 && ch_at(c - 1).is_some_and(|p| cw(p) == 2),
+    };
+    if pos.col >= grid.width || !is_token(pos.col) {
+        return None;
+    }
+    let mut c0 = pos.col;
+    while c0 > 0 && is_token(c0 - 1) {
+        c0 -= 1;
+    }
+    let mut c1 = pos.col;
+    while c1 + 1 < grid.width && is_token(c1 + 1) {
+        c1 += 1;
+    }
+    Some((c0, c1))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -255,8 +306,40 @@ mod tests {
     }
 
     fn feed(s: &mut Selection, g: &Grid, rows: usize, btn: u32, x: u32, y: u32, press: bool) -> SelAction {
+        feed_at(s, g, rows, btn, x, y, press, Instant::now())
+    }
+
+    fn feed_at(s: &mut Selection, g: &Grid, rows: usize, btn: u32, x: u32, y: u32, press: bool, now: Instant) -> SelAction {
         let raw = sgr(btn, x, y, press);
-        s.on_mouse(btn, x, y, press, &raw, g, rows)
+        s.on_mouse(btn, x, y, press, &raw, g, rows, now)
+    }
+
+    #[test]
+    fn double_click_copies_the_token_and_swallows_its_release() {
+        let g = grid(&["path/to/file.rs:42 next"]);
+        let mut s = Selection::new();
+        let t0 = Instant::now();
+        assert_eq!(feed_at(&mut s, &g, 1, 0, 5, 1, true, t0), SelAction::Consumed);
+        assert!(matches!(feed_at(&mut s, &g, 1, 0, 5, 1, false, t0), SelAction::Click(_)));
+        let t1 = t0 + Duration::from_millis(200);
+        assert_eq!(feed_at(&mut s, &g, 1, 0, 5, 1, true, t1), SelAction::Copy("path/to/file.rs:42".into()));
+        assert_eq!(feed_at(&mut s, &g, 1, 0, 5, 1, false, t1), SelAction::Consumed);
+        assert!(s.overlay(&g, 30, 1).contains("\x1b[0;7mpath/to/file.rs:42\x1b[0m"));
+        // a third press after the window is an ordinary click again
+        let t2 = t1 + Duration::from_millis(900);
+        assert_eq!(feed_at(&mut s, &g, 1, 0, 5, 1, true, t2), SelAction::Consumed);
+        assert!(matches!(feed_at(&mut s, &g, 1, 0, 5, 1, false, t2), SelAction::Click(_)));
+    }
+
+    #[test]
+    fn double_click_on_blank_is_a_plain_click() {
+        let g = grid(&["ab   cd"]);
+        let mut s = Selection::new();
+        let t0 = Instant::now();
+        feed_at(&mut s, &g, 1, 0, 4, 1, true, t0);
+        feed_at(&mut s, &g, 1, 0, 4, 1, false, t0);
+        assert_eq!(feed_at(&mut s, &g, 1, 0, 4, 1, true, t0 + Duration::from_millis(100)), SelAction::Consumed);
+        assert!(matches!(feed_at(&mut s, &g, 1, 0, 4, 1, false, t0 + Duration::from_millis(100)), SelAction::Click(_)));
     }
 
     #[test]

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,333 @@
+// Local drag-select for mirror panes.
+//
+// While the remote foreground is a TUI the wrapper holds the local mouse grab
+// (?1002h) so clicks and wheel can be forwarded. herdr therefore hands the
+// whole drag to this pane instead of starting its own selection. Forwarding
+// the drag is a dead end: the remote app may highlight on its side, but its
+// OSC 52 copy is consumed by the remote herdr (frames carry cells only), so the
+// local clipboard never changes.
+//
+// So the drag is owned here. A left press is held back; if motion follows, the
+// gesture becomes a selection over the decoded grid and the release copies its
+// text through OSC 52 to the hosting terminal (the same path herdr's own copy
+// uses from a local pane). A press released in place is a click and is
+// forwarded as one gesture, so TUI clicks keep working.
+
+use std::fmt::Write as _;
+
+use crate::grid::{cw, Grid};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Pos {
+    pub row: usize,
+    pub col: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SelAction {
+    /// not a plain left-button event: leave it to the normal routing
+    Pass,
+    /// swallowed (selection bookkeeping only)
+    Consumed,
+    /// a press released in place: the held press plus its release, to forward
+    /// as one click gesture
+    Click(Vec<u8>),
+    /// a drag ended: copy this text
+    Copy(String),
+}
+
+/// SGR button codes: plain left press/release, and left-held motion (bit 32).
+const LEFT: u32 = 0;
+const LEFT_MOTION: u32 = 32;
+
+#[derive(Default)]
+pub struct Selection {
+    /// a left press whose meaning (click or drag) is not known yet
+    pending_press: Option<(Pos, Vec<u8>)>,
+    anchor: Option<Pos>,
+    head: Option<Pos>,
+    dragging: bool,
+    dirty: bool,
+}
+
+impl Selection {
+    pub fn new() -> Selection {
+        Selection::default()
+    }
+
+    /// Feed one SGR mouse event in local pane coordinates (1-based, as
+    /// reported). `out_rows` is the local pane height, for the same
+    /// bottom-anchored window math the renderer uses.
+    pub fn on_mouse(
+        &mut self,
+        btn: u32,
+        x: u32,
+        y: u32,
+        press: bool,
+        raw: &[u8],
+        grid: &Grid,
+        out_rows: usize,
+    ) -> SelAction {
+        let pos = Pos {
+            row: (y.max(1) as usize - 1) + grid.window_offset(out_rows),
+            col: x.max(1) as usize - 1,
+        };
+        match (btn, press) {
+            (LEFT, true) => {
+                self.clear();
+                self.pending_press = Some((pos, raw.to_vec()));
+                SelAction::Consumed
+            }
+            (LEFT_MOTION, true) => {
+                if let Some((start, _)) = &self.pending_press {
+                    if *start != pos {
+                        let start = *start;
+                        self.pending_press = None;
+                        self.anchor = Some(start);
+                        self.head = Some(pos);
+                        self.dragging = true;
+                        self.dirty = true;
+                    }
+                    // else: jitter inside the pressed cell, still a click so far
+                    SelAction::Consumed
+                } else if self.dragging {
+                    if self.head != Some(pos) {
+                        self.head = Some(pos);
+                        self.dirty = true;
+                    }
+                    SelAction::Consumed
+                } else {
+                    SelAction::Pass
+                }
+            }
+            (LEFT, false) => {
+                if let Some((_, mut bytes)) = self.pending_press.take() {
+                    bytes.extend_from_slice(raw);
+                    return SelAction::Click(bytes);
+                }
+                if self.dragging {
+                    self.dragging = false;
+                    if self.head != Some(pos) {
+                        self.head = Some(pos);
+                        self.dirty = true;
+                    }
+                    return SelAction::Copy(self.text(grid));
+                }
+                SelAction::Pass
+            }
+            _ => SelAction::Pass,
+        }
+    }
+
+    /// Drop the held press and any retained highlight.
+    pub fn clear(&mut self) {
+        if self.anchor.is_some() {
+            self.dirty = true;
+        }
+        self.pending_press = None;
+        self.anchor = None;
+        self.head = None;
+        self.dragging = false;
+    }
+
+    pub fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Take the "needs renderer invalidation" flag.
+    pub fn take_dirty(&mut self) -> bool {
+        std::mem::take(&mut self.dirty)
+    }
+
+    /// Selection bounds in grid coordinates, row-major ordered.
+    fn bounds(&self) -> Option<(Pos, Pos)> {
+        let (a, h) = (self.anchor?, self.head?);
+        Some(if a <= h { (a, h) } else { (h, a) })
+    }
+
+    /// Row-major span of `row` inside the selection: inclusive column bounds.
+    fn span(&self, row: usize, width: usize, a: Pos, b: Pos) -> Option<(usize, usize)> {
+        if row < a.row || row > b.row || width == 0 {
+            return None;
+        }
+        let c0 = if row == a.row { a.col } else { 0 };
+        let c1 = if row == b.row { b.col } else { width - 1 };
+        let c1 = c1.min(width - 1);
+        (c0 <= c1).then_some((c0, c1))
+    }
+
+    /// The selected text: rows joined by newlines, trailing blanks trimmed.
+    pub fn text(&self, grid: &Grid) -> String {
+        let Some((a, b)) = self.bounds() else { return String::new() };
+        let mut lines: Vec<String> = Vec::new();
+        for row in a.row..=b.row.min(grid.height.saturating_sub(1)) {
+            let Some((c0, c1)) = self.span(row, grid.width, a, b) else { continue };
+            let cells = &grid.rows[row];
+            let mut line = String::new();
+            let mut c = c0;
+            while c <= c1 {
+                match cells.get(c).and_then(|c| c.as_ref()) {
+                    Some(cell) => {
+                        line.push(cell.ch);
+                        c += cw(cell.ch);
+                    }
+                    None => {
+                        line.push(' ');
+                        c += 1;
+                    }
+                }
+            }
+            lines.push(line.trim_end().to_string());
+        }
+        lines.join("\n")
+    }
+
+    /// ANSI overlay that paints the selection in reverse video. Window math
+    /// mirrors Renderer::paint (bottom-anchored).
+    pub fn overlay(&self, grid: &Grid, out_cols: usize, out_rows: usize) -> String {
+        let Some((a, b)) = self.bounds() else { return String::new() };
+        let offset_r = grid.window_offset(out_rows);
+        let width = grid.width.min(out_cols);
+        let mut out = String::new();
+        for row in a.row..=b.row {
+            if row < offset_r || row >= grid.height {
+                continue;
+            }
+            let wr = row - offset_r;
+            if wr >= out_rows {
+                break;
+            }
+            let Some((c0, c1)) = self.span(row, width, a, b) else { continue };
+            let cells = &grid.rows[row];
+            let mut s = String::new();
+            let mut c = c0;
+            while c <= c1 {
+                match cells.get(c).and_then(|c| c.as_ref()) {
+                    Some(cell) => {
+                        // a wide char that would straddle the edge is blanked,
+                        // as the renderer does
+                        if cw(cell.ch) == 2 && c + 1 > c1 {
+                            s.push(' ');
+                            c += 1;
+                        } else {
+                            s.push(cell.ch);
+                            c += cw(cell.ch);
+                        }
+                    }
+                    None => {
+                        s.push(' ');
+                        c += 1;
+                    }
+                }
+            }
+            let _ = write!(out, "\x1b[{};{}H\x1b[0;7m{}\x1b[0m", wr + 1, c0 + 1, s);
+        }
+        if out.is_empty() {
+            return out;
+        }
+        // the renderer parked the cursor before this overlay ran; put it back
+        let cr = grid.cursor_row as isize - offset_r as isize;
+        if grid.cursor_visible && cr >= 0 && (cr as usize) < out_rows {
+            let _ = write!(out, "\x1b[{};{}H", cr + 1, grid.cursor_col.min(out_cols.saturating_sub(1)) + 1);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid(lines: &[&str]) -> Grid {
+        let width = lines.iter().map(|l| l.chars().map(cw).sum::<usize>()).max().unwrap_or(1).max(1);
+        let mut g = Grid::new();
+        g.resize(width, lines.len());
+        let mut ansi = String::new();
+        for (r, l) in lines.iter().enumerate() {
+            ansi.push_str(&format!("\x1b[{};1H{}", r + 1, l));
+        }
+        g.apply(&ansi);
+        g
+    }
+
+    fn sgr(btn: u32, x: u32, y: u32, press: bool) -> Vec<u8> {
+        format!("\x1b[<{btn};{x};{y}{}", if press { 'M' } else { 'm' }).into_bytes()
+    }
+
+    fn feed(s: &mut Selection, g: &Grid, rows: usize, btn: u32, x: u32, y: u32, press: bool) -> SelAction {
+        let raw = sgr(btn, x, y, press);
+        s.on_mouse(btn, x, y, press, &raw, g, rows)
+    }
+
+    #[test]
+    fn press_released_in_place_is_one_forwarded_click() {
+        let g = grid(&["hello world"]);
+        let mut s = Selection::new();
+        assert_eq!(feed(&mut s, &g, 1, 0, 3, 1, true), SelAction::Consumed);
+        // jitter inside the same cell keeps it a click
+        assert_eq!(feed(&mut s, &g, 1, 32, 3, 1, true), SelAction::Consumed);
+        let mut expect = sgr(0, 3, 1, true);
+        expect.extend(sgr(0, 3, 1, false));
+        assert_eq!(feed(&mut s, &g, 1, 0, 3, 1, false), SelAction::Click(expect));
+        assert!(s.overlay(&g, 20, 1).is_empty());
+    }
+
+    #[test]
+    fn drag_copies_the_grid_text_and_keeps_the_highlight() {
+        let g = grid(&["hello world", "second line", "third"]);
+        let mut s = Selection::new();
+        feed(&mut s, &g, 3, 0, 7, 1, true);
+        assert_eq!(feed(&mut s, &g, 3, 32, 9, 1, true), SelAction::Consumed);
+        assert!(s.take_dirty());
+        assert_eq!(feed(&mut s, &g, 3, 32, 3, 2, true), SelAction::Consumed);
+        assert_eq!(feed(&mut s, &g, 3, 0, 3, 2, false), SelAction::Copy("world\nsec".into()));
+        let ov = s.overlay(&g, 20, 3);
+        assert!(ov.contains("\x1b[1;7H\x1b[0;7mworld\x1b[0m"), "{ov:?}");
+        assert!(ov.contains("\x1b[2;1H\x1b[0;7msec\x1b[0m"), "{ov:?}");
+        // a keystroke clears the retained highlight
+        s.clear();
+        assert!(s.take_dirty());
+        assert!(s.overlay(&g, 20, 3).is_empty());
+    }
+
+    #[test]
+    fn backwards_drag_orders_the_range() {
+        let g = grid(&["abc", "def"]);
+        let mut s = Selection::new();
+        feed(&mut s, &g, 2, 0, 2, 2, true);
+        feed(&mut s, &g, 2, 32, 2, 1, true);
+        assert_eq!(feed(&mut s, &g, 2, 0, 2, 1, false), SelAction::Copy("bc\nde".into()));
+    }
+
+    #[test]
+    fn coordinates_follow_the_bottom_anchored_window() {
+        // grid is 4 rows, the local pane shows the bottom 2: local row 1 is grid row 2
+        let g = grid(&["r0", "r1", "r2", "r3"]);
+        let mut s = Selection::new();
+        feed(&mut s, &g, 2, 0, 1, 1, true);
+        feed(&mut s, &g, 2, 32, 2, 1, true);
+        assert_eq!(feed(&mut s, &g, 2, 0, 2, 1, false), SelAction::Copy("r2".into()));
+        let ov = s.overlay(&g, 10, 2);
+        assert!(ov.starts_with("\x1b[1;1H\x1b[0;7mr2\x1b[0m"), "{ov:?}");
+    }
+
+    #[test]
+    fn wide_chars_copy_once() {
+        let g = grid(&["日本 ok"]);
+        let mut s = Selection::new();
+        feed(&mut s, &g, 1, 0, 1, 1, true);
+        feed(&mut s, &g, 1, 32, 7, 1, true);
+        assert_eq!(feed(&mut s, &g, 1, 0, 7, 1, false), SelAction::Copy("日本 ok".into()));
+    }
+
+    #[test]
+    fn other_buttons_pass_through() {
+        let g = grid(&["abc"]);
+        let mut s = Selection::new();
+        assert_eq!(feed(&mut s, &g, 1, 64, 1, 1, true), SelAction::Pass); // wheel
+        assert_eq!(feed(&mut s, &g, 1, 2, 1, 1, true), SelAction::Pass); // right
+        assert_eq!(feed(&mut s, &g, 1, 16, 1, 1, true), SelAction::Pass); // ctrl+left
+        assert_eq!(feed(&mut s, &g, 1, 32, 1, 1, true), SelAction::Pass); // stray motion
+        assert_eq!(feed(&mut s, &g, 1, 0, 1, 1, false), SelAction::Pass); // stray release
+    }
+}


### PR DESCRIPTION
## Problem

In a mirror pane whose remote foreground is a TUI (Claude Code, vim, …), a plain
left drag never copies. Two things combine to cause it, and no herdr or terminal
config setting fixes it:

1. The wrapper holds the local mouse grab (`?1002h`) whenever the remote
   foreground is not a shell, so clicks and wheel can reach the app. herdr
   therefore forwards the whole drag to the pane instead of starting its own
   selection.
2. The remote app's own copy never arrives locally: herdr streams frame cells
   only, so the app's OSC 52 clipboard write is consumed on the remote side and
   the local clipboard is left unchanged.

A plain-shell pane is unaffected, because the wrapper releases the grab for a
shell foreground and herdr's native selection takes over.

I verified the two legs on a clean, dotfiles-free devpod with the released
0.2.1 binary: a shell-foreground pane emits `?1002h` then `?1002l` (grab
released, copy works); a vim-foreground pane emits `?1002h` with no release
(grab held, no copy) — identically whether the remote's `mouse_capture` is
`true` or `false`. A live hand-drag on the vim pane left the clipboard
unchanged.

## Fix

Own the left drag in the wrapper. A press is held; motion turns it into a
selection over the already-decoded grid, drawn in reverse video; the release
copies the text with OSC 52 from the local pane, where the clipboard path is
the same one herdr uses for its own copies. A press released in place is
forwarded as one click, so TUI clicks still work. A double-click copies the
whitespace-delimited token under the pointer. The wheel path is untouched.

## Config

`local_select` (global or per host, default `true`) turns the local selection
off for anyone who prefers drags forwarded to the remote app; the pane receives
it as `--no-local-select`.

```toml
# local_select = false   # forward drags to the remote TUI instead of selecting locally
```

## Behavior

- shell foreground: unchanged — herdr selects and copies natively.
- TUI foreground: plain drag selects locally and copies just that pane's text;
  double-click copies the token; a click still reaches the app; wheel still
  scrolls.

## Testing

- `cargo test` — 120 pass (6 new in `src/select.rs` covering click-vs-drag,
  backward drags, the bottom-anchored window offset, wide chars, double-click
  token copy and release-swallow, and the `local_select` argv/config plumbing).
- End-to-end: pty-injected SGR drag against a live remote pane emits the correct
  OSC 52; confirmed by hand in a Claude Code mirror pane.

## Notes

Draft for discussion — happy to adjust the interaction (double-click word
boundaries, the reverse-video style, or the config surface) to your taste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
